### PR TITLE
skill på definisjon og identifisert produsent

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Produsent.kt
@@ -83,9 +83,8 @@ object Produsent {
 
             val graphql = async {
                 ProdusentAPI.newGraphQL(
-                    produsentRepository = produsentModelAsync.await(),
                     kafkaProducer = createKafkaProducer(),
-                    produsentRegister = produsentRegister
+                    produsentRepository = produsentModelAsync.await()
 
                 )
             }
@@ -98,7 +97,7 @@ object Produsent {
                 }) {
                     httpServerSetup(
                         authProviders = authProviders,
-                        extractContext = extractProdusentContext,
+                        extractContext = extractProdusentContext(produsentRegister),
                         graphql = graphql
                     )
                 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpAuthProviders.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpAuthProviders.kt
@@ -22,7 +22,7 @@ data class BrukerPrincipal(
 ) : Principal
 
 data class ProdusentPrincipal(
-    val produsentid: String,
+    val appName: String,
 ) : Principal
 
 data class JWTAuthentication(
@@ -119,7 +119,7 @@ object HttpAuthProviders {
                         return@validate null
                     }
 
-                    ProdusentPrincipal(produsentid = appName)
+                    ProdusentPrincipal(appName = appName)
                 }
             }
         )
@@ -156,7 +156,7 @@ object HttpAuthProviders {
 
                 validate {
                     ProdusentPrincipal(
-                        produsentid = it.payload.getClaim("azp").asString()
+                        appName = it.payload.getClaim("azp").asString()
                     )
                 }
             }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
@@ -24,6 +24,8 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLRequest
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.TypedGraphQL
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.WithCoroutineScope
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.PRODUSENT_REGISTER
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.ProdusentRegister
 import org.slf4j.event.Level
 import java.util.*
 import java.util.concurrent.Executors
@@ -39,12 +41,15 @@ val extractBrukerContext = fun PipelineContext<Unit, ApplicationCall>.(): Bruker
     )
 }
 
-val extractProdusentContext = fun PipelineContext<Unit, ApplicationCall>.(): ProdusentAPI.Context {
-    val principal = call.principal<ProdusentPrincipal>()!!
-    return ProdusentAPI.Context(
-        produsentid = principal.produsentid,
-        coroutineScope = this
-    )
+fun extractProdusentContext(produsentRegister: ProdusentRegister): PipelineContext<Unit, ApplicationCall>.() -> ProdusentAPI.Context {
+    return fun PipelineContext<Unit, ApplicationCall>.(): ProdusentAPI.Context {
+        val principal = call.principal<ProdusentPrincipal>()!!
+        return ProdusentAPI.Context(
+            appName = principal.appName,
+            produsent = produsentRegister.finn(principal.appName), // TODO: use interface
+            coroutineScope = this
+        )
+    }
 }
 
 private val metricsDispatcher: CoroutineContext = Executors.newFixedThreadPool(1)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
@@ -41,15 +41,13 @@ val extractBrukerContext = fun PipelineContext<Unit, ApplicationCall>.(): Bruker
     )
 }
 
-fun extractProdusentContext(produsentRegister: ProdusentRegister): PipelineContext<Unit, ApplicationCall>.() -> ProdusentAPI.Context {
-    return fun PipelineContext<Unit, ApplicationCall>.(): ProdusentAPI.Context {
-        val principal = call.principal<ProdusentPrincipal>()!!
-        return ProdusentAPI.Context(
-            appName = principal.appName,
-            produsent = produsentRegister.finn(principal.appName), // TODO: use interface
-            coroutineScope = this
-        )
-    }
+fun extractProdusentContext(produsentRegister: ProdusentRegister) = fun PipelineContext<Unit, ApplicationCall>.(): ProdusentAPI.Context {
+    val principal = call.principal<ProdusentPrincipal>()!!
+    return ProdusentAPI.Context(
+        appName = principal.appName,
+        produsent = produsentRegister.finn(principal.appName),
+        coroutineScope = this
+    )
 }
 
 private val metricsDispatcher: CoroutineContext = Executors.newFixedThreadPool(1)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegister.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegister.kt
@@ -9,18 +9,12 @@ import java.util.*
 
 typealias Merkelapp = String
 
-data class ProdusentDefinisjon(
+data class Produsent(
+    val id: String,
     val accessPolicy: List<AppName>,
     val tillatteMerkelapper: List<Merkelapp> = emptyList(),
     val tillatteMottakere: List<MottakerDefinisjon> = emptyList()
-)
-
-data class Produsent(
-    val id: AppName,
-    val definisjon: ProdusentDefinisjon
 ) {
-    val tillatteMerkelapper by definisjon::tillatteMerkelapper
-    val tillatteMottakere by definisjon::tillatteMottakere
 
     fun kanSendeTil(merkelapp: Merkelapp): Boolean {
         return tillatteMerkelapper.contains(merkelapp)
@@ -83,7 +77,7 @@ interface ProdusentRegister {
 }
 
 class ProdusentRegisterImpl(
-    produsenter: List<ProdusentDefinisjon>
+    produsenter: List<Produsent>
 ) : ProdusentRegister {
 
     val log = logger()
@@ -100,8 +94,8 @@ class ProdusentRegisterImpl(
 
     private val produsenterByName: Map<AppName, Produsent> =
         produsenter
-            .flatMap { definisjon ->
-                definisjon.accessPolicy.map { appNavn -> Pair(appNavn, Produsent(appNavn, definisjon)) }
+            .flatMap { produsent ->
+                produsent.accessPolicy.map { appNavn -> Pair(appNavn, produsent) }
             }
             .toMap()
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegister.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegister.kt
@@ -9,11 +9,19 @@ import java.util.*
 
 typealias Merkelapp = String
 
-data class Produsent(
+data class ProdusentDefinisjon(
     val accessPolicy: List<AppName>,
     val tillatteMerkelapper: List<Merkelapp> = emptyList(),
     val tillatteMottakere: List<MottakerDefinisjon> = emptyList()
+)
+
+data class Produsent(
+    val id: AppName,
+    val definisjon: ProdusentDefinisjon
 ) {
+    val tillatteMerkelapper by definisjon::tillatteMerkelapper
+    val tillatteMottakere by definisjon::tillatteMottakere
+
     fun kanSendeTil(merkelapp: Merkelapp): Boolean {
         return tillatteMerkelapper.contains(merkelapp)
     }
@@ -75,7 +83,7 @@ interface ProdusentRegister {
 }
 
 class ProdusentRegisterImpl(
-    produsenter: List<Produsent>
+    produsenter: List<ProdusentDefinisjon>
 ) : ProdusentRegister {
 
     val log = logger()
@@ -92,8 +100,8 @@ class ProdusentRegisterImpl(
 
     private val produsenterByName: Map<AppName, Produsent> =
         produsenter
-            .flatMap { produsent ->
-                produsent.accessPolicy.map { appNavn -> Pair(appNavn, produsent) }
+            .flatMap { definisjon ->
+                definisjon.accessPolicy.map { appNavn -> Pair(appNavn, Produsent(appNavn, definisjon)) }
             }
             .toMap()
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegisterImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegisterImpl.kt
@@ -2,7 +2,8 @@ package no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter
 
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
 
-val FAGER_TESTPRODUSENT = ProdusentDefinisjon(
+val FAGER_TESTPRODUSENT = Produsent(
+    id = "fager",
     accessPolicy = basedOnEnv(
         prod = listOf("prod-gcp:fager:notifikasjon-test-produsent"),
         other = listOf("dev-gcp:fager:notifikasjon-test-produsent")
@@ -15,7 +16,8 @@ val FAGER_TESTPRODUSENT = ProdusentDefinisjon(
     )
 )
 
-val ARBEIDSGIVER_TILTAK = ProdusentDefinisjon(
+val ARBEIDSGIVER_TILTAK = Produsent(
+    id = "arbeidsgiver-tiltak",
     accessPolicy = basedOnEnv(
         prod = listOf(),
         other = listOf(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegisterImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegisterImpl.kt
@@ -2,21 +2,20 @@ package no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter
 
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
 
-val FAGER_TESTPRODUSENT =
-    Produsent(
-        accessPolicy = basedOnEnv(
-            prod = listOf("prod-gcp:fager:notifikasjon-test-produsent"),
-            other = listOf("dev-gcp:fager:notifikasjon-test-produsent")
-        ),
-        tillatteMerkelapper = listOf(
-            "fager",
-        ),
-        tillatteMottakere = listOf(
-            ServicecodeDefinisjon(code = "4936", version = "1"),
-        )
+val FAGER_TESTPRODUSENT = ProdusentDefinisjon(
+    accessPolicy = basedOnEnv(
+        prod = listOf("prod-gcp:fager:notifikasjon-test-produsent"),
+        other = listOf("dev-gcp:fager:notifikasjon-test-produsent")
+    ),
+    tillatteMerkelapper = listOf(
+        "fager",
+    ),
+    tillatteMottakere = listOf(
+        ServicecodeDefinisjon(code = "4936", version = "1"),
     )
+)
 
-val ARBEIDSGIVER_TILTAK = Produsent(
+val ARBEIDSGIVER_TILTAK = ProdusentDefinisjon(
     accessPolicy = basedOnEnv(
         prod = listOf(),
         other = listOf(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentAPI.kt
@@ -17,7 +17,8 @@ object ProdusentAPI {
     private val log = logger()
 
     data class Context(
-        val produsentid: String,
+        val appName: String,
+        val produsent: Produsent?,
         override val coroutineScope: CoroutineScope
     ) : WithCoroutineScope
 
@@ -371,19 +372,19 @@ object ProdusentAPI {
 
     fun newGraphQL(
         kafkaProducer: CoroutineKafkaProducer<KafkaKey, Hendelse> = createKafkaProducer(),
-        produsentRegister: ProdusentRegister,
         produsentRepository: ProdusentRepository,
     ): TypedGraphQL<Context> {
 
         fun queryWhoami(env: DataFetchingEnvironment): String {
-            return env.getContext<Context>().produsentid
+            // TODO: returner hele context objectet som struct
+            return env.getContext<Context>().appName
         }
 
         suspend fun queryMineNotifikasjoner(env: DataFetchingEnvironment): MineNotifikasjonerResultat {
             val merkelapp = env.getArgument<String>("merkelapp")
             val first = env.getArgumentOrDefault("first", 1000)
             val after = Cursor(env.getArgumentOrDefault("after", Cursor.empty().value))
-            val produsent = hentProdusent(env, produsentRegister) { error -> return error }
+            val produsent = hentProdusent(env) { error -> return error }
             tilgangsstyrMerkelapp(produsent, merkelapp) { error -> return error }
             return produsentRepository
                 .finnNotifikasjoner(merkelapp = merkelapp, antall = first, offset = after.offset)
@@ -396,7 +397,6 @@ object ProdusentAPI {
 
             tilgangsstyrNyNotifikasjon(
                 env,
-                produsentRegister,
                 nyBeskjed.mottaker.tilDomene(),
                 nyBeskjed.notifikasjon.merkelapp
             ) { error ->
@@ -432,7 +432,6 @@ object ProdusentAPI {
             val nyOppgave = env.getTypedArgument<NyOppgaveInput>("nyOppgave")
             tilgangsstyrNyNotifikasjon(
                 env,
-                produsentRegister,
                 nyOppgave.mottaker.tilDomene(),
                 nyOppgave.notifikasjon.merkelapp
             ) { error -> return error }
@@ -471,7 +470,7 @@ object ProdusentAPI {
                 return Error.NotifikasjonFinnesIkke("Notifikasjon med id $id er ikke en oppgave")
             }
 
-            val produsent = hentProdusent(env, produsentRegister) { error -> return error }
+            val produsent = hentProdusent(env) { error -> return error }
 
             tilgangsstyrMerkelapp(produsent, notifikasjon.merkelapp) { error -> return error }
 
@@ -496,7 +495,7 @@ object ProdusentAPI {
                 return Error.NotifikasjonFinnesIkke("Notifikasjon med eksternId $eksternId og merkelapp $merkelapp er ikke en oppgave")
             }
 
-            val produsent = hentProdusent(env, produsentRegister) { error -> return error }
+            val produsent = hentProdusent(env) { error -> return error }
 
             tilgangsstyrMerkelapp(produsent, notifikasjon.merkelapp) { error -> return error }
 
@@ -516,7 +515,7 @@ object ProdusentAPI {
             val notifikasjon = produsentRepository.hentNotifikasjon(id)
                 ?: return Error.NotifikasjonFinnesIkke("Notifikasjon med id $id finnes ikke")
 
-            val produsent = hentProdusent(env, produsentRegister) { error -> return error }
+            val produsent = hentProdusent(env) { error -> return error }
             tilgangsstyrMerkelapp(produsent, notifikasjon.merkelapp) { error -> return error }
 
             val softDelete = Hendelse.SoftDelete(
@@ -537,7 +536,7 @@ object ProdusentAPI {
             val notifikasjon = produsentRepository.hentNotifikasjon(eksternId, merkelapp)
                 ?: return Error.NotifikasjonFinnesIkke("Notifikasjon med eksternId $eksternId og merkelapp $merkelapp finnes ikke")
 
-            val produsent = hentProdusent(env, produsentRegister) { error ->
+            val produsent = hentProdusent(env) { error ->
                 return error
             }
 
@@ -562,7 +561,7 @@ object ProdusentAPI {
             val notifikasjon = produsentRepository.hentNotifikasjon(id)
                 ?: return Error.NotifikasjonFinnesIkke("Notifikasjon med id $id finnes ikke")
 
-            val produsent = hentProdusent(env, produsentRegister) { error -> return error }
+            val produsent = hentProdusent(env) { error -> return error }
             tilgangsstyrMerkelapp(produsent, notifikasjon.merkelapp) { error -> return error }
 
             val hardDelete = Hendelse.HardDelete(
@@ -583,7 +582,7 @@ object ProdusentAPI {
             val notifikasjon = produsentRepository.hentNotifikasjon(eksternId, merkelapp)
                 ?: return Error.NotifikasjonFinnesIkke("Notifikasjon med eksternId $eksternId og merkelapp $merkelapp finnes ikke")
 
-            val produsent = hentProdusent(env, produsentRegister) { error -> return error }
+            val produsent = hentProdusent(env) { error -> return error }
 
             tilgangsstyrMerkelapp(produsent, notifikasjon.merkelapp) { error -> return error }
 
@@ -638,12 +637,11 @@ object ProdusentAPI {
 
 private inline fun tilgangsstyrNyNotifikasjon(
     env: DataFetchingEnvironment,
-    produsentRegister: ProdusentRegister,
     mottaker: Mottaker,
     merkelapp: String,
     onError: (ProdusentAPI.NyNotifikasjonError) -> Nothing
 ) {
-    val produsent = hentProdusent(env, produsentRegister) { error -> onError(error) }
+    val produsent = hentProdusent(env) { error -> onError(error) }
     tilgangsstyrMottaker(produsent, mottaker) { error -> onError(error) }
     tilgangsstyrMerkelapp(produsent, merkelapp) { error -> onError(error) }
 }
@@ -684,18 +682,15 @@ private inline fun tilgangsstyrMottaker(
 
 inline fun hentProdusent(
     env: DataFetchingEnvironment,
-    produsentRegister: ProdusentRegister,
     onMissing: (error: ProdusentAPI.Error.UkjentProdusent) -> Nothing
 ): Produsent {
     val context = env.getContext<ProdusentAPI.Context>()
-    val produsentid = context.produsentid
-    val produsent = produsentRegister.finn(produsentid)
-    if (produsent == null) {
+    if (context.produsent == null) {
         onMissing(ProdusentAPI.Error.UkjentProdusent(
-            "Finner ikke produsent med id $produsentid"
+            "Finner ikke produsent med id ${context.appName}"
         ))
     } else {
-        return produsent
+        return context.produsent
     }
 }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/LocalMainProdusentAPI.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/LocalMainProdusentAPI.kt
@@ -1,26 +1,26 @@
 package no.nav.arbeidsgiver.notifikasjon.executable
 
 import db.migration.OS
-import no.nav.arbeidsgiver.notifikasjon.Produsent
+import no.nav.arbeidsgiver.notifikasjon.Produsent as ProdusentMain
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.HttpAuthProviders
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.FAGER_TESTPRODUSENT
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.Produsent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.ProdusentRegister
 import no.nav.arbeidsgiver.notifikasjon.util.LOCALHOST_PRODUSENT_AUTHENTICATION
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.Produsent as ProdusentDefinisjon
 
 
 /* Produsent api */
 fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
     OS.setupLocal()
-    Produsent.main(
+    ProdusentMain.main(
         httpPort = 8081,
         authProviders = listOf(
             HttpAuthProviders.FAKEDINGS_PRODUSENT,
             LOCALHOST_PRODUSENT_AUTHENTICATION,
         ),
         produsentRegister = object : ProdusentRegister {
-            override fun finn(appName: String): ProdusentDefinisjon {
-                return FAGER_TESTPRODUSENT
+            override fun finn(appName: String): Produsent {
+                return Produsent(appName, FAGER_TESTPRODUSENT)
             }
         }
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/LocalMainProdusentAPI.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/LocalMainProdusentAPI.kt
@@ -20,7 +20,7 @@ fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
         ),
         produsentRegister = object : ProdusentRegister {
             override fun finn(appName: String): Produsent {
-                return Produsent(appName, FAGER_TESTPRODUSENT)
+                return FAGER_TESTPRODUSENT
             }
         }
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/Common.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/Common.kt
@@ -2,10 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.produsent_api
 
 import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLRequest
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.NærmesteLederDefinisjon
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.Produsent
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.ProdusentRegister
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.ServicecodeDefinisjon
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.*
 import no.nav.arbeidsgiver.notifikasjon.util.PRODUSENT_HOST
 import no.nav.arbeidsgiver.notifikasjon.util.TOKENDINGS_TOKEN
 import no.nav.arbeidsgiver.notifikasjon.util.post
@@ -22,19 +19,22 @@ fun TestApplicationEngine.produsentApi(req: GraphQLRequest): TestApplicationResp
 }
 
 fun TestApplicationEngine.produsentApi(
-    @Language("GraphQL") req: String
+    @Language("GraphQL") req: String,
 ): TestApplicationResponse {
     return produsentApi(GraphQLRequest(req))
 }
 
-val stubProdusentRegister: ProdusentRegister = object: ProdusentRegister {
-    override fun finn(produsentid: String): Produsent {
+val stubProdusentRegister: ProdusentRegister = object : ProdusentRegister {
+    override fun finn(appName: String): Produsent {
         return Produsent(
-            accessPolicy = listOf("someproducer"),
-            tillatteMerkelapper = listOf("tag"),
-            tillatteMottakere = listOf(
-                ServicecodeDefinisjon(code = "5441", version = "1"),
-                NærmesteLederDefinisjon,
+            appName,
+            ProdusentDefinisjon(
+                accessPolicy = listOf("someproducer"),
+                tillatteMerkelapper = listOf("tag"),
+                tillatteMottakere = listOf(
+                    ServicecodeDefinisjon(code = "5441", version = "1"),
+                    NærmesteLederDefinisjon,
+                )
             )
         )
     }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/Common.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/Common.kt
@@ -27,14 +27,12 @@ fun TestApplicationEngine.produsentApi(
 val stubProdusentRegister: ProdusentRegister = object : ProdusentRegister {
     override fun finn(appName: String): Produsent {
         return Produsent(
-            appName,
-            ProdusentDefinisjon(
-                accessPolicy = listOf("someproducer"),
-                tillatteMerkelapper = listOf("tag"),
-                tillatteMottakere = listOf(
-                    ServicecodeDefinisjon(code = "5441", version = "1"),
-                    NærmesteLederDefinisjon,
-                )
+            id = "someproducer",
+            accessPolicy = listOf("someproducer"),
+            tillatteMerkelapper = listOf("tag"),
+            tillatteMottakere = listOf(
+                ServicecodeDefinisjon(code = "5441", version = "1"),
+                NærmesteLederDefinisjon,
             )
         )
     }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/HardDeleteNotifikasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/HardDeleteNotifikasjonTests.kt
@@ -37,7 +37,6 @@ class HardDeleteNotifikasjonTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = kafkaProducer,
-            produsentRegister = stubProdusentRegister,
             produsentRepository = produsentModel
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/IdempotensOppførselForProdusentApi.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/IdempotensOppførselForProdusentApi.kt
@@ -20,9 +20,8 @@ class IdempotensOppførselForProdusentApi : DescribeSpec({
 
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
-            produsentRepository = queryModel,
             kafkaProducer = mockk(relaxed = true),
-            produsentRegister = stubProdusentRegister
+            produsentRepository = queryModel
         )
     )
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/InputValideringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/InputValideringTests.kt
@@ -16,7 +16,6 @@ class InputValideringTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = mockk(),
-            produsentRegister = stubProdusentRegister,
             produsentRepository = mockk()
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/MineNotifikasjonerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/MineNotifikasjonerTests.kt
@@ -23,7 +23,6 @@ class MineNotifikasjonerTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = mockk(),
-            produsentRegister = stubProdusentRegister,
             produsentRepository = produsentModel
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyBeskjedTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyBeskjedTests.kt
@@ -31,7 +31,6 @@ class NyBeskjedTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = embeddedKafka.newProducer(),
-            produsentRegister = stubProdusentRegister,
             produsentRepository = produsentRepository,
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyOppgaveTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyOppgaveTests.kt
@@ -31,7 +31,6 @@ class NyOppgaveTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = embeddedKafka.newProducer(),
-            produsentRegister = stubProdusentRegister,
             produsentRepository = produsentRepository,
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/OppgaveUtførtTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/OppgaveUtførtTests.kt
@@ -34,7 +34,6 @@ class OppgaveUtførtTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = kafkaProducer,
-            produsentRegister = stubProdusentRegister,
             produsentRepository = produsentModel
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/SoftDeleteNotifikasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/SoftDeleteNotifikasjonTests.kt
@@ -37,7 +37,6 @@ class SoftDeleteNotifikasjonTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = kafkaProducer,
-            produsentRegister = stubProdusentRegister,
             produsentRepository = produsentModel
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/TilgangsstyringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/TilgangsstyringTests.kt
@@ -17,7 +17,6 @@ class TilgangsstyringTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = mockk(),
-            produsentRegister = stubProdusentRegister,
             produsentRepository = mockk()
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/KtorTestServer.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/KtorTestServer.kt
@@ -16,6 +16,8 @@ import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentAPI
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.TypedGraphQL
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.objectMapper
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.ProdusentRegister
+import no.nav.arbeidsgiver.notifikasjon.produsent_api.stubProdusentRegister
 import org.intellij.lang.annotations.Language
 
 fun Spec.ktorBrukerTestServer(
@@ -36,6 +38,7 @@ fun Spec.ktorBrukerTestServer(
 }
 
 fun Spec.ktorProdusentTestServer(
+    produsentRegister: ProdusentRegister = stubProdusentRegister,
     produsentGraphQL: TypedGraphQL<ProdusentAPI.Context> = mockk(),
     environment: ApplicationEngineEnvironmentBuilder.() -> Unit = {}
 ): TestApplicationEngine {
@@ -45,7 +48,7 @@ fun Spec.ktorProdusentTestServer(
     listener(KtorTestListener(engine) {
         httpServerSetup(
             authProviders = listOf(LOCALHOST_PRODUSENT_AUTHENTICATION),
-            extractContext = extractProdusentContext,
+            extractContext = extractProdusentContext(produsentRegister),
             graphql = CompletableDeferred(produsentGraphQL)
         )
     })
@@ -115,7 +118,7 @@ val LOCALHOST_PRODUSENT_AUTHENTICATION = JWTAuthentication(
 
         validate {
             ProdusentPrincipal(
-                produsentid = it.payload.getClaim("azp").asString()
+                appName = it.payload.getClaim("azp").asString()
             )
         }
     }


### PR DESCRIPTION
motivasjon for denne endringen er å kunne bruke produsentid lenger ned i appen.
Ved å skille på definisjon og identifisert produsent så vet vi at dersom vi har en Produsent, så er denne identifisert via oppslag i register.