### PR TITLE
bruk navn fra jdbc for database-operasjoner

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
@@ -123,7 +123,7 @@ class BrukerModelImpl(
 
         val ansatteLookupTable = ansatte.toSet()
 
-        val notifikasjoner = database.standaloneExecuteQuery(
+        val notifikasjoner = database.nonTransactionalExecuteQuery(
             """
             select 
                 n.*, 
@@ -190,7 +190,7 @@ class BrukerModelImpl(
     }
 
     override suspend fun virksomhetsnummerForNotifikasjon(notifikasjonsid: UUID): String? =
-        database.standaloneExecuteQuery(
+        database.nonTransactionalExecuteQuery(
             """
                 SELECT virksomhetsnummer FROM notifikasjonsid_virksomhet_map WHERE notifikasjonsid = ? LIMIT 1
             """, {
@@ -232,7 +232,7 @@ class BrukerModelImpl(
     }
 
     private suspend fun oppdaterModellEtterOppgaveUtført(utførtHendelse: Hendelse.OppgaveUtført) {
-        database.standaloneExecuteUpdate(
+        database.nonTransactionalExecuteUpdate(
             """
             UPDATE notifikasjon
             SET tilstand = '${ProdusentModel.Oppgave.Tilstand.UTFOERT}'
@@ -244,7 +244,7 @@ class BrukerModelImpl(
     }
 
     private suspend fun oppdaterModellEtterBrukerKlikket(brukerKlikket: Hendelse.BrukerKlikket) {
-        database.standaloneExecuteUpdate(
+        database.nonTransactionalExecuteUpdate(
             """
             INSERT INTO brukerklikk(fnr, notifikasjonsid) VALUES (?, ?)
             ON CONFLICT ON CONSTRAINT brukerklikk_pkey

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NærmesteLederModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NærmesteLederModel.kt
@@ -42,7 +42,7 @@ class NærmesteLederModelImpl(
 ) : NærmesteLederModel {
 
     override suspend fun hentAnsatte(narmesteLederFnr: String): List<NærmesteLederModel.NærmesteLederFor> {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """
             select * from naermeste_leder_kobling 
                 where naermeste_leder_fnr = ?
@@ -59,7 +59,7 @@ class NærmesteLederModelImpl(
 
     override suspend fun oppdaterModell(nærmesteLederLeesah: NarmesteLederLeesah) {
         if (nærmesteLederLeesah.aktivTom != null) {
-            database.standaloneExecuteUpdate(
+            database.nonTransactionalExecuteUpdate(
                 """
                 delete from naermeste_leder_kobling where id = ?
             """
@@ -67,7 +67,7 @@ class NærmesteLederModelImpl(
                 uuid(nærmesteLederLeesah.narmesteLederId)
             }
         } else {
-            database.standaloneExecuteUpdate(
+            database.nonTransactionalExecuteUpdate(
                 """
                 INSERT INTO naermeste_leder_kobling(id, fnr, naermeste_leder_fnr, orgnummer)
                 VALUES(?, ?, ?, ?) 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -96,7 +96,7 @@ class Database private constructor(
         }
     }
 
-    suspend fun <T> standaloneExecuteQuery(
+    suspend fun <T> nonTransactionalExecuteQuery(
         @Language("PostgreSQL") sql: String,
         setup: ParameterSetters.() -> Unit = {},
         transform: ResultSet.() -> T
@@ -105,14 +105,14 @@ class Database private constructor(
             Transaction(this).executeQuery(sql, setup, transform)
         }
 
-    suspend fun standaloneExecuteUpdate(
+    suspend fun nonTransactionalExecuteUpdate(
         @Language("PostgreSQL") sql: String,
         setup: ParameterSetters.() -> Unit = {},
     ): Int = dataSource.withConnection {
         Transaction(this).executeUpdate(sql, setup)
     }
 
-    suspend fun <T> standaloneExecuteBatch(
+    suspend fun <T> nonTransactionalExecuteBatch(
         @Language("PostgreSQL") sql: String,
         iterable: Iterable<T>,
         setup: ParameterSetters.(it: T) -> Unit = {},

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModel.kt
@@ -53,7 +53,7 @@ class KafkaReaperModelImpl(
     }
 
     override suspend fun alleRelaterteHendelser(notifikasjonId: UUID): List<UUID> {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """
                 SELECT hendelse_id FROM notifikasjon_hendelse_relasjon
                 WHERE notifikasjon_id = ?
@@ -67,7 +67,7 @@ class KafkaReaperModelImpl(
     }
 
     override suspend fun erSlettet(notifikasjonId: UUID): Boolean {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """
                 SELECT *
                 FROM deleted_notifikasjon
@@ -82,7 +82,7 @@ class KafkaReaperModelImpl(
     }
 
     override suspend fun fjernRelasjon(hendelseId: UUID) {
-        database.standaloneExecuteUpdate(
+        database.nonTransactionalExecuteUpdate(
             """
                 DELETE FROM notifikasjon_hendelse_relasjon
                 WHERE hendelse_id = ?

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -27,7 +27,7 @@ class ProdusentRepositoryImpl(
     val log = logger()
 
     override suspend fun hentNotifikasjon(id: UUID): ProdusentModel.Notifikasjon? {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """ select * from notifikasjon where id = ? """, {
                 uuid(id)
             }, resultSetTilNotifikasjon
@@ -35,7 +35,7 @@ class ProdusentRepositoryImpl(
     }
 
     override suspend fun hentNotifikasjon(eksternId: String, merkelapp: String): ProdusentModel.Notifikasjon? {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """ select * from notifikasjon where ekstern_id = ? and merkelapp = ? """, {
                 string(eksternId)
                 string(merkelapp)
@@ -89,7 +89,7 @@ class ProdusentRepositoryImpl(
     }
 
     private suspend fun oppdaterModellEtterHardDelete(hardDelete: Hendelse.HardDelete) {
-        database.standaloneExecuteUpdate(
+        database.nonTransactionalExecuteUpdate(
             """
             DELETE FROM notifikasjon 
             WHERE id = ?
@@ -100,7 +100,7 @@ class ProdusentRepositoryImpl(
     }
 
     private suspend fun oppdaterModellEtterSoftDelete(softDelete: Hendelse.SoftDelete) {
-        database.standaloneExecuteUpdate(
+        database.nonTransactionalExecuteUpdate(
             """
             UPDATE notifikasjon
             SET deleted_at = ? 
@@ -118,7 +118,7 @@ class ProdusentRepositoryImpl(
         antall: Int,
         offset: Int
     ): List<ProdusentModel.Notifikasjon> {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """ select * from notifikasjon 
                   where merkelapp = any(?)
                   ${grupperingsid?.let { "and grupperingsid = ?" }?:""} 
@@ -133,7 +133,7 @@ class ProdusentRepositoryImpl(
     }
 
     private suspend fun oppdatertModellEtterOppgaveUtført(utførtHendelse: Hendelse.OppgaveUtført) {
-        database.standaloneExecuteUpdate(
+        database.nonTransactionalExecuteUpdate(
             """
             UPDATE notifikasjon
             SET tilstand = '${ProdusentModel.Oppgave.Tilstand.UTFOERT}'
@@ -146,7 +146,7 @@ class ProdusentRepositoryImpl(
 
 
     private suspend fun oppdaterModellEtterBeskjedOpprettet(beskjedOpprettet: Hendelse.BeskjedOpprettet) {
-        database.standaloneExecuteUpdate(
+        database.nonTransactionalExecuteUpdate(
             """
             insert into notifikasjon(
                 type,
@@ -177,7 +177,7 @@ class ProdusentRepositoryImpl(
     }
 
     private suspend fun oppdaterModellEtterOppgaveOpprettet(oppgaveOpprettet: Hendelse.OppgaveOpprettet) {
-        database.standaloneExecuteUpdate(
+        database.nonTransactionalExecuteUpdate(
             """
             insert into notifikasjon(
                 type,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/statistikk/StatistikkModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/statistikk/StatistikkModel.kt
@@ -14,7 +14,7 @@ class StatistikkModel(
     val database: Database,
 ) {
     suspend fun antallUtførteHistogram(): List<MultiGauge.Row<Number>> {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """
                 WITH alder_tabell AS (
                     select
@@ -76,7 +76,7 @@ class StatistikkModel(
     }
 
     suspend fun antallKlikk(): List<MultiGauge.Row<Number>> {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """
                 select 
                     notifikasjon.produsent_id,
@@ -103,7 +103,7 @@ class StatistikkModel(
     }
 
     suspend fun antallUnikeTekster(): List<MultiGauge.Row<Number>> {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """
                 select 
                     produsent_id,
@@ -129,7 +129,7 @@ class StatistikkModel(
     }
 
     suspend fun antallNotifikasjoner(): List<MultiGauge.Row<Number>> {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """
                 select produsent_id, merkelapp, mottaker, notifikasjon_type, count(*) as antall
                 from notifikasjon
@@ -150,7 +150,7 @@ class StatistikkModel(
     }
 
     suspend fun antallVarsler(): List<MultiGauge.Row<Number>> {
-        return database.standaloneExecuteQuery(
+        return database.nonTransactionalExecuteQuery(
             """
                 select notifikasjon.produsent_id, merkelapp, varsel_type, coalesce(status, 'bestilt') as status, count(*) as antall
                 from varsel_bestilling as bestilling
@@ -176,7 +176,7 @@ class StatistikkModel(
     suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse, metadata: HendelseMetadata) {
         when (hendelse) {
             is Hendelse.BeskjedOpprettet -> {
-                database.standaloneExecuteUpdate(
+                database.nonTransactionalExecuteUpdate(
                     """
                     insert into notifikasjon 
                         (produsent_id, notifikasjon_id, notifikasjon_type, merkelapp, mottaker, checksum, opprettet_tidspunkt)
@@ -195,7 +195,7 @@ class StatistikkModel(
                 oppdaterVarselBestilling(hendelse, hendelse.produsentId, hendelse.eksterneVarsler)
             }
             is Hendelse.OppgaveOpprettet -> {
-                database.standaloneExecuteUpdate(
+                database.nonTransactionalExecuteUpdate(
                     """
                     insert into notifikasjon(
                         produsent_id, 
@@ -222,7 +222,7 @@ class StatistikkModel(
                 oppdaterVarselBestilling(hendelse, hendelse.produsentId, hendelse.eksterneVarsler)
             }
             is Hendelse.OppgaveUtført -> {
-                database.standaloneExecuteUpdate(
+                database.nonTransactionalExecuteUpdate(
                     """
                     update notifikasjon 
                         set utfoert_tidspunkt = ?
@@ -234,7 +234,7 @@ class StatistikkModel(
                 }
             }
             is Hendelse.BrukerKlikket -> {
-                database.standaloneExecuteUpdate(
+                database.nonTransactionalExecuteUpdate(
                     """
                     insert into notifikasjon_klikk 
                         (hendelse_id, notifikasjon_id, klikket_paa_tidspunkt)
@@ -248,7 +248,7 @@ class StatistikkModel(
                 }
             }
             is Hendelse.EksterntVarselVellykket -> {
-                database.standaloneExecuteUpdate(
+                database.nonTransactionalExecuteUpdate(
                     """
                     insert into varsel_resultat 
                         (hendelse_id, varsel_id, notifikasjon_id, produsent_id, status)
@@ -264,7 +264,7 @@ class StatistikkModel(
                 }
             }
             is Hendelse.EksterntVarselFeilet -> {
-                database.standaloneExecuteUpdate(
+                database.nonTransactionalExecuteUpdate(
                     """
                     insert into varsel_resultat 
                         (hendelse_id, varsel_id, notifikasjon_id, produsent_id, status)
@@ -280,7 +280,7 @@ class StatistikkModel(
                 }
             }
             is Hendelse.SoftDelete -> {
-                database.standaloneExecuteUpdate(
+                database.nonTransactionalExecuteUpdate(
                     """
                     update notifikasjon 
                         set soft_deleted_tidspunkt = ?
@@ -302,7 +302,7 @@ class StatistikkModel(
         produsentId: String,
         iterable: List<EksterntVarsel>,
     ) {
-        database.standaloneExecuteBatch(
+        database.nonTransactionalExecuteBatch(
             """
                         insert into varsel_bestilling 
                             (varsel_id, varsel_type, notifikasjon_id, produsent_id, mottaker)


### PR DESCRIPTION
To endringer:

1. standariser på  `nonTransactional`-prefixet
2. bruker samme navn som jdbc (`executeUpdate`, `executeQuery` og `executeBatch`).