### PR TITLE
lagre virksomhetsnummer i notifikasjon-tabell

### DIFF
--- a/app/src/main/resources/db/migration/bruker_model/V6__vnr_notifikasjon_tabell.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V6__vnr_notifikasjon_tabell.sql
@@ -1,0 +1,1 @@
+alter table notifikasjon add column virksomhetsnummer text;


### PR DESCRIPTION
Bruker-api-model: Denne PRen lagrer virksomhetnsummer i notifikasjon-tabellen.
Når migrasjonen er ferdig, så ka:
- koden oppdateres til å lese virksomhetsnummer der i fra
- gjøre kolonnen not-null