### PR TITLE
drop mottaker-kolonne. virksomhetsnummer not null

### DIFF
--- a/app/src/main/resources/db/migration/produsent_model/V7__drop_mottaker_column_strengthen_constraints.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V7__drop_mottaker_column_strengthen_constraints.sql
@@ -1,0 +1,2 @@
+alter table notifikasjon drop column mottaker;
+alter table notifikasjon alter column virksomhetsnummer set not null;


### PR DESCRIPTION
skal ikke deployes før forrige deploy er helt ute.

Kommer til å kjøres i dev før den kjøres i prod, men venter med å gjøre det til approved, siden det ikke er mulig å rulle tilbake.