### PR TITLE
enable cors for `*.nav.no` :shipit:

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.11.2</version>
+            <version>2.13.0</version>
         </dependency>
 
         <!-- ktor client -->

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <kotlin.version>1.5.10</kotlin.version>
-        <ktor.version>1.6.0</ktor.version>
+        <ktor.version>1.6.6</ktor.version>
         <kotest.version>4.6.0</kotest.version>
         <!-- <kotlin.compiler.incremental>true</kotlin.compiler.incremental> -->
         <jvm.version>15</jvm.version>

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
@@ -85,7 +85,7 @@ fun <T : WithCoroutineScope> Application.httpServerSetup(
         allowNonSimpleContentTypes = true
         when (System.getenv("NAIS_CLUSTER_NAME")) {
             "prod-gcp" -> {
-                host("arbeidsgiver.nav.no", schemes = listOf("https"))
+                host("*.nav.no", schemes = listOf("https"))
             }
             "dev-gcp" -> {
                 host("*.dev.nav.no", schemes = listOf("https"))

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
@@ -88,8 +88,7 @@ fun <T : WithCoroutineScope> Application.httpServerSetup(
                 host("arbeidsgiver.nav.no", schemes = listOf("https"))
             }
             "dev-gcp" -> {
-                host("min-side-arbeidsgiver.dev.nav.no", schemes = listOf("https"))
-                host("arbeidsforhold.dev.nav.no", schemes = listOf("https"))
+                host("*.dev.nav.no", schemes = listOf("https"))
                 host("localhost:3000")
             }
         }


### PR DESCRIPTION
![Kapture 2021-11-30 at 20 31 08](https://user-images.githubusercontent.com/189395/144115038-adb321da-21ba-442f-a648-4c5278b5ca7a.gif)

Dette er en liten PoC på å enable out-of-the-box støtte for arbeidsgiver-notifikasjon-widget
Vi vurderte å legge til støtte for jwt vha cookie i backend, men fant ut at det kanskje var bedre å legge den slags funksjonalitet utenfor, så vi laget en egen [frackend/proxy for widgeten](https://github.com/navikt/arbeidsgiver-notifikasjon-widget/pull/12/files#diff-351a953837d40f520006509ae4a28f9cd4a93511dbb403e71462cffdc13a7a1b). Denne overfører selvbetjenings cookie som en Authorization Bearer header før den videresender til backend uten å endre origin. Dette kombinert med cors whitelist i backend gjør det mulig for sider på *.dev.nav.no å hente notifikasjoner uten noe spesielt oppsett annet enn å droppe inn widget på frontenden sin.

må ses i sammenheng med:
* https://github.com/navikt/arbeidsgiver-notifikasjon-widget/pull/12
* https://github.com/navikt/arbeidsgiver-innsyn-aareg/pull/435
* https://github.com/navikt/min-side-arbeidsgiver/pull/933