### PR TITLE
mens vi gjør delay vil ikke kafka kunne rebalansere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@
   * `kafka-delete-records.sh --bootstrap-server $KAFKA_BROKERS --offset-json-file delete-records.json`
 * inspect a consumer group
   * `kafka-consumer-groups.sh --bootstrap-server $KAFKA_BROKERS --command-config /kafka.properties --group query-model-builder --describe` 
-* adjust offset of a consumer group
-  * `kafka-consumer-groups.sh --bootstrap-server $KAFKA_BROKERS --command-config /kafka.properties --group query-model-builder --topic arbeidsgiver.notifikasjon --reset-offsets --to-earliest --execute`
+* adjust offset of a consumer group (requires group is inactive, i.e. no running consumers)
+  * `kafka-consumer-groups.sh --bootstrap-server $KAFKA_BROKERS --command-config /kafka.properties --group query-model-builder --topic arbeidsgiver.notifikasjon --reset-offsets --to-earlies --execute`
   * `kafka-consumer-groups.sh --bootstrap-server $KAFKA_BROKERS --command-config /kafka.properties --group query-model-builder --topic arbeidsgiver.notifikasjon --shift-by 1 --execute`
+  * specify partition using `--topic topic:0,1,2`. e.g. reset offset for partition 14 to 5004:
+  * `kafka-consumer-groups.sh --bootstrap-server $KAFKA_BROKERS --command-config /kafka.properties --group query-model-builder --topic arbeidsgiver.notifikasjon:14 --reset-offsets --to-offset 5004 --execute`
 
 ref:
 https://medium.com/@TimvanBaarsen/apache-kafka-cli-commands-cheat-sheet-a6f06eac01b

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
@@ -31,12 +31,12 @@ object Main {
             }
 
             launch {
-                val kafkaConsumer = createKafkaConsumer()
-                val queryModel = queryModelAsync.await()
-
-                kafkaConsumer.forEachEvent { event ->
-                    queryModel.oppdaterModellEtterHendelse(event)
-                }
+//                val kafkaConsumer = createKafkaConsumer()
+//                val queryModel = queryModelAsync.await()
+//
+//                kafkaConsumer.forEachEvent { event ->
+//                    queryModel.oppdaterModellEtterHendelse(event)
+//                }
             }
 
             launch {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
@@ -31,12 +31,12 @@ object Main {
             }
 
             launch {
-//                val kafkaConsumer = createKafkaConsumer()
-//                val queryModel = queryModelAsync.await()
-//
-//                kafkaConsumer.forEachEvent { event ->
-//                    queryModel.oppdaterModellEtterHendelse(event)
-//                }
+                val kafkaConsumer = createKafkaConsumer()
+                val queryModel = queryModelAsync.await()
+
+                kafkaConsumer.forEachEvent { event ->
+                    queryModel.oppdaterModellEtterHendelse(event)
+                }
             }
 
             launch {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Kafka.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Kafka.kt
@@ -221,7 +221,7 @@ class CoroutineConsumerImpl<K, V>(
             return
         }
 
-        records.partitions().forEach { partition ->
+        records.partitions().forEach currentPartition@{ partition ->
             val retries = retriesForPartition(partition.partition())
             records.records(partition).forEach currentRecord@{ record ->
                 try {
@@ -234,7 +234,6 @@ class CoroutineConsumerImpl<K, V>(
                 } catch (e: Exception) {
                     val attempt = retries.incrementAndGet()
                     val backoffMillis = 1000L * 2.toThePowerOf(attempt)
-
                     log.error("exception while processing {}. attempt={}. backoff={}.",
                         record.loggableToString(),
                         attempt,
@@ -247,6 +246,7 @@ class CoroutineConsumerImpl<K, V>(
                     retryTimer.schedule(backoffMillis) {
                         resumeQueue.offer(currentPartition)
                     }
+                    return@currentPartition
                 }
             }
         }

--- a/http/dev-graphql-query.http
+++ b/http/dev-graphql-query.http
@@ -2,7 +2,7 @@
 POST http://localhost:8081/api/graphql
 host: ag-notifikasjon-produsent-api.dev.nav.no
 content-type: application/json
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiJzb21lcHJvZHVjZXIiLCJpc3MiOiJsb2NhbGhvc3QifQ.
+Authorization: Bearer {{auth_token}}
 
 {
   "query":
@@ -14,7 +14,7 @@ Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiJzb21lcHJvZH
 POST http://localhost:8081/api/graphql
 content-type: application/json
 host: ag-notifikasjon-produsent-api.nav.no
-Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJzdWIiOiJzb21lcHJvZHVjZXIiLCJpc3MiOiJsb2NhbGhvc3QifQ.
+Authorization: Bearer {{auth_token}}
 
 {
   "query":


### PR DESCRIPTION
Dette betyr at nye poder ikke får subscribet mens en partisjon er i retry modus.
denne endringen gjør slik at vi pauser partisjonen og seeker til offset, slik at vi kan fortsette å polle som normalt, og rebalance vil ikke bli forhindret.

NB:
Jeg er ikke helt sikker på hvordan pause/resume spiller sammen med en restart. Altså om det er informasjon som overlever kall til subscribe, men jeg vil tro at det ikke gjør det. Dersom det ikke er tilfellet må vi bare eksplisitt resume alle partisjoner når vi subscriber.

---

En mer avansert approach vil være å lagre offsets i databasen, og styre rebalance selv. Dette har noen pros og cons. Cons er at det er mer vi må håndtere og implementere. Pros er at det vil gjøre det enklere for oss å manage offsets og trigge replays uten å lene oss på kafka-cli