### PR TITLE
write both versions to database

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -9,7 +9,10 @@ import kotlinx.coroutines.withContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.unblocking.NonBlockingDataSource
 import org.flywaydb.core.Flyway
 import org.intellij.lang.annotations.Language
-import java.sql.*
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.sql.ResultSet
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime

--- a/app/src/main/resources/db/migration/bruker_model/V5__flere_mottakere.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V5__flere_mottakere.sql
@@ -1,0 +1,31 @@
+
+create table mottaker_altinn_enkeltrettighet
+    (
+        id bigserial primary key,
+        notifikasjon_id uuid not null references notifikasjon(id) on delete cascade,
+        virksomhet text not null,
+        service_code text not null,
+        service_edition text not null
+    );
+
+create index mottaker_altinn_enkeltrettighet_idx on
+    mottaker_altinn_enkeltrettighet(virksomhet, service_code, service_edition);
+
+create table mottaker_digisyfo
+    (
+        id bigserial primary key,
+        notifikasjon_id uuid not null references notifikasjon(id) on delete cascade,
+        virksomhet text not null,
+        fnr_leder text not null,
+        fnr_sykmeldt text not null
+    );
+
+create index mottaker_digisyfo_idx on mottaker_digisyfo(fnr_leder);
+
+create view notifikasjoner_for_digisyfo_fnr as
+    select m.fnr_leder as fnr_leder, m.notifikasjon_id as notifikasjon_id
+    from mottaker_digisyfo m
+    join naermeste_leder_kobling k on
+        m.fnr_leder = k.naermeste_leder_fnr
+        and m.fnr_sykmeldt = k.fnr
+        and m.virksomhet = k.orgnummer;


### PR DESCRIPTION
Implementerer ny databasemodell for mottakere i bruker-api-modellen.

Lesing fra databasen uendret.
Skriver parallellt til både gamle og nye modell.