### PR TITLE
propager x_correlation_id i http klient kall

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Enhetsregisteret.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Enhetsregisteret.kt
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.apache.*
+import io.ktor.client.features.*
 import io.ktor.client.features.json.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import org.slf4j.MDC
 import java.time.LocalDateTime
 import java.util.*
 
@@ -31,6 +33,11 @@ class EnhetsregisteretImpl(
     private val httpClient = HttpClient(Apache) {
         install(JsonFeature) {
             serializer = JacksonSerializer()
+        }
+        defaultRequest {
+            MDC.get("x_correlation_id")?.let {
+                header("x_correlation_id", it)
+            }
         }
         expectSuccess = false
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/NærmesteLederService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/NærmesteLederService.kt
@@ -7,10 +7,12 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.apache.*
+import io.ktor.client.features.*
 import io.ktor.client.features.json.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import org.slf4j.MDC
 
 interface NærmesteLederService {
     data class NærmesteLederFor(
@@ -43,6 +45,11 @@ class NærmesteLederServiceImpl(
     private val httpClient = HttpClient(Apache) {
         install(JsonFeature) {
             serializer = JacksonSerializer()
+        }
+        defaultRequest {
+            MDC.get("x_correlation_id")?.let {
+                header("x_correlation_id", it)
+            }
         }
     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/TokenExchangeClient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/TokenExchangeClient.kt
@@ -1,4 +1,4 @@
-package no.nav.arbeidsgiver.notifikasjon.infrastruktur;
+package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
@@ -8,11 +8,13 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.nimbusds.jose.jwk.RSAKey
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
+import io.ktor.client.features.*
 import io.ktor.client.features.json.*
 import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
+import org.slf4j.MDC
 import java.time.Instant
 import java.util.*
 
@@ -29,6 +31,11 @@ class TokenExchangeClientImpl(
     private val httpClient = HttpClient(Apache) {
         install(JsonFeature) {
             serializer = JacksonSerializer()
+        }
+        defaultRequest {
+            MDC.get("x_correlation_id")?.let {
+                header("x_correlation_id", it)
+            }
         }
     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpAuthProviders.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpAuthProviders.kt
@@ -7,6 +7,7 @@ import io.ktor.auth.*
 import io.ktor.auth.jwt.*
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
+import io.ktor.client.features.*
 import io.ktor.client.features.json.*
 import io.ktor.client.request.*
 import io.ktor.routing.*
@@ -14,6 +15,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.AzurePreAuthorizedAppsImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.UnavailableInProduction
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import org.slf4j.MDC
 import java.net.URL
 import java.util.concurrent.TimeUnit
 
@@ -34,9 +36,14 @@ object HttpAuthProviders {
     val log = logger()
 
     val httpClient = HttpClient(Apache) {
-       install(JsonFeature) {
-           serializer = JacksonSerializer()
-       }
+        install(JsonFeature) {
+            serializer = JacksonSerializer()
+        }
+        defaultRequest {
+            MDC.get("x_correlation_id")?.let {
+                header("x_correlation_id", it)
+            }
+        }
     }
 
     private val idportenIssuer = Regex(


### PR DESCRIPTION
Undersøkte en log.error i prod. 
Vi får en 400 feil mot tokendings, men jeg klarer ikke trace denne. 
Så derfor at vi ikke forwarder correlation id. 
Denne endringen tror jeg vil løse det hvis vi ønsker det