### PR TITLE
du vil ikke tro hva som skjedde når TestApplicationResponse.getTypedContent ble kalt med $

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -228,6 +228,12 @@
             <version>2.7.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.6.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerKlikkGraphQL_QueryModell_IntegrasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerKlikkGraphQL_QueryModell_IntegrasjonTests.kt
@@ -76,7 +76,7 @@ class BrukerKlikkGraphQL_QueryModell_IntegrasjonTests: DescribeSpec({
             """
         )
 
-        val klikkMarkørFørKlikk = response.getTypedContent<Boolean>("/notifikasjoner/notifikasjoner/0/brukerKlikk/klikketPaa")
+        val klikkMarkørFørKlikk = response.getTypedContent<Boolean>("$.notifikasjoner.notifikasjoner[0].brukerKlikk.klikketPaa")
 
         it("notifikasjon er ikke klikket på") {
             klikkMarkørFørKlikk shouldBe false
@@ -110,7 +110,7 @@ class BrukerKlikkGraphQL_QueryModell_IntegrasjonTests: DescribeSpec({
             }
             """
         )
-        val klikkMarkørEtterKlikk = responseEtterKlikk.getTypedContent<Boolean>("/notifikasjoner/notifikasjoner/0/brukerKlikk/klikketPaa")
+        val klikkMarkørEtterKlikk = responseEtterKlikk.getTypedContent<Boolean>("$.notifikasjoner.notifikasjoner[0].brukerKlikk.klikketPaa")
 
         it("notifikasjon er klikket på") {
             klikkMarkørEtterKlikk shouldBe true


### PR DESCRIPTION
getTypedContent støtter nå både jsonpath og jsonpointer. 
Alle json paths starter med `$`. Jsonpath har også en del flere features som jeg av og til har savnet i testene.
Som f.eks å plukke ut attributter fra elementer i en liste. (e.g. `$.store.book[*].author`)
readme til jsonpath lib har en del eksempler https://github.com/json-path/JsonPath#path-examples