### PR TITLE
returner tom liste ved 403

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Altinn.kt
@@ -83,10 +83,10 @@ object AltinnImpl : Altinn {
                 false
             )
         } catch (error: AltinnException) {
-            if (error.proxyError.httpStatus == 400)
-                return emptyList()
-            else
-                throw error
+            when (error.proxyError.httpStatus) {
+                400, 403 -> return emptyList()
+                else -> throw error
+            }
         } catch (error: Exception) {
             if (error.message?.contains("403") == true)
                 return emptyList()


### PR DESCRIPTION
denne logikken blir nok borte så snart vi får fikset grensesnittet i proxyen. Men i mellomtiden vil dette redusere støy i loggene