### PR TITLE
støtte for flere mottakere i graphql

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Hendelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Hendelse.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon
 
 import com.fasterxml.jackson.annotation.*
 import com.fasterxml.jackson.databind.JsonNode
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.requireGraphql
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -41,7 +42,7 @@ sealed class Hendelse {
         val eksterneVarsler: List<EksterntVarsel>,
     ) : Hendelse() {
         init {
-            require(mottakere.isNotEmpty()) {
+            requireGraphql(mottakere.isNotEmpty()) {
                 "minst 1 mottaker må gis"
             }
         }
@@ -104,7 +105,7 @@ sealed class Hendelse {
         val eksterneVarsler: List<EksterntVarsel>,
     ) : Hendelse() {
         init {
-            require(mottakere.isNotEmpty()) {
+            requireGraphql(mottakere.isNotEmpty()) {
                 "minst 1 mottaker må gis"
             }
         }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -79,6 +79,15 @@ data class GraphQLRequest(
     val variables: Map<String, String>? = null,
 )
 
+inline fun requireGraphql(check: Boolean, message: () -> String) {
+    if (!check) {
+        throw GraphqlErrorException
+            .newErrorException()
+            .message(message())
+            .build()
+    }
+}
+
 class TypedGraphQL<T : WithCoroutineScope>(
     private val graphQL: GraphQL
 ) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -2,14 +2,23 @@ package no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql
 
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.module.kotlin.convertValue
-import graphql.*
+import graphql.ErrorClassification
+import graphql.ErrorType
+import graphql.ExecutionInput
+import graphql.GraphQL
 import graphql.GraphQL.newGraphQL
-import graphql.schema.*
-import graphql.schema.idl.*
+import graphql.GraphQLError
+import graphql.GraphqlErrorException
+import graphql.execution.DataFetcherResult
+import graphql.language.SourceLocation
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.RuntimeWiring.newRuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TypeRuntimeWiring
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.objectMapper
@@ -30,13 +39,49 @@ interface WithCoroutineScope {
     val coroutineScope: CoroutineScope
 }
 
-fun <T> TypeRuntimeWiring.Builder.coDataFetcher(fieldName: String, fetcher: suspend (DataFetchingEnvironment) -> T) {
+class UnhandledGraphQLExceptionError(
+    private val exception: Exception
+): GraphQLError {
+    override fun getErrorType(): ErrorClassification {
+        return ErrorType.DataFetchingException
+    }
+
+    override fun getLocations(): MutableList<SourceLocation> {
+        return mutableListOf()
+    }
+
+    override fun getMessage(): String {
+        return "unhandled exception ${exception.javaClass.canonicalName}: ${exception.message ?: ""}"
+    }
+}
+
+fun <T> TypeRuntimeWiring.Builder.coDataFetcher(
+    fieldName: String,
+    fetcher: suspend (DataFetchingEnvironment) -> T,
+) {
     dataFetcher(fieldName) { env ->
         val ctx = env.getContext<WithCoroutineScope>()
-        ctx.coroutineScope.future(Dispatchers.Default) {
-            fetcher(env)
+        ctx.coroutineScope.future(Dispatchers.IO) {
+            try {
+                fetcher(env)
+            } catch (e: GraphqlErrorException) {
+                handleUnexepctedError(e, e)
+            } catch (e: Exception) {
+                handleUnexepctedError(e, UnhandledGraphQLExceptionError(e))
+            }
         }
     }
+}
+
+fun handleUnexepctedError(exception: Exception, error: GraphQLError): DataFetcherResult<*> {
+    GraphQLLogger.log.error(
+        "unhandled exception while executing coDataFetcher: {}",
+        exception.javaClass.canonicalName,
+        exception
+    )
+    return DataFetcherResult.newResult<Nothing?>()
+        .error(error)
+        .build()
 }
 
 object GraphQLLogger {
@@ -94,11 +139,6 @@ class TypedGraphQL<T : WithCoroutineScope>(
     fun execute(request: GraphQLRequest, context: T): Any {
         val executionInput = executionInput(request, context)
         return graphQL.execute(executionInput).toSpecification()
-    }
-
-    suspend fun executeAsync(request: GraphQLRequest, context: T): Any {
-        val executionInput = executionInput(request, context)
-        return graphQL.executeAsync(executionInput).await().toSpecification()
     }
 
     private fun executionInput(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/QueryMineNotifikasjoner.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/QueryMineNotifikasjoner.kt
@@ -284,3 +284,17 @@ val QueryMineNotifikasjoner.Notifikasjon.metadata: QueryMineNotifikasjoner.Metad
 
 val QueryMineNotifikasjoner.Notifikasjon.id: UUID
     get() = this.metadata.id
+
+fun finnVirksomhetsnummer(
+    virksomhetsnummer: String?,
+    mottakere: List<MottakerInput>
+): String {
+    val mottakerVirksomhetsnummer = mottakere.flatMap {
+            listOfNotNull(
+                it.altinn?.virksomhetsnummer,
+                it.naermesteLeder?.virksomhetsnummer
+            )
+        }
+    val alleVirksomhetsnummer = listOfNotNull(virksomhetsnummer) + mottakerVirksomhetsnummer
+    return alleVirksomhetsnummer.toSet().single()
+}

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/QueryMineNotifikasjoner.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/QueryMineNotifikasjoner.kt
@@ -62,7 +62,7 @@ class QueryMineNotifikasjoner(
                             opprettetTidspunkt = beskjed.opprettetTidspunkt,
                             softDeletedAt = beskjed.deletedAt,
                         ),
-                        mottaker = Mottaker.fraDomene(beskjed.mottakere.single()),
+                        mottaker = Mottaker.fraDomene(beskjed.mottakere.first()),
                         mottakere = beskjed.mottakere.map { Mottaker.fraDomene(it) },
                         beskjed = BeskjedData(
                             merkelapp = beskjed.merkelapp,
@@ -100,7 +100,7 @@ class QueryMineNotifikasjoner(
                             opprettetTidspunkt = oppgave.opprettetTidspunkt,
                             softDeletedAt = oppgave.deletedAt
                         ),
-                        mottaker = Mottaker.fraDomene(oppgave.mottakere.single()),
+                        mottaker = Mottaker.fraDomene(oppgave.mottakere.first()),
                         mottakere = oppgave.mottakere.map { Mottaker.fraDomene(it) },
                         oppgave = OppgaveData(
                             tilstand = enumValueOf(oppgave.tilstand.name),

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -332,14 +332,41 @@ type OppgaveUtfoertVellykket {
 }
 
 input NyBeskjedInput {
-    mottaker: MottakerInput!
+    """
+    Se dokumentasjonen til `mottakere`-feltet.
+    """
+    mottaker: MottakerInput
+
+    """
+    Her bestemmer dere hvem som skal få se notifikasjonen.
+
+    Hvis dere oppgir en mottaker i `mottaker`-feltet, så tolker vi det som om det var et element
+    i denne listen over mottakere.
+
+    Dere må gi oss minst 1 mottaker.
+    """
+    mottakere: [MottakerInput!]! = []
+
     notifikasjon: NotifikasjonInput!
     metadata: MetadataInput!
     eksterneVarsler: [EksterntVarselInput!]! = []
 }
 
 input NyOppgaveInput {
+    """
+    Se dokumentasjonen til `mottakere`-feltet.
+    """
     mottaker: MottakerInput!
+
+    """
+    Her bestemmer dere hvem som skal få se notifikasjonen.
+
+    Hvis dere oppgir en mottaker i `mottaker`-feltet, så tolker vi det som om det var et element
+    i denne listen over mottakere.
+
+    Dere må gi oss minst 1 mottaker.
+    """
+    mottakere: [MottakerInput!]! = []
     notifikasjon: NotifikasjonInput!
     metadata: MetadataInput!
     eksterneVarsler: [EksterntVarselInput!]! = []

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyBeskjedFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyBeskjedFlereMottakereTests.kt
@@ -1,0 +1,57 @@
+package no.nav.arbeidsgiver.notifikasjon.produsent_api
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.shouldNot
+import io.mockk.mockk
+import no.nav.arbeidsgiver.notifikasjon.Produsent
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.api.ProdusentAPI
+import no.nav.arbeidsgiver.notifikasjon.util.getGraphqlErrors
+import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+
+class NyBeskjedFlereMottakereTests: DescribeSpec({
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+
+    val engine = ktorProdusentTestServer(
+        produsentGraphQL = ProdusentAPI.newGraphQL(
+            kafkaProducer = mockk(),
+            produsentRepository = produsentRepository,
+        )
+    )
+
+    describe("sender ingen mottakere") {
+        val response = engine.produsentApi("""
+            mutation {
+                nyBeskjed(nyBeskjed: {
+                    metadata: {
+                        eksternId: "0"
+                        virksomhetsnummer: "0"
+                    }
+                    notifikasjon: {
+                        lenke: ""
+                        tekst: ""
+                        merkelapp: ""
+                    }
+                }) {
+                    __typename
+                    ... on NyBeskjedVellykket {
+                        id
+                    }
+                    ... on Error {
+                        feilmelding
+                    }
+                }
+            
+            }
+        """)
+
+        it("response should have error") {
+            val errors = response.getGraphqlErrors()
+            println(errors)
+            errors shouldNot beEmpty()
+        }
+    }
+})

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyBeskjedFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyBeskjedFlereMottakereTests.kt
@@ -1,15 +1,24 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent_api
 
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.convertValue
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.ktor.server.testing.*
 import io.mockk.mockk
 import no.nav.arbeidsgiver.notifikasjon.Produsent
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.objectMapper
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.ProdusentAPI
+import no.nav.arbeidsgiver.notifikasjon.produsent.api.QueryMineNotifikasjoner
 import no.nav.arbeidsgiver.notifikasjon.util.getGraphqlErrors
+import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import java.util.*
 
 class NyBeskjedFlereMottakereTests: DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
@@ -17,15 +26,169 @@ class NyBeskjedFlereMottakereTests: DescribeSpec({
 
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
-            kafkaProducer = mockk(),
+            kafkaProducer = mockk(relaxed = true),
             produsentRepository = produsentRepository,
         )
     )
 
     describe("sender ingen mottakere") {
-        val response = engine.produsentApi("""
+        val response = engine.produsentApi(nyBeskjed("""
+        """))
+        it("response should have error") {
+            val errors = response.getGraphqlErrors()
+            errors shouldNot beEmpty()
+        }
+    }
+
+    describe("sender 1 mottaker i 'mottaker'") {
+        val response = engine.produsentApi(nyBeskjed("""
+            mottaker: {
+                altinn: {
+                    serviceCode: "5441"
+                    serviceEdition: "1"
+                }
+            }
+        """))
+        it("no error in response") {
+            val errors = response.getGraphqlErrors()
+            errors.shouldBeEmpty()
+        }
+
+        it("en mottaker registrert") {
+            val resultType = response.getTypedContent<String>("$.nyBeskjed.__typename")
+            resultType shouldBe "NyBeskjedVellykket"
+
+            val id = response.getTypedContent<UUID>("/nyBeskjed/id")
+            val mottakere = engine.hentMottakere(id)
+            mottakere.toSet() shouldBe setOf(
+                QueryMineNotifikasjoner.AltinnMottaker(
+                    serviceCode = "5441",
+                    serviceEdition = "1",
+                    virksomhetsnummer = "0"
+                )
+            )
+        }
+    }
+
+    describe("sender 1 mottaker i 'mottakere'") {
+        val response = engine.produsentApi(nyBeskjed("""
+            mottakere: [
+                {
+                    altinn: {
+                        serviceCode: "5441"
+                        serviceEdition: "1"
+                    }
+                }
+            ]
+        """))
+        it("no error in response") {
+            val errors = response.getGraphqlErrors()
+            errors.shouldBeEmpty()
+        }
+        it("en mottaker registrert") {
+            val resultType = response.getTypedContent<String>("$.nyBeskjed.__typename")
+            resultType shouldBe "NyBeskjedVellykket"
+
+            val id = response.getTypedContent<UUID>("/nyBeskjed/id")
+            val mottakere = engine.hentMottakere(id)
+            mottakere.toSet() shouldBe setOf(
+                QueryMineNotifikasjoner.AltinnMottaker(
+                    serviceCode = "5441",
+                    serviceEdition = "1",
+                    virksomhetsnummer = "0"
+                )
+            )
+        }
+    }
+    describe("sender 2 mottakere i 'mottakere'") {
+        val response = engine.produsentApi(nyBeskjed("""
+            mottakere: [
+                {
+                    altinn: {
+                        serviceCode: "5441"
+                        serviceEdition: "1"
+                    }
+                },
+                {
+                    naermesteLeder: {
+                        naermesteLederFnr: "2"
+                        ansattFnr: "3"
+                    }
+                }
+            ]
+        """))
+        it("no errors in response") {
+            val errors = response.getGraphqlErrors()
+            errors.shouldBeEmpty()
+        }
+        it("en mottaker registrert") {
+            val resultType = response.getTypedContent<String>("$.nyBeskjed.__typename")
+            resultType shouldBe "NyBeskjedVellykket"
+
+            val id = response.getTypedContent<UUID>("/nyBeskjed/id")
+            val mottakere = engine.hentMottakere(id)
+            mottakere.toSet() shouldBe setOf(
+                QueryMineNotifikasjoner.AltinnMottaker(
+                    serviceCode = "5441",
+                    serviceEdition = "1",
+                    virksomhetsnummer = "0"
+                ),
+                QueryMineNotifikasjoner.NærmesteLederMottaker(
+                    ansattFnr = "3",
+                    naermesteLederFnr = "2",
+                    virksomhetsnummer = "0"
+                )
+            )
+        }
+    }
+
+    describe("sender 2 mottaker, en i 'mottaker' og en i 'mottakere'") {
+        val response = engine.produsentApi(nyBeskjed("""
+            mottaker: {
+                altinn: {
+                    serviceCode: "5441"
+                    serviceEdition: "1"
+                }
+            }
+            mottakere: [
+                {
+                    naermesteLeder: {
+                        naermesteLederFnr: "2"
+                        ansattFnr: "3"
+                    }
+                }
+            ]
+        """))
+        it("no errors in response") {
+            val errors = response.getGraphqlErrors()
+            errors.shouldBeEmpty()
+        }
+        it("en mottaker registrert") {
+            val resultType = response.getTypedContent<String>("$.nyBeskjed.__typename")
+            resultType shouldBe "NyBeskjedVellykket"
+
+            val id = response.getTypedContent<UUID>("/nyBeskjed/id")
+            val mottakere = engine.hentMottakere(id)
+            mottakere.toSet() shouldBe setOf(
+                QueryMineNotifikasjoner.AltinnMottaker(
+                    serviceCode = "5441",
+                    serviceEdition = "1",
+                    virksomhetsnummer = "0"
+                ),
+                QueryMineNotifikasjoner.NærmesteLederMottaker(
+                    ansattFnr = "3",
+                    naermesteLederFnr = "2",
+                    virksomhetsnummer = "0"
+                )
+            )
+        }
+    }
+})
+
+fun nyBeskjed(fragment: String) = """
             mutation {
                 nyBeskjed(nyBeskjed: {
+                    $fragment
                     metadata: {
                         eksternId: "0"
                         virksomhetsnummer: "0"
@@ -33,7 +196,7 @@ class NyBeskjedFlereMottakereTests: DescribeSpec({
                     notifikasjon: {
                         lenke: ""
                         tekst: ""
-                        merkelapp: ""
+                        merkelapp: "tag"
                     }
                 }) {
                     __typename
@@ -46,12 +209,63 @@ class NyBeskjedFlereMottakereTests: DescribeSpec({
                 }
             
             }
-        """)
+        """
 
-        it("response should have error") {
-            val errors = response.getGraphqlErrors()
-            println(errors)
-            errors shouldNot beEmpty()
+fun TestApplicationEngine.hentMottakere(id: UUID): List<QueryMineNotifikasjoner.Mottaker> {
+    return this.produsentApi("""
+        query {
+            mineNotifikasjoner(merkelapp: "tag") {
+                ... on NotifikasjonConnection {
+                    edges {
+                        node {
+                            __typename
+                            ... on Beskjed {
+                                metadata {
+                                    id
+                                }
+                                mottakere {
+                                    __typename
+                                    ... on AltinnMottaker {
+                                        serviceCode
+                                        serviceEdition
+                                        virksomhetsnummer
+                                    }
+                                    ... on NaermesteLederMottaker {
+                                        ansattFnr
+                                        naermesteLederFnr
+                                        virksomhetsnummer
+                                    }
+                                }
+                            }
+                            ... on Oppgave {
+                                metadata {
+                                    id
+                                }
+                                mottakere {
+                                    __typename
+                                    ... on AltinnMottaker {
+                                        serviceCode
+                                        serviceEdition
+                                        virksomhetsnummer
+                                    }
+                                    ... on NaermesteLederMottaker {
+                                        ansattFnr
+                                        naermesteLederFnr
+                                        virksomhetsnummer
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
-    }
-})
+    """)
+        .getTypedContent<List<JsonNode>>("$.mineNotifikasjoner.edges[*].node")
+        .flatMap {
+            if (it["metadata"]["id"].asText() == id.toString())
+                objectMapper.convertValue<List<QueryMineNotifikasjoner.Mottaker>>(it["mottakere"])
+            else
+                listOf()
+        }
+}

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
@@ -1,7 +1,12 @@
 package no.nav.arbeidsgiver.notifikasjon.util
 
 import com.fasterxml.jackson.databind.node.NullNode
-import no.nav.arbeidsgiver.notifikasjon.*
+import no.nav.arbeidsgiver.notifikasjon.AltinnMottaker
+import no.nav.arbeidsgiver.notifikasjon.EksterntVarselSendingsvindu
+import no.nav.arbeidsgiver.notifikasjon.EpostVarselKontaktinfo
+import no.nav.arbeidsgiver.notifikasjon.Hendelse
+import no.nav.arbeidsgiver.notifikasjon.NærmesteLederMottaker
+import no.nav.arbeidsgiver.notifikasjon.SmsVarselKontaktinfo
 import java.time.OffsetDateTime
 
 
@@ -43,6 +48,50 @@ object EksempelHendelse {
             )
         )
     )
+    val BeskjedOpprettet_2_Mottakere = Hendelse.BeskjedOpprettet(
+        virksomhetsnummer = "1",
+        notifikasjonId = uuid("1"),
+        hendelseId = uuid("2"),
+        produsentId = "1",
+        kildeAppNavn = "1",
+        merkelapp = "1",
+        eksternId = "1",
+        mottakere = listOf(
+            AltinnMottaker(
+                virksomhetsnummer = "1",
+                serviceCode = "1",
+                serviceEdition = "1"
+            ),
+            NærmesteLederMottaker(
+                naermesteLederFnr = "1",
+                ansattFnr = "1",
+                virksomhetsnummer = "1"
+            )
+        ),
+        tekst = "1",
+        grupperingsid = null,
+        lenke = "",
+        opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01+00"),
+        eksterneVarsler = listOf(
+            SmsVarselKontaktinfo(
+                varselId = uuid("3"),
+                fnrEllerOrgnr = "1",
+                tlfnr = "1",
+                smsTekst = "hey",
+                sendevindu = EksterntVarselSendingsvindu.LØPENDE,
+                sendeTidspunkt = null
+            ),
+            EpostVarselKontaktinfo(
+                varselId = uuid("4"),
+                fnrEllerOrgnr = "1",
+                epostAddr = "1",
+                tittel = "hey",
+                htmlBody = "body",
+                sendevindu = EksterntVarselSendingsvindu.LØPENDE,
+                sendeTidspunkt = null
+            )
+        )
+    )
     val OppgaveOpprettet = Hendelse.OppgaveOpprettet(
         virksomhetsnummer = "1",
         notifikasjonId = uuid("1"),
@@ -56,6 +105,50 @@ object EksempelHendelse {
             serviceCode = "1",
             serviceEdition = "1"
         )),
+        tekst = "1",
+        grupperingsid = null,
+        lenke = "",
+        opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01+00"),
+        eksterneVarsler = listOf(
+            SmsVarselKontaktinfo(
+                varselId = uuid("3"),
+                fnrEllerOrgnr = "1",
+                tlfnr = "1",
+                smsTekst = "hey",
+                sendevindu = EksterntVarselSendingsvindu.LØPENDE,
+                sendeTidspunkt = null
+            ),
+            EpostVarselKontaktinfo(
+                varselId = uuid("4"),
+                fnrEllerOrgnr = "1",
+                epostAddr = "1",
+                tittel = "hey",
+                htmlBody = "body",
+                sendevindu = EksterntVarselSendingsvindu.LØPENDE,
+                sendeTidspunkt = null
+            )
+        )
+    )
+    val OppgaveOpprettet_2_Mottakere = Hendelse.OppgaveOpprettet(
+        virksomhetsnummer = "1",
+        notifikasjonId = uuid("1"),
+        hendelseId = uuid("2"),
+        produsentId = "1",
+        kildeAppNavn = "1",
+        merkelapp = "1",
+        eksternId = "1",
+        mottakere = listOf(
+            AltinnMottaker(
+                virksomhetsnummer = "1",
+                serviceCode = "1",
+                serviceEdition = "1"
+            ),
+            NærmesteLederMottaker(
+                virksomhetsnummer = "1",
+                ansattFnr = "1",
+                naermesteLederFnr = "2"
+            )
+        ),
         tekst = "1",
         grupperingsid = null,
         lenke = "",
@@ -133,6 +226,7 @@ object EksempelHendelse {
 
     val Alle = listOf(
         BeskjedOpprettet,
+        BeskjedOpprettet_2_Mottakere,
         OppgaveOpprettet,
         OppgaveUtført,
         SoftDelete,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon.util
 
 import com.fasterxml.jackson.module.kotlin.convertValue
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.jayway.jsonpath.JsonPath
 import io.ktor.http.*
 import io.ktor.server.testing.*
@@ -32,7 +33,8 @@ inline fun <reified T> TestApplicationResponse.getTypedContent(name: String): T 
         val dataNode = tree.get("data")
 
         return if (name.startsWith("$")) {
-            JsonPath.read(dataNode.toString(), name)
+            val rawJson = objectMapper.writeValueAsString(JsonPath.read(dataNode.toString(), name))
+            objectMapper.readValue(rawJson)
         } else {
             val node = dataNode.at(name.ensurePrefix("/"))
             if (node.isNull || node.isMissingNode) {


### PR DESCRIPTION
Har problem med unit-test. Implementasjonen av mutation-en kaster exception når det er feil, men hadde forventet at det ble en graphql-error, ikke at serveren kræsjet.

```
graphql.GraphqlErrorException: minst 1 mottaker må gis
	at graphql.GraphqlErrorException$Builder.build(GraphqlErrorException.java:58)
	at no.nav.arbeidsgiver.notifikasjon.Hendelse$BeskjedOpprettet.<init>(Hendelse.kt:289)
	at no.nav.arbeidsgiver.notifikasjon.produsent.api.MutationNyBeskjed$NyBeskjedInput.tilDomene(MutationNyBeskjed.kt:62)
	at no.nav.arbeidsgiver.notifikasjon.produsent.api.MutationNyBeskjed.nyBeskjed(MutationNyBeskjed.kt:86)
	at no.nav.arbeidsgiver.notifikasjon.produsent.api.MutationNyBeskjed.access$nyBeskjed(MutationNyBeskjed.kt:19)
	at no.nav.arbeidsgiver.notifikasjon.produsent.api.MutationNyBeskjed$wire$1$1.invokeSuspend(MutationNyBeskjed.kt:30)
	at no.nav.arbeidsgiver.notifikasjon.produsent.api.MutationNyBeskjed$wire$1$1.invoke(MutationNyBeskjed.kt)
	at no.nav.arbeidsgiver.notifikasjon.produsent.api.MutationNyBeskjed$wire$1$1.invoke(MutationNyBeskjed.kt)
	at no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLKt$coDataFetcher$1$1.invokeSuspend(GraphQL.kt:37)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```