### PR TITLE
produsent-api: filtrering på merkelapp

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -178,6 +178,15 @@ class ParameterSetters(
 ) {
     private var index = 1
 
+
+    fun stringList(value: List<String>) {
+        val array = preparedStatement.connection.createArrayOf(
+            "text",
+            value.toTypedArray()
+        )
+        preparedStatement.setArray(index++, array)
+    }
+
     fun string(value: String) =
         preparedStatement.setString(index++, value)
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -14,7 +14,7 @@ interface ProdusentRepository {
     suspend fun hentNotifikasjon(eksternId: String, merkelapp: String): ProdusentModel.Notifikasjon?
     suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse)
     suspend fun finnNotifikasjoner(
-        merkelapp: String,
+        merkelapper: List<String>,
         grupperingsid: String?,
         antall: Int,
         offset: Int
@@ -111,19 +111,19 @@ class ProdusentRepositoryImpl(
     }
 
     override suspend fun finnNotifikasjoner(
-        merkelapp: String,
+        merkelapper: List<String>,
         grupperingsid: String?,
         antall: Int,
         offset: Int
     ): List<ProdusentModel.Notifikasjon> {
         return database.runNonTransactionalQuery(
             """ select * from notifikasjon 
-                  where merkelapp = ? 
+                  where merkelapp = any(?)
                   ${grupperingsid?.let { "and grupperingsid = ?" }?:""} 
                   limit $antall
                   offset $offset
             """.trimMargin(), {
-                string(merkelapp)
+                stringList(merkelapper)
                 grupperingsid?.let { string(grupperingsid) }
             },
             resultSetTilNotifikasjon

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -47,14 +47,24 @@ type Query {
     informasjon.
 
     Dere må gjenta paremetere når dere blar gjennom alle notifikasjonen.
+
+    Hvis verken `merkelapp` eller `merkelapper` er gitt, vil notifikasjoner
+    med alle dine merkelapper være med.
     """
     mineNotifikasjoner(
         "antall notifikasjoner du ønsker å hente"
         first: Int @Validate @MaxValue(upToIncluding: 10000)
+
         """Cursor til notifikasjonen du henter fra. Cursor får du fra [NotifikasjonEdge](#notifikasjonedge)."""
         after: String
-        merkelapp: String,
-        grupperingsid: String,
+
+        """Filtrer på merkelapp. Kan ikke brukes sammen med `merkelapper`."""
+        merkelapp: String
+
+        """Filtrer på merkelapper. Kan ikke brukes sammen med `merkelapp`."""
+        merkelapper: [String!]
+
+        grupperingsid: String
     ): MineNotifikasjonerResultat!
 }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/Common.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/Common.kt
@@ -29,7 +29,7 @@ val stubProdusentRegister: ProdusentRegister = object : ProdusentRegister {
         return Produsent(
             id = "someproducer",
             accessPolicy = listOf("someproducer"),
-            tillatteMerkelapper = listOf("tag"),
+            tillatteMerkelapper = listOf("tag", "tag2"),
             tillatteMottakere = listOf(
                 ServicecodeDefinisjon(code = "5441", version = "1"),
                 NærmesteLederDefinisjon,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/MineNotifikasjonerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/MineNotifikasjonerTests.kt
@@ -67,6 +67,36 @@ class MineNotifikasjonerTests : DescribeSpec({
                 grupperingsid = grupperingsid
             )
         )
+        val uuid3 = UUID.randomUUID()
+        produsentModel.oppdaterModellEtterHendelse(
+            Hendelse.BeskjedOpprettet(
+                virksomhetsnummer = "1",
+                merkelapp = merkelapp + "noe annet",
+                eksternId = "3",
+                mottaker = mottaker,
+                hendelseId = uuid3,
+                notifikasjonId = uuid3,
+                tekst = "test",
+                lenke = "https://nav.no",
+                opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z"),
+                grupperingsid = grupperingsid
+            )
+        )
+        val uuid4 = UUID.randomUUID()
+        produsentModel.oppdaterModellEtterHendelse(
+            Hendelse.BeskjedOpprettet(
+                virksomhetsnummer = "1",
+                merkelapp = merkelapp + "2",
+                eksternId = "3",
+                mottaker = mottaker,
+                hendelseId = uuid4,
+                notifikasjonId = uuid4,
+                tekst = "test",
+                lenke = "https://nav.no",
+                opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z"),
+                grupperingsid = grupperingsid
+            )
+        )
     }
 
     describe("mineNotifikasjoner") {
@@ -173,6 +203,7 @@ class MineNotifikasjonerTests : DescribeSpec({
                 response.getTypedContent<ProdusentAPI.NotifikasjonConnection>("mineNotifikasjoner")
             }
         }
+
         context("henter alle med angitt paginering") {
             val response = engine.produsentApi(
                 """
@@ -259,6 +290,95 @@ class MineNotifikasjonerTests : DescribeSpec({
                 val connection = response.getTypedContent<ProdusentAPI.NotifikasjonConnection>("mineNotifikasjoner")
                 connection.edges.size shouldBe 1
                 connection.pageInfo.hasNextPage shouldBe true
+            }
+        }
+
+        context("når merkelapper=[] i filter") {
+            val response = engine.produsentApi(
+                """
+                    query {
+                        mineNotifikasjoner(merkelapper: []) {
+                            ... on NotifikasjonConnection {
+                                edges {
+                                    cursor
+                                }
+                            }
+                        }
+                    }
+                """.trimIndent()
+            )
+
+            it("respons inneholder forventet data") {
+                val edges = response.getTypedContent<List<JsonNode>>("mineNotifikasjoner/edges")
+                edges.size shouldBe 0
+            }
+        }
+
+        context("når merkelapp(er) ikke er angitt i filter") {
+            val response = engine.produsentApi(
+                """
+                    query {
+                        mineNotifikasjoner {
+                            ... on NotifikasjonConnection {
+                                edges {
+                                    cursor
+                                }
+                            }
+                        }
+                    }
+                """.trimIndent()
+            )
+
+            it("respons inneholder forventet data") {
+                val edges = response.getTypedContent<List<JsonNode>>("mineNotifikasjoner/edges")
+                edges.size shouldBe 3
+            }
+        }
+
+        context("når merkelapper er angitt i filter") {
+            val response = engine.produsentApi(
+                """
+                    query {
+                        mineNotifikasjoner(
+                            merkelapper: ["tag"]
+                        ) {
+                            ... on NotifikasjonConnection {
+                                edges {
+                                    cursor
+                                }
+                            }
+                        }
+                    }
+                """.trimIndent()
+            )
+
+            it("respons inneholder forventet data") {
+                val edges = response.getTypedContent<List<JsonNode>>("mineNotifikasjoner/edges")
+                edges.size shouldBe 2
+            }
+        }
+
+        context("når forskjellige merkelapper er angitt i filter") {
+            val response = engine.produsentApi(
+                """
+                    query {
+                        mineNotifikasjoner(
+                            merkelapper: ["tag" "tag2"]
+                        ) {
+                            __typename
+                            ... on NotifikasjonConnection {
+                                edges {
+                                    cursor
+                                }
+                            }
+                        }
+                    }
+                """.trimIndent()
+            )
+
+            it("respons inneholder forventet data") {
+                val edges = response.getTypedContent<List<JsonNode>>("mineNotifikasjoner/edges")
+                edges.size shouldBe 3
             }
         }
 


### PR DESCRIPTION
Legg til støtte for å ikke speisifisere merkelapp (bruker da alle tilgjengelig for produsenten).

Legg til støtte for å oppgi en liste med merkelapper.