### PR TITLE
fjern kafka cli fra docker image

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,16 +2,4 @@ FROM navikt/java:15
 COPY target/produsent-api/app.jar app.jar
 COPY target/produsent-api/lib lib
 
-USER root
-RUN apt-get install -y curl
-
-RUN mkdir -p /opt/kafka
-RUN cd /opt/kafka && wget -O kafka.tgz https://archive.apache.org/dist/kafka/2.7.1/kafka_2.13-2.7.1.tgz
-RUN cd /opt/kafka && tar --strip-components=1 -xzf kafka.tgz
-RUN chmod +x /opt/kafka/bin/*
-ENV PATH="/opt/kafka/bin:${PATH}"
-
-COPY 99-create-kafka-properties.sh /init-scripts/
-RUN chmod +x /init-scripts/99-create-kafka-properties.sh
-
 USER apprunner


### PR DESCRIPTION
hovedmotivasjonen for å fjerne er pga log4j sårbarhet, selv om dette ikke er en reell angrepsvektor i dette tilfellet.
vi får egenglig ikke brukt kafka-cli til å resette offsets via migrering, og siden vi likevel må gjøre dette manuellt er det bedre å ta i bruk aiven cli til den slags https://doc.nais.io/cli/commands/aiven/
fjerner kafka-cli clik at ikke våre images blir flagget som sårbare på nais.