### PR TITLE
valider at tekst ikke inneholder fødselsnummer

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/GraphQLValidation.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/GraphQLValidation.kt
@@ -113,6 +113,18 @@ private val FIELD_VALIDATORS = listOf<ValidatorBuilder<GraphQLInputObjectField>>
                 }
             }
         }
+    },
+    object : ValidatorBuilder<GraphQLInputObjectField> {
+        override val name = "NonIdentifying"
+
+        override fun createValidator(directive: GraphQLDirective, obj: GraphQLInputObjectField): Validator {
+            return { value ->
+                val valueStr = value as String?
+                if (valueStr != null && valueStr.contains(Regex("""\d{11}"""))) {
+                    throw ValideringsFeil("felt '${obj.name}' kan ikke inneholde identifiserende data")
+                }
+            }
+        }
     }
 ).associateBy { it.name }
 

--- a/app/src/main/resources/produsent.graphqls
+++ b/app/src/main/resources/produsent.graphqls
@@ -1,5 +1,6 @@
 directive @Validate on ARGUMENT_DEFINITION
 directive @MaxLength(max: Int) on INPUT_FIELD_DEFINITION
+directive @NonIdentifying on INPUT_FIELD_DEFINITION
 directive @ExactlyOneFieldGiven on INPUT_OBJECT
 
 """
@@ -44,7 +45,7 @@ input NyBeskjedInput {
     """
     Teksten som vises til brukeren.
     """
-    tekst: String! @MaxLength(max: 300)
+    tekst: String! @MaxLength(max: 300) @NonIdentifying
 
     """
     Lenken som brukeren føres til hvis de klikker på beskjeden.

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/InputValideringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/InputValideringTests.kt
@@ -58,11 +58,10 @@ class InputValideringTests : DescribeSpec({
                 errors.first().message shouldContain "felt 'tekst' overstiger max antall tegn. antall=301, max=300"
             }
         }
-    }
 
-    context("Mutation.nyBeskjed med ingen mottaker") {
-        val response = engine.produsentApi(
-            """
+        context("Mutation.nyBeskjed med ingen mottaker") {
+            val response = engine.produsentApi(
+                """
                     mutation {
                         nyBeskjed(nyBeskjed: {
                             lenke: "https://foo.bar",
@@ -77,16 +76,16 @@ class InputValideringTests : DescribeSpec({
                         }
                     }
                 """.trimIndent()
-        )
+            )
 
-        it("Feil pga ingen mottaker-felt oppgitt") {
-            response.getGraphqlErrors()[0].message shouldContainIgnoringCase "nøyaktig ett felt"
+            it("Feil pga ingen mottaker-felt oppgitt") {
+                response.getGraphqlErrors()[0].message shouldContainIgnoringCase "nøyaktig ett felt"
+            }
         }
-    }
 
-    context("Mutation.nyBeskjed med to mottakere") {
-        val response = engine.produsentApi(
-            """
+        context("Mutation.nyBeskjed med to mottakere") {
+            val response = engine.produsentApi(
+                """
                     mutation {
                         nyBeskjed(nyBeskjed: {
                             lenke: "https://foo.bar",
@@ -114,10 +113,40 @@ class InputValideringTests : DescribeSpec({
                         }
                     }
                 """.trimIndent()
-        )
+            )
 
-        it("response inneholder ikke feil") {
-            response.getGraphqlErrors()[0].message shouldContainIgnoringCase "nøyaktig ett felt"
+            it("Feil pga to mottaker-felt oppgitt") {
+                response.getGraphqlErrors()[0].message shouldContainIgnoringCase "nøyaktig ett felt"
+            }
+        }
+
+        context("når tekst inneholder fødselsnummer") {
+            val response = engine.produsentApi(
+                """
+                    mutation {
+                        nyBeskjed(nyBeskjed: {
+                            lenke: "https://foo.bar",
+                            tekst: "${"1".repeat(11)}",
+                            merkelapp: "tag",
+                            eksternId: "heuer",
+                            mottaker: {
+                                naermesteLeder: {
+                                    naermesteLederFnr: "12345678910",
+                                    ansattFnr: "3213"
+                                    virksomhetsnummer: "42"
+                                } 
+                            }
+                            opprettetTidspunkt: "2019-10-12T07:20:50.52Z"
+                        }) {
+                            __typename
+                        }
+                    }
+                """.trimIndent()
+            )
+
+            it("feil pga identifiserende data i tekst") {
+                response.getGraphqlErrors()[0].message shouldContainIgnoringCase "'tekst' kan ikke inneholde identifiserende data"
+            }
         }
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/InputValideringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/InputValideringTests.kt
@@ -137,10 +137,11 @@ class InputValideringTests : DescribeSpec({
                 """
                     mutation {
                         nyBeskjed(nyBeskjed: {
-                            lenke: "https://foo.bar",
-                            tekst: "${"1".repeat(11)}",
-                            merkelapp: "tag",
-                            eksternId: "heuer",
+                            notifikasjon: {
+                                lenke: "https://foo.bar",
+                                tekst: "${"1".repeat(11)}",
+                                merkelapp: "tag",
+                            }
                             mottaker: {
                                 naermesteLeder: {
                                     naermesteLederFnr: "12345678910",
@@ -148,7 +149,10 @@ class InputValideringTests : DescribeSpec({
                                     virksomhetsnummer: "42"
                                 } 
                             }
-                            opprettetTidspunkt: "2019-10-12T07:20:50.52Z"
+                            metadata: {
+                                eksternId: "heuer",
+                                opprettetTidspunkt: "2019-10-12T07:20:50.52Z"
+                            }
                         }) {
                             __typename
                         }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
@@ -45,4 +45,8 @@ fun TestApplicationResponse.getGraphqlErrors(): List<GraphQLError> {
     return if (errors == null) emptyList() else objectMapper.convertValue(errors)
 }
 
+fun TestApplicationResponse.getFirstGraphqlError(): GraphQLError {
+    return getGraphqlErrors().first()
+}
+
 


### PR DESCRIPTION
vurderte å låne en mer nøyaktig sjekk for fødselsnummer, f.eks [herfra](https://github.com/navikt/helse-arbeidsgiver-felles-backend/blob/9462b011ee3cbcd30abf23905494eeed1eac5f13/src/main/kotlin/no/nav/helse/arbeidsgiver/web/validation/Validators.kt) men endte med å bare sjekke for 11 digits i første omgang 

