### PR TITLE
disable colors in log messages

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
@@ -111,6 +111,7 @@ fun <T : WithCoroutineScope> Application.httpServerSetup(
     }
 
     install(CallLogging) {
+        disableDefaultColors()
         level = Level.INFO
 
         filter { call ->


### PR DESCRIPTION
I forbindelse med oppgradering av ktor, så har CallLogging begynt å legge på fine farger. Det fungerer dessverre kun i terminaler, ikke i kibana. I Kibana ser et sånn ut:  `[32m200 OK [m:  [36mPOST [m - /api/graphql`