### PR TITLE
Expose metric for emergency break

### DIFF
--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/ekstern_varsling/LocalMainEksternVarsling.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/ekstern_varsling/LocalMainEksternVarsling.kt
@@ -1,24 +1,12 @@
 package no.nav.arbeidsgiver.notifikasjon.executable.ekstern_varsling
 
-import com.fasterxml.jackson.databind.node.NullNode
 import db.migration.OS
 import no.nav.arbeidsgiver.notifikasjon.EksternVarsling
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.AltinnVarselKlient
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.EksternVarsel
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
-
 
 fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
     OS.setupLocal()
     EksternVarsling.main(
         httpPort = 8085,
-        altinnVarselKlient = object: AltinnVarselKlient {
-            val log = logger()
-            override suspend fun send(eksternVarsel: EksternVarsel): Result<AltinnVarselKlient.AltinnResponse> {
-                log.info("stub altinn varsel klient, send: $eksternVarsel")
-                return Result.success(AltinnVarselKlient.AltinnResponse.Ok(NullNode.instance))
-            }
-        }
     )
 }
 


### PR DESCRIPTION
1) Exposer emergency_break som metric.

2) Utenfor prod, så er default for AltinnVarselKlient en som bare logger, så ingen vits i å duplisere det.