### PR TITLE
Respond with string in /internal/{alive/ready}

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
@@ -195,7 +195,10 @@ fun Route.internalRoutes() {
             if (Health.alive) {
                 call.respond(HttpStatusCode.OK)
             } else {
-                call.respond(HttpStatusCode.ServiceUnavailable, Health.subsystemAlive)
+                call.respond(
+                    HttpStatusCode.ServiceUnavailable,
+                    Health.subsystemAlive.toString()
+                )
             }
         }
 
@@ -203,7 +206,10 @@ fun Route.internalRoutes() {
             if (Health.ready) {
                 call.respond(HttpStatusCode.OK)
             } else {
-                call.respond(HttpStatusCode.ServiceUnavailable, Health.subsystemReady)
+                call.respond(
+                    HttpStatusCode.ServiceUnavailable,
+                    Health.subsystemReady.toString()
+                )
             }
         }
 


### PR DESCRIPTION
ktor doesn't know how to serialize ConcurrentHashMap as response
body. The toString-method is reasonable.

Fixes error logs with stack-trace
```
java.lang.IllegalArgumentException: Response pipeline couldn't transform 'class java.util.concurrent.ConcurrentHashMap' to the OutgoingContent
	at io.ktor.server.engine.BaseApplicationResponse$Companion$setupSendPipeline$1.invokeSuspend(BaseApplicationResponse.kt:311)
	at io.ktor.server.engine.BaseApplicationResponse$Companion$setupSendPipeline$1.invoke(BaseApplicationResponse.kt)
	at io.ktor.server.engine.BaseApplicationResponse$Companion$setupSendPipeline$1.invoke(BaseApplicationResponse.kt)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:248)
	at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:116)
	at io.ktor.metrics.micrometer.MicrometerMetrics$Feature$install$3.invokeSuspend(MicrometerMetrics.kt:255)
	at io.ktor.metrics.micrometer.MicrometerMetrics$Feature$install$3.invoke(MicrometerMetrics.kt)
	at io.ktor.metrics.micrometer.MicrometerMetrics$Feature$install$3.invoke(MicrometerMetrics.kt)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:248)
	at io.ktor.util.pipeline.SuspendFunctionGun.proceed(SuspendFunctionGun.kt:116)
	at io.ktor.util.pipeline.SuspendFunctionGun.execute(SuspendFunctionGun.kt:136)
	at io.ktor.util.pipeline.Pipeline.execute(Pipeline.kt:79)
	at no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.HttpServerKt$internalRoutes$1$2.invokeSuspend(HttpServer.kt:278)
	at no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.HttpServerKt$internalRoutes$1$2.invoke(HttpServer.kt)
	at no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.HttpServerKt$internalRoutes$1$2.invoke(HttpServer.kt)
	at io.ktor.util.pipeline.SuspendFunctionGun.loop(SuspendFunctionGun.kt:248)
```