### PR TITLE
hindre at pod blir restartet ved belasting

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -49,7 +49,7 @@
         <!-- http/ktor-server -->
         <dependency>
             <groupId>io.ktor</groupId>
-            <artifactId>ktor-server-netty</artifactId>
+            <artifactId>ktor-server-cio</artifactId>
             <version>${ktor.version}</version>
         </dependency>
         <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <kotlin.version>1.4.32</kotlin.version>
-        <ktor.version>1.5.2</ktor.version>
+        <ktor.version>1.5.3</ktor.version>
         <kotest.version>4.4.3</kotest.version>
 
         <jvm.version>15</jvm.version>
@@ -49,7 +49,7 @@
         <!-- http/ktor-server -->
         <dependency>
             <groupId>io.ktor</groupId>
-            <artifactId>ktor-server-cio</artifactId>
+            <artifactId>ktor-server-netty</artifactId>
             <version>${ktor.version}</version>
         </dependency>
         <dependency>
@@ -202,7 +202,6 @@
                 <executions>
                     <execution>
                         <id>compile</id>
-                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
@@ -210,7 +209,6 @@
 
                     <execution>
                         <id>test-compile</id>
-                        <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
                         </goals>

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.ktor.server.cio.*
 import io.ktor.server.engine.*
-import io.ktor.server.netty.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.future.asCompletableFuture
@@ -51,7 +51,7 @@ fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
         }
 
         launch {
-            val httpServer = embeddedServer(Netty, port = 8080) {
+            val httpServer = embeddedServer(CIO, port = 8080) {
                 httpServerSetup(
                     brukerGraphQL = createBrukerGraphQL(
                         altinn = AltinnImpl,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import io.ktor.server.cio.*
 import io.ktor.server.engine.*
+import io.ktor.server.netty.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.future.asCompletableFuture
@@ -51,7 +51,11 @@ fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
         }
 
         launch {
-            val httpServer = embeddedServer(CIO, port = 8080) {
+            val httpServer = embeddedServer(Netty, port = 8080, configure = {
+                connectionGroupSize = 16
+                callGroupSize = 16
+                workerGroupSize = 16
+            }) {
                 httpServerSetup(
                     brukerGraphQL = createBrukerGraphQL(
                         altinn = AltinnImpl,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -1,6 +1,5 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
-import kotlinx.coroutines.*
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnConfig
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlient
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlientConfig
@@ -74,13 +73,8 @@ fun AltinnrettigheterProxyKlient.hentTilganger(
 fun AltinnrettigheterProxyKlient.hentAlleTilganger(
     fnr: String,
     selvbetjeningsToken: String,
-): List<Tilgang> = runBlocking(Dispatchers.IO) {
-    VÅRE_TJENESTER.map {
-        async {
-//            hentTilganger(fnr, it.first, it.second, selvbetjeningsToken)
-            emptyList<Tilgang>()
-        }
-    }.awaitAll().flatten()
+): List<Tilgang> = VÅRE_TJENESTER.flatMap {
+    hentTilganger(fnr, it.first, it.second, selvbetjeningsToken)
 }
 
 object AltinnImpl : Altinn {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -1,9 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnConfig
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlient
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlientConfig
@@ -80,7 +77,8 @@ fun AltinnrettigheterProxyKlient.hentAlleTilganger(
 ): List<Tilgang> = runBlocking(Dispatchers.IO) {
     VÅRE_TJENESTER.map {
         async {
-            hentTilganger(fnr, it.first, it.second, selvbetjeningsToken)
+//            hentTilganger(fnr, it.first, it.second, selvbetjeningsToken)
+            emptyList<Tilgang>()
         }
     }.awaitAll().flatten()
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
+import kotlinx.coroutines.*
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnConfig
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlient
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlientConfig
@@ -73,8 +74,12 @@ fun AltinnrettigheterProxyKlient.hentTilganger(
 fun AltinnrettigheterProxyKlient.hentAlleTilganger(
     fnr: String,
     selvbetjeningsToken: String,
-): List<Tilgang> = VÅRE_TJENESTER.flatMap {
-    hentTilganger(fnr, it.first, it.second, selvbetjeningsToken)
+): List<Tilgang> = runBlocking(Dispatchers.IO) {
+    VÅRE_TJENESTER.map {
+        async {
+            hentTilganger(fnr, it.first, it.second, selvbetjeningsToken)
+        }
+    }.awaitAll().flatten()
 }
 
 object AltinnImpl : Altinn {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -1,6 +1,9 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnConfig
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlient
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlientConfig
@@ -83,6 +86,7 @@ fun AltinnrettigheterProxyKlient.hentAlleTilganger(
 }
 
 object AltinnImpl : Altinn {
+    private val timer = Health.meterRegistry.timer("altinn_klient_hent_alle_tilganger")
     private val altinnrettigheterProxyKlient = AltinnrettigheterProxyKlient(
         AltinnrettigheterProxyKlientConfig(
             ProxyConfig(
@@ -98,6 +102,8 @@ object AltinnImpl : Altinn {
     )
 
     override fun hentAlleTilganger(fnr: String, selvbetjeningsToken: String): List<Tilgang> =
-        altinnrettigheterProxyKlient.hentAlleTilganger(fnr, selvbetjeningsToken)
+        timer.recordCallable {
+            altinnrettigheterProxyKlient.hentAlleTilganger(fnr, selvbetjeningsToken)
+        }
 }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import com.zaxxer.hikari.metrics.prometheus.PrometheusMetricsTrackerFactory
 import kotlinx.coroutines.delay
 import org.flywaydb.core.Flyway
 import org.slf4j.LoggerFactory
@@ -20,6 +21,7 @@ private val DEFAULT_HIKARI_CONFIG = HikariConfig().apply {
     username = System.getenv("DB_USERNAME") ?: "postgres"
     password = System.getenv("DB_PASSWORD") ?: "postgres"
     driverClassName = "org.postgresql.Driver"
+    metricsTrackerFactory = PrometheusMetricsTrackerFactory()
 }
 
 fun HikariConfig.connectionPossible(): Boolean {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -38,6 +38,7 @@ fun HikariConfig.connectionPossible(): Boolean {
     }
 }
 
+
 suspend fun createDataSource(hikariConfig: HikariConfig = DEFAULT_HIKARI_CONFIG): DataSource {
     while (!hikariConfig.connectionPossible()) {
         delay(1000)

--- a/app/src/main/resources/db/migration/V3__indekser_notifikasjon.sql
+++ b/app/src/main/resources/db/migration/V3__indekser_notifikasjon.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_opprettet_tidspunkt ON notifikasjon (opprettet_tidspunkt);

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/PerfTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/PerfTest.kt
@@ -6,6 +6,7 @@ import io.ktor.client.engine.apache.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.http.ContentType.Application.FormUrlEncoded
 import kotlinx.coroutines.*
 import java.lang.System.currentTimeMillis
 import java.time.Instant
@@ -17,14 +18,18 @@ val client = HttpClient(Apache) {
         connectTimeout = 0
         connectionRequestTimeout = 0
         customizeClient {
-            setMaxConnTotal(10)
+            setMaxConnTotal(20)
         }
     }
 }
 const val selvbetjeningToken =
-    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImZ5akpfczQwN1ZqdnRzT0NZcEItRy1IUTZpYzJUeDNmXy1JT3ZqVEFqLXcifQ.eyJleHAiOjE2MTk0NzAzNDIsIm5iZiI6MTYxOTQ2Njc0MiwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9uYXZ0ZXN0YjJjLmIyY2xvZ2luLmNvbS9kMzhmMjVhYS1lYWI4LTRjNTAtOWYyOC1lYmY5MmMxMjU2ZjIvdjIuMC8iLCJzdWIiOiIxNjEyMDEwMTE4MSIsImF1ZCI6IjAwOTBiNmUxLWZmY2MtNGMzNy1iYzIxLTA0OWY3ZDFmMGZlNSIsImFjciI6IkxldmVsNCIsIm5vbmNlIjoiNDdvWmNGU045YmxxNkVJOHROLWE2aThVNUVHZzBWR281ZVF3SENkZVAzcyIsImlhdCI6MTYxOTQ2Njc0MiwiYXV0aF90aW1lIjoxNjE5NDY2NzQxLCJqdGkiOiIwRXNDaFBubkQ3OFYzZ3Q1cF9nTmdqWTNGTUx4NmtMV21iMGFMQ3JCTWFrIiwiYXRfaGFzaCI6ImFZZmxsU2NmNm1ReDN1NF9MYzdjZ2cifQ.MAAQniUjWasxIi28DGl4j6WE63Tai4oo5YUWX-emmZHseOsMs6zbzMBh1rovsfddF66ZxJUPXty8oGvzIKCy7xyz_P7J1DZdL8NQp6GlOp1StE6OLOYWQh-BPCc4etoZs3ZZ9E44zudQDp2EmuOZYMkGBIWhRxIQdUqWXUV-TFRo5QyqdNy2CPCvVKjtLFYY9vSXQigcCzeDVijpKqTJb8679ZMhob0KBXGeiRqLQnvgPeRMilqeagu77QDAe9bAYxeY6mQUpQ8KPWjIQTNA3wj2hRX9XVA0tnAvjftovM8tO7prVOGwf1a6AqF135Te35Q1f8422hdmBtm3h6n3MA"
-const val tokenDingsToken =
-    "eyJraWQiOiJtb2NrLW9hdXRoMi1zZXJ2ZXIta2V5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJzb21lcHJvZHVjZXIiLCJhdWQiOiJwcm9kdXNlbnQtYXBpIiwibmJmIjoxNjE5NDY2ODA0LCJpc3MiOiJodHRwczpcL1wvZmFrZWRpbmdzLmRldi1nY3AubmFpcy5pb1wvZmFrZSIsImV4cCI6MTYyMzA2NjgwNCwiaWF0IjoxNjE5NDY2ODA0LCJqdGkiOiJkNjM4NzA1OC0wYzE2LTRmOWUtYmVlYy1kYjg1NzJlNDZlYzEifQ.FhMOh9nwW9rGLKBFCu0SyMug_JV_6bRYHaoAQU9vPLyp1uYuBWjObZRb61ZxYjtLWjm3IW45P-JIuxGDNF3cxb9lnDD9ayc_Yzox9I8s7vgChL1-3yZN_jDHS2hPvgNFgJSf2eb7nNx4jsk2f-1YCArfD1eLYGOzLxPLbhaKRP4w-srxuvcwL826lYxH8ojQQ8c-V03QFMBI54__WGcGOZn-VeuR2YNJbdcvhu9CCZdFh0-ZystDtOsWyyqqN01H0RFIybNhr8FLcN2mvCF1Njb8iUSrLpdDZR7i9FNHMPsHmhB0SZg532xrxXQyH56zRUnYmlJO9laoF99kcSMDTw"
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImZ5akpfczQwN1ZqdnRzT0NZcEItRy1IUTZpYzJUeDNmXy1JT3ZqVEFqLXcifQ.eyJleHAiOjE2MTk2NjAyMTQsIm5iZiI6MTYxOTY1NjYxNCwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9uYXZ0ZXN0YjJjLmIyY2xvZ2luLmNvbS9kMzhmMjVhYS1lYWI4LTRjNTAtOWYyOC1lYmY5MmMxMjU2ZjIvdjIuMC8iLCJzdWIiOiIxNjEyMDEwMTE4MSIsImF1ZCI6IjAwOTBiNmUxLWZmY2MtNGMzNy1iYzIxLTA0OWY3ZDFmMGZlNSIsImFjciI6IkxldmVsNCIsIm5vbmNlIjoiVFp1Ti1TTi01ZG9zSmVoYkg5SGNaTVJNMUxZcTVHbmNmZTdXdi1ydEhSRSIsImlhdCI6MTYxOTY1NjYxNCwiYXV0aF90aW1lIjoxNjE5NjU2NjEzLCJqdGkiOiJUZTFlN3dzODQxeUtyaFlFTGVFdzZLb3NObDZNRlNfdVFaUGRRa3EzRzlrIiwiYXRfaGFzaCI6IlQ5RHA3M1BzaWlidjhFdVhfMENkVFEifQ.szuNOGqw-Cv0Hh09Hvzvu1n5nD-aYulp7LJhc49dGcQN9m7T_PfIRaHL0h8OXT8Ed8xGoZpRUVs5TvDoNGKc28ZrRmT3acjePD9OUUM-GNmSIZfQWty32PenBAY4dPLlqakbKiu-0MuIg0X8PA6hZD7BMlv-Z0aP4zlGKZC9M9VBV3OKD09dAaLzhLlFseCd5LnEcFagN0ATdkgV6WqEoS3h06UdqaNJqfvx8UzmLCjw8VM5UgLdNUw-tNYHWy7F8m6GkqMTQW9YH1ezTImEZzIrhIe9ZXkhGtBNUrB-y3klx-I3soQuBAO2NnWIpKfAhx0EEjgNNf2OWmdfnFXjRg"
+val tokenDingsToken : String = runBlocking {
+    client.post<HttpResponse>("https://fakedings.dev-gcp.nais.io/fake/custom") {
+        contentType(FormUrlEncoded)
+        body = "sub=someproducer&aud=produsent-api"
+    }.readText()
+}
 
 suspend fun concurrentWithStats(
     title: String = "work",
@@ -149,8 +154,8 @@ suspend fun nyBeskjed(count: Int, api: Api = Api.PRODUSENT_GCP) {
 
 fun main() = runBlocking {
     client.use {
-        nyBeskjed(1_000, Api.PRODUSENT_GCP)
-        hentNotifikasjoner(1_000, Api.BRUKER_GCP)
+        nyBeskjed(10_000)
+        hentNotifikasjoner(10_000)
     }
 }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/PerfTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/PerfTest.kt
@@ -12,6 +12,13 @@ import java.lang.System.currentTimeMillis
 import java.time.Instant
 import kotlin.system.measureTimeMillis
 
+fun main() = runBlocking {
+    client.use {
+        nyBeskjed(10_000)
+        hentNotifikasjoner(10_000)
+    }
+}
+
 val client = HttpClient(Apache) {
     engine {
         socketTimeout = 0
@@ -149,13 +156,6 @@ suspend fun nyBeskjed(count: Int, api: Api = Api.PRODUSENT_GCP) {
                     | }"
                     |}""".trimMarginAndNewline()
         }
-    }
-}
-
-fun main() = runBlocking {
-    client.use {
-        nyBeskjed(10_000)
-        hentNotifikasjoner(10_000)
     }
 }
 


### PR DESCRIPTION
Under ytelsestest så vi at podene ble restartet ved relativ lav belastning. 
Det var flere ting som gjorde at dette problemet oppstod. 
Default oppsett på nais er at liveness må svare innen 1 sekund, ellers timer den ut. Etter 3 feilede forsøk vil poden bli restartet.

Flere ting er endret i denne PR. Innføring av dedikerte dispatchere til internal/ bruker og produsent routene.
Litt med ressurser til Netty.

Jeg la også på timer metrikker for kallene til altinn og database, slik at vi fikk se hva som brukte tid. Det avdekket at query mot db tok veldig lang tid. Dette er nå rettet.
 
Dette medførte en 10x økning i ytelse på både produsent og bruker kallene, samt at podene ikke lenger blir force restarta av k8s.

### YT resultat: 
nyBeskjed fra 50 r/s til 350 r/s 
hentNotifikasjoner fra 1-4 r/s til 50+ r/s. 

#### før:
![image](https://user-images.githubusercontent.com/189395/116514330-29ea9900-a8cb-11eb-8ad5-7207213249dc.png)

![image](https://user-images.githubusercontent.com/189395/116514421-47b7fe00-a8cb-11eb-827e-d031d5e5b3b3.png)

![image](https://user-images.githubusercontent.com/189395/116514461-59010a80-a8cb-11eb-9b8a-1fbb655652fd.png)


#### etter

![image](https://user-images.githubusercontent.com/189395/116514574-82219b00-a8cb-11eb-9a5b-9fb1395cdfae.png)

![image](https://user-images.githubusercontent.com/189395/116514603-8d74c680-a8cb-11eb-8572-76490012e710.png)

![image](https://user-images.githubusercontent.com/189395/116514688-a7aea480-a8cb-11eb-923f-2017025b2c0f.png)


### Andre ting:
Forsøk på å bytte med CIO gjorde at routene ikke resolvet. CIO og Netty håndterer host resolvers forskjellig og man ender med 404 på CIO. 
