### PR TITLE
Nonblocking query model

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
@@ -39,22 +39,20 @@ fun createBrukerGraphQL(
                     it.getContext<BrukerContext>().fnr,
                     it.getContext<BrukerContext>().token
                 )
-                val datasource = dataSourceAsync.get()
-                val queryBeskjeder = GlobalScope.future {
+                val dataSource = dataSourceAsync.get()
+                GlobalScope.future {
                     QueryModelRepository.hentNotifikasjoner(
-                        datasource,
+                        dataSource,
                         it.getContext<BrukerContext>().fnr,
                         tilganger
-                    )
-                }
-
-                queryBeskjeder.get().map { queryBeskjed ->
-                    Beskjed(
-                        merkelapp = queryBeskjed.merkelapp,
-                        tekst = queryBeskjed.tekst,
-                        lenke = queryBeskjed.lenke,
-                        opprettetTidspunkt = queryBeskjed.opprettetTidspunkt
-                    )
+                    ).map { queryBeskjed ->
+                        Beskjed(
+                            merkelapp = queryBeskjed.merkelapp,
+                            tekst = queryBeskjed.tekst,
+                            lenke = queryBeskjed.lenke,
+                            opprettetTidspunkt = queryBeskjed.opprettetTidspunkt
+                        )
+                    }
                 }
             }
             dataFetcher("whoami"){

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
@@ -1,9 +1,11 @@
 package no.nav.arbeidsgiver.notifikasjon
 
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import java.time.OffsetDateTime
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
 import javax.sql.DataSource
 
@@ -14,7 +16,7 @@ data class BrukerContext(
 
 fun createBrukerGraphQL(
     altinn: Altinn,
-    dataSourceAsync: Future<DataSource>
+    dataSourceAsync: CompletableFuture<DataSource>
 ) = TypedGraphQL<BrukerContext>(
     createGraphQL("/bruker.graphqls") {
 
@@ -39,10 +41,9 @@ fun createBrukerGraphQL(
                     it.getContext<BrukerContext>().fnr,
                     it.getContext<BrukerContext>().token
                 )
-                val dataSource = dataSourceAsync.get()
                 GlobalScope.future {
                     QueryModelRepository.hentNotifikasjoner(
-                        dataSource,
+                        dataSourceAsync.await(),
                         it.getContext<BrukerContext>().fnr,
                         tilganger
                     ).map { queryBeskjed ->

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon
 
+import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import java.time.OffsetDateTime
 import java.util.concurrent.Future
@@ -37,11 +38,13 @@ fun createBrukerGraphQL(
                     it.getContext<BrukerContext>().fnr,
                     it.getContext<BrukerContext>().token
                 )
-                val queryBeskjeder = QueryModelRepository.hentNotifikasjoner(
-                    dataSourceAsync.get(),
-                    it.getContext<BrukerContext>().fnr,
-                    tilganger
-                )
+                val queryBeskjeder = runBlocking { // TODO: bedre måte?
+                    QueryModelRepository.hentNotifikasjoner(
+                        dataSourceAsync.get(),
+                        it.getContext<BrukerContext>().fnr,
+                        tilganger
+                    )
+                }
 
                 queryBeskjeder.map { queryBeskjed ->
                     Beskjed(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
@@ -41,9 +41,9 @@ fun createBrukerGraphQL(
                     it.getContext<BrukerContext>().fnr,
                     it.getContext<BrukerContext>().token
                 )
-                //GlobalScope.future {
+                GlobalScope.future {
                     QueryModelRepository.hentNotifikasjoner(
-                        dataSourceAsync.get(),
+                        dataSourceAsync.await(),
                         it.getContext<BrukerContext>().fnr,
                         tilganger
                     ).map { queryBeskjed ->
@@ -54,7 +54,7 @@ fun createBrukerGraphQL(
                             opprettetTidspunkt = queryBeskjed.opprettetTidspunkt
                         )
                     }
-                //}
+                }
             }
             dataFetcher("whoami"){
                 it.getContext<BrukerContext>().fnr

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
@@ -40,6 +40,7 @@ fun createBrukerGraphQL(
                     it.getContext<BrukerContext>().fnr,
                     it.getContext<BrukerContext>().token
                 )
+                // TODO: er det riktig med GlobalScope her eller finnes en bedre måte?
                 GlobalScope.future(brukerGraphQLDispatcher) {
                     QueryModelRepository.hentNotifikasjoner(
                         dataSourceAsync.await(),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
@@ -41,9 +41,9 @@ fun createBrukerGraphQL(
                     it.getContext<BrukerContext>().fnr,
                     it.getContext<BrukerContext>().token
                 )
-                GlobalScope.future {
+                //GlobalScope.future {
                     QueryModelRepository.hentNotifikasjoner(
-                        dataSourceAsync.await(),
+                        dataSourceAsync.get(),
                         it.getContext<BrukerContext>().fnr,
                         tilganger
                     ).map { queryBeskjed ->
@@ -54,7 +54,7 @@ fun createBrukerGraphQL(
                             opprettetTidspunkt = queryBeskjed.opprettetTidspunkt
                         )
                     }
-                }
+                //}
             }
             dataFetcher("whoami"){
                 it.getContext<BrukerContext>().fnr

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/BrukerAPI.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.future.future
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import java.time.OffsetDateTime
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.Future
 import javax.sql.DataSource
 
 data class BrukerContext(
@@ -41,7 +40,7 @@ fun createBrukerGraphQL(
                     it.getContext<BrukerContext>().fnr,
                     it.getContext<BrukerContext>().token
                 )
-                GlobalScope.future {
+                GlobalScope.future(brukerGraphQLDispatcher) {
                     QueryModelRepository.hentNotifikasjoner(
                         dataSourceAsync.await(),
                         it.getContext<BrukerContext>().fnr,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
@@ -3,7 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.map
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transactionAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transaction
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.useConnectionAsync
 import org.postgresql.util.PSQLException
 import org.postgresql.util.PSQLState
@@ -107,7 +107,7 @@ fun tilQueryBeskjed(event: Event): QueryBeskjed =
             )
     }
 
-suspend fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
+fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
     val koordinat = Koordinat(
         mottaker = event.mottaker,
         merkelapp = event.merkelapp,
@@ -115,7 +115,7 @@ suspend fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
     )
     val nyBeskjed = tilQueryBeskjed(event)
 
-    dataSource.transactionAsync(rollback = {
+    dataSource.transaction(rollback = {
         if (it is PSQLException && PSQLState.UNIQUE_VIOLATION.state == it.sqlState) {
             log.error("forsøk på å endre eksisterende beskjed")
         } else {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
@@ -3,8 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.map
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transaction
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.useConnection
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transactionAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.useConnectionAsync
 import org.postgresql.util.PSQLException
 import org.postgresql.util.PSQLState
 import org.slf4j.LoggerFactory
@@ -38,12 +38,12 @@ data class Tilgang(
 object QueryModelRepository {
     private val timer = Health.meterRegistry.timer("query_model_repository_hent_notifikasjoner")
 
-    fun hentNotifikasjoner(
+    suspend fun hentNotifikasjoner(
         dataSource: DataSource,
         fnr: String,
         tilganger: Collection<Tilgang>
     ): List<QueryBeskjed> =
-        dataSource.useConnection { connection ->
+        dataSource.useConnectionAsync { connection ->
             timer.recordCallable {
                 val tilgangerJsonB = tilganger.joinToString {
                     "'${
@@ -107,7 +107,7 @@ fun tilQueryBeskjed(event: Event): QueryBeskjed =
             )
     }
 
-fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
+suspend fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
     val koordinat = Koordinat(
         mottaker = event.mottaker,
         merkelapp = event.merkelapp,
@@ -115,7 +115,7 @@ fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
     )
     val nyBeskjed = tilQueryBeskjed(event)
 
-    dataSource.transaction(rollback = {
+    dataSource.transactionAsync(rollback = {
         if (it is PSQLException && PSQLState.UNIQUE_VIOLATION.state == it.sqlState) {
             log.error("forsøk på å endre eksisterende beskjed")
         } else {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
@@ -3,7 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.map
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transaction
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transactionAsync
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.useConnectionAsync
 import org.postgresql.util.PSQLException
 import org.postgresql.util.PSQLState
@@ -107,7 +107,7 @@ fun tilQueryBeskjed(event: Event): QueryBeskjed =
             )
     }
 
-fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
+suspend fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
     val koordinat = Koordinat(
         mottaker = event.mottaker,
         merkelapp = event.merkelapp,
@@ -115,7 +115,7 @@ fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
     )
     val nyBeskjed = tilQueryBeskjed(event)
 
-    dataSource.transaction(rollback = {
+    dataSource.transactionAsync(rollback = {
         if (it is PSQLException && PSQLState.UNIQUE_VIOLATION.state == it.sqlState) {
             log.error("forsøk på å endre eksisterende beskjed")
         } else {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
@@ -57,20 +57,18 @@ object QueryModelRepository {
                     }'"
                 }
 
-                val prepstat = connection.prepareStatement(
-                    """
-                            select * from notifikasjon
-                            where (
-                                mottaker ->> '@type' = 'fodselsnummer'
-                                and mottaker ->> 'fodselsnummer' = ?
-                            ) 
-                            or (
-                                mottaker ->> '@type' = 'altinn'
-                                and mottaker @> ANY (ARRAY [$tilgangerJsonB]::jsonb[]))
-                            order by opprettet_tidspunkt desc
-                            limit 50
-                        """
-                )
+                val prepstat = connection.prepareStatement("""
+                    select * from notifikasjon
+                    where (
+                        mottaker ->> '@type' = 'fodselsnummer'
+                        and mottaker ->> 'fodselsnummer' = ?
+                    ) 
+                    or (
+                        mottaker ->> '@type' = 'altinn'
+                        and mottaker @> ANY (ARRAY [$tilgangerJsonB]::jsonb[]))
+                    order by opprettet_tidspunkt desc
+                    limit 50
+                """)
                 prepstat.setString(1, fnr)
 
                 prepstat.executeQuery().use { resultSet ->
@@ -82,10 +80,7 @@ object QueryModelRepository {
                             lenke = resultSet.getString("lenke"),
                             eksternId = resultSet.getString("ekstern_id"),
                             mottaker = objectMapper.readValue(resultSet.getString("mottaker")),
-                            opprettetTidspunkt = resultSet.getObject(
-                                "opprettet_tidspunkt",
-                                OffsetDateTime::class.java
-                            )
+                            opprettetTidspunkt = resultSet.getObject("opprettet_tidspunkt", OffsetDateTime::class.java)
                         )
                     }
                 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
@@ -1,8 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.map
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transactionAsync
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.useConnectionAsync
 import org.postgresql.util.PSQLException
@@ -43,7 +42,7 @@ object QueryModelRepository {
         fnr: String,
         tilganger: Collection<Tilgang>
     ): List<QueryBeskjed> =
-        dataSource.useConnectionAsync { connection ->
+        dataSource.useConnection { connection ->
             timer.recordCallable {
                 val tilgangerJsonB = tilganger.joinToString {
                     "'${
@@ -115,7 +114,7 @@ suspend fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
     )
     val nyBeskjed = tilQueryBeskjed(event)
 
-    dataSource.transactionAsync(rollback = {
+    dataSource.transaction(rollback = {
         if (it is PSQLException && PSQLState.UNIQUE_VIOLATION.state == it.sqlState) {
             log.error("forsøk på å endre eksisterende beskjed")
         } else {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/QueryModel.kt
@@ -3,8 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.map
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transactionAsync
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.useConnectionAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.transaction
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.useConnection
 import org.postgresql.util.PSQLException
 import org.postgresql.util.PSQLState
 import org.slf4j.LoggerFactory
@@ -43,7 +43,7 @@ object QueryModelRepository {
         fnr: String,
         tilganger: Collection<Tilgang>
     ): List<QueryBeskjed> =
-        dataSource.useConnectionAsync { connection ->
+        dataSource.useConnection { connection ->
             timer.recordCallable {
                 val tilgangerJsonB = tilganger.joinToString {
                     "'${
@@ -110,7 +110,7 @@ suspend fun queryModelBuilderProcessor(dataSource: DataSource, event: Event) {
     )
     val nyBeskjed = tilQueryBeskjed(event)
 
-    dataSource.transactionAsync(rollback = {
+    dataSource.transaction(rollback = {
         if (it is PSQLException && PSQLState.UNIQUE_VIOLATION.state == it.sqlState) {
             log.error("forsøk på å endre eksisterende beskjed")
         } else {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -19,7 +19,7 @@ interface Altinn {
     fun hentAlleTilganger(fnr: String, selvbetjeningsToken: String): List<Tilgang>
 }
 
-private val VÅRE_TJENESTER = setOf(
+val VÅRE_TJENESTER = setOf(
     "5216" to "1", // Mentortilskudd
     "5212" to "1", // Inkluderingstilskudd
     "5384" to "1", // Ekspertbistand

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -8,10 +8,6 @@ import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnConfig
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlient
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.AltinnrettigheterProxyKlientConfig
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.ProxyConfig
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.SelvbetjeningToken
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.ServiceCode
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.ServiceEdition
-import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.Subject
 import no.nav.arbeidsgiver.notifikasjon.Tilgang
 import org.slf4j.LoggerFactory
 
@@ -40,38 +36,8 @@ fun AltinnrettigheterProxyKlient.hentTilganger(
     serviceCode: String,
     serviceEdition: String,
     selvbetjeningsToken: String,
-): List<Tilgang> =
-    try {
-        this.hentOrganisasjoner(
-            SelvbetjeningToken(selvbetjeningsToken),
-            Subject(fnr),
-            ServiceCode(serviceCode),
-            ServiceEdition(serviceEdition),
-            false
-        )
-            .filter { it.type != "Enterprise" }
-            .filter {
-                if (it.organizationNumber == null) {
-                    log.warn("filtrerer ut reportee uten organizationNumber")
-                    false
-                } else {
-                    true
-                }
+): List<Tilgang> = VÅRE_TJENESTER.map { Tilgang("910825518", it.first, it.second) }
 
-            }
-            .map {
-                Tilgang(
-                    virksomhet = it.organizationNumber!!,
-                    servicecode = serviceCode,
-                    serviceedition = serviceEdition
-                )
-            }
-    } catch (error: Exception) {
-        if (error.message?.contains("403") == true)
-            emptyList()
-        else
-            throw error
-    }
 
 
 fun AltinnrettigheterProxyKlient.hentAlleTilganger(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -26,6 +26,7 @@ private val DEFAULT_HIKARI_CONFIG = HikariConfig().apply {
     driverClassName = "org.postgresql.Driver"
     metricsTrackerFactory = PrometheusMetricsTrackerFactory()
     minimumIdle = 1
+    maximumPoolSize = 2
     connectionTimeout = 10000
     idleTimeout = 10001
     maxLifetime = 30001

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -25,7 +25,6 @@ private val DEFAULT_HIKARI_CONFIG = HikariConfig().apply {
     password = System.getenv("DB_PASSWORD") ?: "postgres"
     driverClassName = "org.postgresql.Driver"
     metricsTrackerFactory = PrometheusMetricsTrackerFactory()
-    maximumPoolSize = 3
     minimumIdle = 1
     connectionTimeout = 10000
     idleTimeout = 10001

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -25,6 +25,11 @@ private val DEFAULT_HIKARI_CONFIG = HikariConfig().apply {
     password = System.getenv("DB_PASSWORD") ?: "postgres"
     driverClassName = "org.postgresql.Driver"
     metricsTrackerFactory = PrometheusMetricsTrackerFactory()
+    maximumPoolSize = 3
+    minimumIdle = 1
+    connectionTimeout = 10000
+    idleTimeout = 10001
+    maxLifetime = 30001
 }
 
 fun HikariConfig.connectionPossible(): Boolean {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -25,13 +25,6 @@ private val DEFAULT_HIKARI_CONFIG = HikariConfig().apply {
     password = System.getenv("DB_PASSWORD") ?: "postgres"
     driverClassName = "org.postgresql.Driver"
     metricsTrackerFactory = PrometheusMetricsTrackerFactory()
-    leakDetectionThreshold = 30000
-    minimumIdle = 0
-    idleTimeout = 10001
-    connectionTimeout = 10000
-    maxLifetime = 30001
-    isAutoCommit = false
-    transactionIsolation = "TRANSACTION_REPEATABLE_READ"
 }
 
 fun HikariConfig.connectionPossible(): Boolean {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -25,6 +25,13 @@ private val DEFAULT_HIKARI_CONFIG = HikariConfig().apply {
     password = System.getenv("DB_PASSWORD") ?: "postgres"
     driverClassName = "org.postgresql.Driver"
     metricsTrackerFactory = PrometheusMetricsTrackerFactory()
+    leakDetectionThreshold = 30000
+    minimumIdle = 0
+    idleTimeout = 10001
+    connectionTimeout = 10000
+    maxLifetime = 30001
+    isAutoCommit = false
+    transactionIsolation = "TRANSACTION_REPEATABLE_READ"
 }
 
 fun HikariConfig.connectionPossible(): Boolean {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
@@ -236,7 +236,7 @@ fun Route.ide() {
     }
 }
 
-private val brukerGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
+private val brukerGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(16).asCoroutineDispatcher()
 fun Route.brukerGraphQL(
     path: String,
     graphQL: TypedGraphQL<BrukerContext>
@@ -251,7 +251,7 @@ fun Route.brukerGraphQL(
         }
     }
 }
-private val produsentGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
+private val produsentGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(16).asCoroutineDispatcher()
 fun Route.produsentGraphQL(
     path: String,
     graphQL: TypedGraphQL<ProdusentContext>

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
@@ -246,7 +246,7 @@ fun Route.brukerGraphQL(
             val token = call.principal<JWTPrincipal>()!!
             val authHeader = call.request.authorization()!!.removePrefix("Bearer ") //TODO skal veksles inn hos tokenX når altinnproxy kan validere et slikt token
             val request = call.receive<GraphQLRequest>()
-            val result = graphQL.execute(request, BrukerContext(token.payload.subject, authHeader))
+            val result = graphQL.executeAsync(request, BrukerContext(token.payload.subject, authHeader))
             call.respond(result)
         }
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
@@ -236,7 +236,7 @@ fun Route.ide() {
     }
 }
 
-private val brukerGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(16).asCoroutineDispatcher()
+private val brukerGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
 fun Route.brukerGraphQL(
     path: String,
     graphQL: TypedGraphQL<BrukerContext>
@@ -251,7 +251,7 @@ fun Route.brukerGraphQL(
         }
     }
 }
-private val produsentGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(16).asCoroutineDispatcher()
+private val produsentGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
 fun Route.produsentGraphQL(
     path: String,
     graphQL: TypedGraphQL<ProdusentContext>

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
@@ -201,7 +201,7 @@ fun Application.httpServerSetup(
     }
 }
 
-private val internalDispatcher: CoroutineContext = Executors.newFixedThreadPool(16).asCoroutineDispatcher()
+private val internalDispatcher: CoroutineContext = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
 fun Route.internal() {
     get("alive") {
         withContext(this.coroutineContext + internalDispatcher) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
@@ -12,6 +12,12 @@ import io.ktor.metrics.micrometer.*
 import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -84,6 +90,14 @@ fun Application.httpServerSetup(
         distributionStatisticConfig = DistributionStatisticConfig.Builder()
             .percentilesHistogram(true)
             .build()
+        meterBinders = listOf(
+            ClassLoaderMetrics(),
+            JvmMemoryMetrics(),
+            JvmGcMetrics(),
+            ProcessorMetrics(),
+            JvmThreadMetrics(),
+            LogbackMetrics()
+        )
     }
 
     install(CallId) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpServer.kt
@@ -236,7 +236,7 @@ fun Route.ide() {
     }
 }
 
-private val brukerGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(16).asCoroutineDispatcher()
+val brukerGraphQLDispatcher: CoroutineContext = Executors.newFixedThreadPool(16).asCoroutineDispatcher()
 fun Route.brukerGraphQL(
     path: String,
     graphQL: TypedGraphQL<BrukerContext>

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Kafka.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Kafka.kt
@@ -121,7 +121,7 @@ fun Producer<KafkaKey, Event>.beskjedOpprettet(beskjed: BeskjedOpprettet) {
 
 private val log = LoggerFactory.getLogger("Consumer.processSingle")!!
 
-suspend fun <K, V>Consumer<K, V>.forEachEvent(processor: suspend (V) -> Unit) {
+suspend fun <K, V>Consumer<K, V>.forEachEvent(processor: (V) -> Unit) {
     while (true) {
         val records = try {
             poll(Duration.ofMillis(1000))
@@ -138,7 +138,7 @@ val retriesPerPartition = ConcurrentHashMap<Int, AtomicInteger>()
 
 private suspend fun <K, V> Consumer<K, V>.processWithRetry(
     records: ConsumerRecords<K, V>,
-    processor: suspend (V) -> Unit
+    processor: (V) -> Unit
 ) {
     if (records.isEmpty) {
         return

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Kafka.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Kafka.kt
@@ -121,7 +121,7 @@ fun Producer<KafkaKey, Event>.beskjedOpprettet(beskjed: BeskjedOpprettet) {
 
 private val log = LoggerFactory.getLogger("Consumer.processSingle")!!
 
-suspend fun <K, V>Consumer<K, V>.forEachEvent(processor: (V) -> Unit) {
+suspend fun <K, V>Consumer<K, V>.forEachEvent(processor: suspend (V) -> Unit) {
     while (true) {
         val records = try {
             poll(Duration.ofMillis(1000))
@@ -138,7 +138,7 @@ val retriesPerPartition = ConcurrentHashMap<Int, AtomicInteger>()
 
 private suspend fun <K, V> Consumer<K, V>.processWithRetry(
     records: ConsumerRecords<K, V>,
-    processor: (V) -> Unit
+    processor: suspend (V) -> Unit
 ) {
     if (records.isEmpty) {
         return

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/GraphQLTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/GraphQLTests.kt
@@ -12,7 +12,7 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.beOfType
 import io.ktor.http.*
 import io.ktor.server.testing.*
-import io.mockk.every
+import io.mockk.coEvery
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
@@ -192,7 +192,7 @@ class GraphQLTests : DescribeSpec({
 
         beforeEach {
             mockkObject(QueryModelRepository)
-            every {
+            coEvery {
                 QueryModelRepository.hentNotifikasjoner(any(), any(), any())
             } returns listOf(beskjed)
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/PerfTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/PerfTest.kt
@@ -15,8 +15,8 @@ import kotlin.system.measureTimeMillis
 
 fun main() = runBlocking {
     client.use {
-        nyBeskjed(100_000, Api.LOCAL)
-//        hentNotifikasjoner(10_000, Api.LOCAL)
+        nyBeskjed(5000, Api.LOCAL)
+        hentNotifikasjoner(5000, Api.LOCAL)
     }
 }
 val client = HttpClient(Apache) {
@@ -25,12 +25,12 @@ val client = HttpClient(Apache) {
         connectTimeout = 0
         connectionRequestTimeout = 0
         customizeClient {
-            setMaxConnTotal(10)
+            setMaxConnTotal(250)
         }
     }
 }
 const val selvbetjeningToken =
-    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImZ5akpfczQwN1ZqdnRzT0NZcEItRy1IUTZpYzJUeDNmXy1JT3ZqVEFqLXcifQ.eyJleHAiOjE2MTk3ODgyMzksIm5iZiI6MTYxOTc4NDYzOSwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9uYXZ0ZXN0YjJjLmIyY2xvZ2luLmNvbS9kMzhmMjVhYS1lYWI4LTRjNTAtOWYyOC1lYmY5MmMxMjU2ZjIvdjIuMC8iLCJzdWIiOiIxNjEyMDEwMTE4MSIsImF1ZCI6IjAwOTBiNmUxLWZmY2MtNGMzNy1iYzIxLTA0OWY3ZDFmMGZlNSIsImFjciI6IkxldmVsNCIsIm5vbmNlIjoiU09vWjJzRWRZUW45dVh1MXo5emVtblRuZThDcU9sMEVFM1hpdnhkY3dYTSIsImlhdCI6MTYxOTc4NDYzOSwiYXV0aF90aW1lIjoxNjE5Nzg0NjM5LCJqdGkiOiJQVTBWYWNYX2pUZ1VkSTlJaTZIRXR3ZGtZcXBrRnNiWmtKX09nX3ZidlA0IiwiYXRfaGFzaCI6IjFJQXE1WDBEeWZ3X2ZvaExzNTJESUEifQ.PsVGg9M4PR0ovhPlxpt-PP1NXEI4bucvIHic5hEx1_cM-mrLWTTVcvyG7xwVWE3fuGzeVOGFf7QDX1d338cwu21_BEKgDBMb-oUStGO_1QjJPsFdmkeS1sWnapVLEzaVhZm1b-dX2iXamK-XyR4jouUn5JIQJl6mANc6qCyrBlQVNfcwwePujXCpx3ZCcYHvzWMgYOXzPGJq-IAfmd835g1lb2uB2mxnbHUAkPMVe000pHvbr4bv0L-an54kmBN9iWS4Yz4zgneej9L-y4zbfrItCkDS7YYL8_n4QmfT5wU0fXb-_y7JlW53aBvYU_bfvtDrSkhr7IohGh9nkzzr9Q"
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImZ5akpfczQwN1ZqdnRzT0NZcEItRy1IUTZpYzJUeDNmXy1JT3ZqVEFqLXcifQ.eyJleHAiOjE2MjAwNDUxMjcsIm5iZiI6MTYyMDA0MTUyNywidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9uYXZ0ZXN0YjJjLmIyY2xvZ2luLmNvbS9kMzhmMjVhYS1lYWI4LTRjNTAtOWYyOC1lYmY5MmMxMjU2ZjIvdjIuMC8iLCJzdWIiOiIxNjEyMDEwMTE4MSIsImF1ZCI6IjAwOTBiNmUxLWZmY2MtNGMzNy1iYzIxLTA0OWY3ZDFmMGZlNSIsImFjciI6IkxldmVsNCIsIm5vbmNlIjoidXFLUU1FeDlDQmF5aDAyLVc5cFFOYzFDdnJmZmVBampsaHVuNkpMVTVLVSIsImlhdCI6MTYyMDA0MTUyNywiYXV0aF90aW1lIjoxNjIwMDQxNTI2LCJqdGkiOiJ0bkNna0VBZkZjb1N6VWxyTjlSNDBpbF9aTUdPX2VZdFh5djJscGthTlA4IiwiYXRfaGFzaCI6IjZZY3hNSzdBR2FUMVc5VlhXYnpNMEEifQ.YU37kso7tRCldQCpzlBOORkF5g6ioSFX_aYKWMQ1dQTm3KEoGsEMeugByDoUbg4PfDkukufNElxeLnlTBIDgqNT6zEfEmON9kROlLfLTKg2szj8dhiBNurJS5qCI3LGnGX3ckBFIib6SgvOqDGqTqrsgrhc9k0Pbomzle-RgWNJw_Ofl_cl8fIb3h8ccFbj-8MjiG19FOvhZM5pXRlQSsicOKUzHOlN6Qzj3CYY6WwqfuvNMpdJJ6jLgPPS5cmO_4-_h8303qVHXsXegUrKsFHd4HVdJi3HiwMhEhd6Sj2rKkzJGzke89e0jvHWbmLRIwcNFy75Rqg6bphQf_hbL2g"
 val tokenDingsToken : String = runBlocking {
     client.post<HttpResponse>("https://fakedings.dev-gcp.nais.io/fake/custom") {
         contentType(FormUrlEncoded)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/PerfTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/PerfTest.kt
@@ -8,29 +8,29 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.ContentType.Application.FormUrlEncoded
 import kotlinx.coroutines.*
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.VÅRE_TJENESTER
 import java.lang.System.currentTimeMillis
 import java.time.Instant
 import kotlin.system.measureTimeMillis
 
 fun main() = runBlocking {
     client.use {
-        nyBeskjed(10_000)
-        hentNotifikasjoner(10_000)
+        nyBeskjed(100_000, Api.LOCAL)
+//        hentNotifikasjoner(10_000, Api.LOCAL)
     }
 }
-
 val client = HttpClient(Apache) {
     engine {
         socketTimeout = 0
         connectTimeout = 0
         connectionRequestTimeout = 0
         customizeClient {
-            setMaxConnTotal(20)
+            setMaxConnTotal(10)
         }
     }
 }
 const val selvbetjeningToken =
-    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImZ5akpfczQwN1ZqdnRzT0NZcEItRy1IUTZpYzJUeDNmXy1JT3ZqVEFqLXcifQ.eyJleHAiOjE2MTk2NjAyMTQsIm5iZiI6MTYxOTY1NjYxNCwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9uYXZ0ZXN0YjJjLmIyY2xvZ2luLmNvbS9kMzhmMjVhYS1lYWI4LTRjNTAtOWYyOC1lYmY5MmMxMjU2ZjIvdjIuMC8iLCJzdWIiOiIxNjEyMDEwMTE4MSIsImF1ZCI6IjAwOTBiNmUxLWZmY2MtNGMzNy1iYzIxLTA0OWY3ZDFmMGZlNSIsImFjciI6IkxldmVsNCIsIm5vbmNlIjoiVFp1Ti1TTi01ZG9zSmVoYkg5SGNaTVJNMUxZcTVHbmNmZTdXdi1ydEhSRSIsImlhdCI6MTYxOTY1NjYxNCwiYXV0aF90aW1lIjoxNjE5NjU2NjEzLCJqdGkiOiJUZTFlN3dzODQxeUtyaFlFTGVFdzZLb3NObDZNRlNfdVFaUGRRa3EzRzlrIiwiYXRfaGFzaCI6IlQ5RHA3M1BzaWlidjhFdVhfMENkVFEifQ.szuNOGqw-Cv0Hh09Hvzvu1n5nD-aYulp7LJhc49dGcQN9m7T_PfIRaHL0h8OXT8Ed8xGoZpRUVs5TvDoNGKc28ZrRmT3acjePD9OUUM-GNmSIZfQWty32PenBAY4dPLlqakbKiu-0MuIg0X8PA6hZD7BMlv-Z0aP4zlGKZC9M9VBV3OKD09dAaLzhLlFseCd5LnEcFagN0ATdkgV6WqEoS3h06UdqaNJqfvx8UzmLCjw8VM5UgLdNUw-tNYHWy7F8m6GkqMTQW9YH1ezTImEZzIrhIe9ZXkhGtBNUrB-y3klx-I3soQuBAO2NnWIpKfAhx0EEjgNNf2OWmdfnFXjRg"
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImZ5akpfczQwN1ZqdnRzT0NZcEItRy1IUTZpYzJUeDNmXy1JT3ZqVEFqLXcifQ.eyJleHAiOjE2MTk3ODgyMzksIm5iZiI6MTYxOTc4NDYzOSwidmVyIjoiMS4wIiwiaXNzIjoiaHR0cHM6Ly9uYXZ0ZXN0YjJjLmIyY2xvZ2luLmNvbS9kMzhmMjVhYS1lYWI4LTRjNTAtOWYyOC1lYmY5MmMxMjU2ZjIvdjIuMC8iLCJzdWIiOiIxNjEyMDEwMTE4MSIsImF1ZCI6IjAwOTBiNmUxLWZmY2MtNGMzNy1iYzIxLTA0OWY3ZDFmMGZlNSIsImFjciI6IkxldmVsNCIsIm5vbmNlIjoiU09vWjJzRWRZUW45dVh1MXo5emVtblRuZThDcU9sMEVFM1hpdnhkY3dYTSIsImlhdCI6MTYxOTc4NDYzOSwiYXV0aF90aW1lIjoxNjE5Nzg0NjM5LCJqdGkiOiJQVTBWYWNYX2pUZ1VkSTlJaTZIRXR3ZGtZcXBrRnNiWmtKX09nX3ZidlA0IiwiYXRfaGFzaCI6IjFJQXE1WDBEeWZ3X2ZvaExzNTJESUEifQ.PsVGg9M4PR0ovhPlxpt-PP1NXEI4bucvIHic5hEx1_cM-mrLWTTVcvyG7xwVWE3fuGzeVOGFf7QDX1d338cwu21_BEKgDBMb-oUStGO_1QjJPsFdmkeS1sWnapVLEzaVhZm1b-dX2iXamK-XyR4jouUn5JIQJl6mANc6qCyrBlQVNfcwwePujXCpx3ZCcYHvzWMgYOXzPGJq-IAfmd835g1lb2uB2mxnbHUAkPMVe000pHvbr4bv0L-an54kmBN9iWS4Yz4zgneej9L-y4zbfrItCkDS7YYL8_n4QmfT5wU0fXb-_y7JlW53aBvYU_bfvtDrSkhr7IohGh9nkzzr9Q"
 val tokenDingsToken : String = runBlocking {
     client.post<HttpResponse>("https://fakedings.dev-gcp.nais.io/fake/custom") {
         contentType(FormUrlEncoded)
@@ -122,7 +122,9 @@ suspend fun hentNotifikasjoner(count: Int, api: Api = Api.BRUKER_GCP) {
 suspend fun nyBeskjed(count: Int, api: Api = Api.PRODUSENT_GCP) {
     val run = Instant.now()
     val eksterIder = generateSequence(1) { it + 1 }.iterator()
+    val tjenester = VÅRE_TJENESTER.asSequence().looping().iterator()
     concurrentWithStats("nyBeskjed", count) {
+        val (tjenesteKode, tjenesteVersjon) = tjenester.next()
         client.post<HttpResponse>(api.url) {
             headers {
                 append(HttpHeaders.ContentType, "application/json")
@@ -140,8 +142,8 @@ suspend fun nyBeskjed(count: Int, api: Api = Api.PRODUSENT_GCP) {
                     |          merkelapp: \"tiltak\",
                     |          mottaker: {
                     |              altinn: {
-                    |                  altinntjenesteKode: \"5159\",
-                    |                  altinntjenesteVersjon: \"1\",
+                    |                  altinntjenesteKode: \"$tjenesteKode\",
+                    |                  altinntjenesteVersjon: \"$tjenesteVersjon\",
                     |                  virksomhetsnummer: \"910825518\"
                     |              }
                     |          },
@@ -195,3 +197,5 @@ class ProgressBar(
 
 fun String.trimMarginAndNewline() =
     this.trimMargin().replace(Regex("\n"), " ")
+
+fun <T> Sequence<T>.looping() = generateSequence(this) { it }.flatten()


### PR DESCRIPTION
ytelsestest i kveld hvor jeg stubbet ut altinn proxy kallet til å returnere alle tilganger for samme virksomhet.
Rampet opp og endte på rundt 300 req/sek i throughput. tilvarer litt over 1 mill req i timen.
Hvert kall returnerte 50 notifikasjoner. 
Når jeg så på min-side-ag i nettleser mens testen kjørte så jeg at notifikasjoner ble hentet med en svartid på rundt 90ms.

kjørte følgende:

```kotlin
client.use {
        //nyBeskjed(5000)
        (1..10).forEach {
            hentNotifikasjoner(it  * 1000)
            delay(5000)
        }
    }
```

```
----------------------------
     Ok count: 7000
  Error count: 0

     req/s: 280
----------------------------
     Ok count: 8000
  Error count: 0

     req/s: 296
----------------------------
     Ok count: 9000
  Error count: 0

     req/s: 300
----------------------------
     Ok count: 10000
     Error count: 0

     req/s: 303
----------------------------
```

![image](https://user-images.githubusercontent.com/189395/116926640-e1303880-ac5a-11eb-92a1-d2541cbf703f.png)

![image](https://user-images.githubusercontent.com/189395/116926386-96aebc00-ac5a-11eb-942e-b041368cd5f3.png)

![image](https://user-images.githubusercontent.com/189395/116926300-81d22880-ac5a-11eb-9996-3def6c184f02.png)

![image](https://user-images.githubusercontent.com/189395/116926244-73840c80-ac5a-11eb-966d-17275ec2e57e.png)
