### PR TITLE
reduser log.warn ved kall til altinn

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -95,7 +95,8 @@ object AltinnImpl : Altinn {
         }
 
         return reporteeList
-            .filter { it.type == "Business" }
+            .filter { it.type != "Enterprise" }
+            .filterNot { it.type == "Person" && it.organizationNumber == null }
             .filter {
                 if (it.organizationNumber == null) {
                     log.warn("filtrerer ut reportee uten organizationNumber: organizationForm=${it.organizationForm} type=${it.type} status=${it.status}")

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -95,7 +95,7 @@ object AltinnImpl : Altinn {
         }
 
         return reporteeList
-            .filter { it.type != "Enterprise" }
+            .filter { it.type == "Business" }
             .filter {
                 if (it.organizationNumber == null) {
                     log.warn("filtrerer ut reportee uten organizationNumber: organizationForm=${it.organizationForm} type=${it.type} status=${it.status}")


### PR DESCRIPTION
slik det er nå så kommer det ganske mange warnings på at respons fra altinn ikke inneholder orgnr.
Dette skjer når altinn returnerer personer.
Det er et flag i klienten `filtrerPåAktiveOrganisasjoner` som kan settes til true, men denne vil da også kun returnere aktive organisasjoner. Vi kan vurdere å sette flagget til true.
Den enkle fiksen er å filtrere ut Personer slik vi gjør med Enterprise.
Dette betyr i praksis at man filtrerer på type==Business.


_Edit: Enn så lenge så filtrerer jeg ut personer uten orgnummer i tilfelle det finnes personer med orgnummer_