### PR TITLE
Introduser aggregateId i alle hendelser

### DIFF
--- a/.github/workflows/deploy-replay-validator-prod.yaml
+++ b/.github/workflows/deploy-replay-validator-prod.yaml
@@ -1,0 +1,17 @@
+name: deploy replay validator in prod
+on:
+  workflow_dispatch:
+
+jobs:
+  dev-deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - uses: nais/deploy/actions/deploy@v1
+        name: "prod-gcp: deploy replay-validator"
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/arbeidsgiver-notifikasjon-produsent-api:${{ github.sha }}
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: config/prod-gcp-replay-validator.yaml

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ReplayValidator.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ReplayValidator.kt
@@ -27,7 +27,7 @@ object ReplayValidator {
                 val kafkaConsumer = createKafkaConsumer {
                     put(ConsumerConfig.GROUP_ID_CONFIG, "replay-validator")
                 }
-                kafkaConsumer.seekToBeginning()
+                kafkaConsumer.seekToBeginningOnAssignment()
                 kafkaConsumer.forEachEvent { _ ->
                     // noop. implicitly validated
                 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
@@ -196,23 +196,23 @@ class BrukerModelImpl(
             is Hendelse.BrukerKlikket -> oppdaterModellEtterBrukerKlikket(hendelse)
             is Hendelse.OppgaveOpprettet -> oppdaterModellEtterOppgaveOpprettet(hendelse)
             is Hendelse.OppgaveUtført -> oppdaterModellEtterOppgaveUtført(hendelse)
-            is Hendelse.SoftDelete -> oppdaterModellEtterDelete(hendelse.notifikasjonId)
-            is Hendelse.HardDelete -> oppdaterModellEtterDelete(hendelse.notifikasjonId)
+            is Hendelse.SoftDelete -> oppdaterModellEtterDelete(hendelse.aggregateId)
+            is Hendelse.HardDelete -> oppdaterModellEtterDelete(hendelse.aggregateId)
             is Hendelse.EksterntVarselFeilet -> Unit
             is Hendelse.EksterntVarselVellykket -> Unit
         }
     }
 
-    private suspend fun oppdaterModellEtterDelete(hendelsesId: UUID) {
+    private suspend fun oppdaterModellEtterDelete(aggregateId: UUID) {
         database.transaction({
             throw RuntimeException("Delete", it)
         }) {
             executeUpdate(""" DELETE FROM notifikasjon WHERE id = ?;""") {
-                uuid(hendelsesId)
+                uuid(aggregateId)
             }
 
             executeUpdate("""DELETE FROM brukerklikk WHERE notifikasjonsid = ?;""") {
-                uuid(hendelsesId)
+                uuid(aggregateId)
             }
         }
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
@@ -83,7 +83,7 @@ class EksternVarslingRepository(
             set hard_deleted = true
             where notifikasjon_id = ?
         """) {
-            uuid(hardDelete.notifikasjonId)
+            uuid(hardDelete.aggregateId)
         }
     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -90,6 +90,7 @@ class CoroutineKafkaConsumerImpl<K, V>(
 
     override suspend fun seekToBeginning() {
         consumer.seekToBeginning(consumer.assignment())
+        consumer.commitSync()
     }
 
     private suspend fun forEachEvent(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModel.kt
@@ -34,7 +34,7 @@ class KafkaReaperModelImpl(
             """
             ) {
                 uuid(hendelse.hendelseId)
-                uuid(hendelse.notifikasjonId)
+                uuid(hendelse.aggregateId)
                 string(hendelse.typeNavn)
             }
 
@@ -45,7 +45,7 @@ class KafkaReaperModelImpl(
                         VALUES (?, ?)
                         ON CONFLICT DO NOTHING
                     """) {
-                        uuid(hendelse.notifikasjonId)
+                        uuid(hendelse.aggregateId)
                         timestamptz(OffsetDateTime.now())
                 }
             }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperService.kt
@@ -18,7 +18,7 @@ class KafkaReaperServiceImpl(
 
         val ignored : Unit = when (hendelse) {
             is Hendelse.HardDelete -> {
-                for (relatertHendelseId in kafkaReaperModel.alleRelaterteHendelser(hendelse.notifikasjonId)) {
+                for (relatertHendelseId in kafkaReaperModel.alleRelaterteHendelser(hendelse.aggregateId)) {
                     kafkaProducer.tombstone(
                         key = relatertHendelseId.toString(),
                         orgnr = hendelse.virksomhetsnummer
@@ -34,7 +34,7 @@ class KafkaReaperServiceImpl(
             is Hendelse.OppgaveUtført,
             is Hendelse.EksterntVarselFeilet,
             is Hendelse.EksterntVarselVellykket -> {
-                if (kafkaReaperModel.erSlettet(hendelse.notifikasjonId)) {
+                if (kafkaReaperModel.erSlettet(hendelse.aggregateId)) {
                     kafkaProducer.tombstone(
                         key = hendelse.hendelseId.toString(),
                         orgnr = hendelse.virksomhetsnummer

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -195,7 +195,7 @@ class ProdusentRepositoryImpl(
             WHERE id = ?
             """
         ) {
-            uuid(hardDelete.notifikasjonId)
+            uuid(hardDelete.aggregateId)
         }
     }
 
@@ -208,7 +208,7 @@ class ProdusentRepositoryImpl(
             """
         ) {
             timestamptz(softDelete.deletedAt)
-            uuid(softDelete.notifikasjonId)
+            uuid(softDelete.aggregateId)
         }
     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationHardDelete.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationHardDelete.kt
@@ -74,7 +74,7 @@ class MutationHardDelete(
 
         val hardDelete = Hendelse.HardDelete(
             hendelseId = UUID.randomUUID(),
-            notifikasjonId = notifikasjon.id,
+            aggregateId = notifikasjon.id,
             virksomhetsnummer = notifikasjon.virksomhetsnummer,
             deletedAt = OffsetDateTime.now(),
             produsentId = produsent.id,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationSoftDelete.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationSoftDelete.kt
@@ -74,7 +74,7 @@ class MutationSoftDelete(
 
         val softDelete = Hendelse.SoftDelete(
             hendelseId = UUID.randomUUID(),
-            notifikasjonId = notifikasjon.id,
+            aggregateId = notifikasjon.id,
             virksomhetsnummer = notifikasjon.virksomhetsnummer,
             deletedAt = OffsetDateTime.now(),
             produsentId = produsent.id,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/HendelseDeserializationTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/HendelseDeserializationTests.kt
@@ -76,4 +76,24 @@ class HendelseDeserializationTests : DescribeSpec({
             mottaker.virksomhetsnummer shouldBe "3"
         }
     }
+
+    describe("leser 'notifikasjon', selv om den heter 'aggregateId' i kotlin") {
+        val hardDelete = laxObjectMapper.readValue<Hendelse>("""
+            {
+                "@type": "HardDelete",
+                "virksomhetsnummer": "0",
+                "notifikasjonId": "${uuid("1")}",
+                "hendelseId": "${uuid("0")}",
+                "produsentId": "0",
+                "kildeAppNavn": "",
+                "deletedAt": "2020-01-01T01:01+01"
+            }
+        """)
+
+        it("mottaker parsed") {
+            hardDelete as Hendelse.HardDelete
+            hardDelete.hendelseId shouldBe uuid("0")
+            hardDelete.aggregateId shouldBe uuid("1")
+        }
+    }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/HendelseSerializationTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/HendelseSerializationTests.kt
@@ -41,4 +41,71 @@ class HendelseSerializationTests : DescribeSpec({
             json["mottakere"][0]["virksomhetsnummer"].asText() shouldBe "3"
         }
     }
+
+    /* Dette hadde vært fint å få den mer korrekte 'aggregateId' i json, så bare å slette
+     * denne testen hvis det endres! */
+    describe("har ikke 'aggregateId', men 'notifikasjonId' i HardDelete json") {
+        val oppgaveOpprettet = Hendelse.HardDelete(
+            virksomhetsnummer = "",
+            aggregateId = uuid("0"),
+            hendelseId = uuid("0"),
+            produsentId = "",
+            kildeAppNavn = "",
+            deletedAt = OffsetDateTime.parse("2020-02-02T02:02+02")
+        )
+
+        it("mottaker parsed") {
+            val json = laxObjectMapper.readTree(laxObjectMapper.writeValueAsString(oppgaveOpprettet))
+            json.has("aggregateId") shouldBe false
+            json.has("notifikasjonId") shouldBe true
+        }
+    }
+
+    /* Dette hadde vært fint å få den mer korrekte 'aggregateId' i json, så bare å slette
+     * denne testen hvis det endres! */
+    describe("har ikke 'aggregateId', men 'notifikasjonId' i SoftDelete json") {
+        val oppgaveOpprettet = Hendelse.SoftDelete(
+            virksomhetsnummer = "",
+            aggregateId = uuid("0"),
+            hendelseId = uuid("0"),
+            produsentId = "",
+            kildeAppNavn = "",
+            deletedAt = OffsetDateTime.parse("2020-02-02T02:02+02")
+        )
+
+        it("mottaker parsed") {
+            val json = laxObjectMapper.readTree(laxObjectMapper.writeValueAsString(oppgaveOpprettet))
+            json.has("aggregateId") shouldBe false
+            json.has("notifikasjonId") shouldBe true
+        }
+    }
+
+    describe("har ikke 'aggregateId' i json") {
+        val oppgaveOpprettet = Hendelse.OppgaveOpprettet(
+            virksomhetsnummer = "",
+            notifikasjonId = uuid("0"),
+            hendelseId = uuid("0"),
+            produsentId = "",
+            kildeAppNavn = "",
+            merkelapp = "",
+            eksternId = "",
+            mottakere = listOf(AltinnMottaker(
+                serviceCode = "1",
+                serviceEdition = "2",
+                virksomhetsnummer = "3",
+            )),
+            tekst = "",
+            grupperingsid = null,
+            lenke = "",
+            opprettetTidspunkt = OffsetDateTime.parse("2000-01-01T01:01+01"),
+            eksterneVarsler = listOf(),
+        )
+
+
+        it("mottaker parsed") {
+            val json = laxObjectMapper.readTree(laxObjectMapper.writeValueAsString(oppgaveOpprettet))
+            json.has("aggregateId") shouldBe false
+            json.has("notifikasjonId") shouldBe true
+        }
+    }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/HardDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/HardDeleteTests.kt
@@ -48,7 +48,7 @@ class HardDeleteTests : DescribeSpec({
 
         val hardDeleteEvent = Hendelse.HardDelete(
             hendelseId = UUID.randomUUID(),
-            notifikasjonId = uuid1,
+            aggregateId = uuid1,
             virksomhetsnummer = mottaker.virksomhetsnummer,
             deletedAt = OffsetDateTime.MAX,
             kildeAppNavn = "",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/SoftDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/SoftDeleteTests.kt
@@ -48,7 +48,7 @@ class SoftDeleteTests : DescribeSpec({
 
         val softDeleteEvent = Hendelse.SoftDelete(
             hendelseId = UUID.randomUUID(),
-            notifikasjonId = uuid1,
+            aggregateId = uuid1,
             virksomhetsnummer = mottaker.virksomhetsnummer,
             deletedAt = OffsetDateTime.MAX,
             kildeAppNavn = "",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
@@ -273,7 +273,7 @@ object EksempelHendelse {
     )
     val SoftDelete = Hendelse.SoftDelete(
         virksomhetsnummer = "1",
-        notifikasjonId = uuid("1"),
+        aggregateId = uuid("1"),
         hendelseId = uuid("2"),
         produsentId = "1",
         kildeAppNavn = "1",
@@ -281,7 +281,7 @@ object EksempelHendelse {
     )
     val HardDelete = Hendelse.HardDelete(
         virksomhetsnummer = "1",
-        notifikasjonId = uuid("1"),
+        aggregateId = uuid("1"),
         hendelseId = uuid("2"),
         produsentId = "1",
         kildeAppNavn = "1",
@@ -315,7 +315,7 @@ object EksempelHendelse {
         feilmelding = "oops"
     )
 
-    val Alle = listOf(
+    val Alle: List<Hendelse> = listOf(
         BeskjedOpprettet,
         BeskjedOpprettet_2_Mottakere,
         BeskjedOpprettet_3_Mottakere,


### PR DESCRIPTION
Alle hendelser har nå en aggregateId, en ID som forteller hvilket
aggregate (sak, oppgave, beskjed) hendelsen omhandler.

Det er ingen endring i json-representasjon som følge av denne endringen.