### PR TITLE
lagt til støtte for å propagere mdc som flere navngitte headere

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/NærmesteLederService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/NærmesteLederService.kt
@@ -43,6 +43,7 @@ class NærmesteLederServiceImpl(
         }
         install(PropagateFromMDCFeature) {
             propagate("x_correlation_id")
+            propagate("x_correlation_id" asHeader "Nav-Callid")
         }
     }
 


### PR DESCRIPTION
Dette er nyttig f.eks mot digisyfo nærmesteleder der de plukker ut Nav-Callid