### PR TITLE
Tilgangsstyring i bruker api på rolle

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Produsent.kt
@@ -87,8 +87,7 @@ object Produsent {
             val graphql = async {
                 ProdusentAPI.newGraphQL(
                     kafkaProducer = createKafkaProducer(),
-                    produsentRepository = produsentRepositoryAsync.await()
-
+                    produsentRepository = produsentRepositoryAsync.await(),
                 )
             }
 
@@ -111,7 +110,7 @@ object Produsent {
                     "last Altinnroller",
                     pauseAfterEach = Duration.ofDays(1),
                 ) {
-                    AltinnRolleServiceImpl(altinn, produsentRepositoryAsync.await()).lastAltinnroller()
+                    AltinnRolleServiceImpl(altinn, produsentRepositoryAsync.await().altinnRolle).lastAltinnroller()
                 }
             }
         }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/altinn_roller/AltinnRolleRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/altinn_roller/AltinnRolleRepository.kt
@@ -1,0 +1,59 @@
+package no.nav.arbeidsgiver.notifikasjon.altinn_roller
+
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.AltinnRolle
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
+
+interface AltinnRolleRepository {
+    suspend fun leggTilAltinnRoller(roller: Iterable<AltinnRolle>)
+    suspend fun hentAltinnrolle(rolleKode: String): AltinnRolle?
+    suspend fun hentAlleAltinnRoller(): List<AltinnRolle>
+}
+
+open class AltinnRolleRepositoryImpl(
+    private val database: Database,
+) : AltinnRolleRepository {
+    override suspend fun leggTilAltinnRoller(roller: Iterable<AltinnRolle>) {
+        database.nonTransactionalExecuteBatch(
+            """
+            insert into altinn_rolle(
+                 role_definition_id,
+                 role_definition_code                 
+            )
+            values (?, ?)
+            """,
+            roller
+        ) {
+            string(it.RoleDefinitionId)
+            string(it.RoleDefinitionCode)
+        }
+    }
+
+    override suspend fun hentAltinnrolle(rolleKode: String): AltinnRolle? =
+        database.nonTransactionalExecuteQuery("""
+                select role_definition_id,
+                    role_definition_code                
+                from altinn_rolle                
+                where role_definition_code = ?
+        """,
+            { string(rolleKode) }
+        ) {
+            AltinnRolle(
+                RoleDefinitionCode = getString("role_definition_code"),
+                RoleDefinitionId = getString("role_definition_id")
+            )
+        }.firstOrNull()
+
+    override suspend fun hentAlleAltinnRoller(): List<AltinnRolle> =
+        database.nonTransactionalExecuteQuery(
+            """
+                select role_definition_id,
+                    role_definition_code                
+                from altinn_rolle                          
+        """
+        ) {
+            AltinnRolle(
+                RoleDefinitionCode = getString("role_definition_code"),
+                RoleDefinitionId = getString("role_definition_id")
+            )
+        }
+}

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/altinn_roller/AltinnRolleService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/altinn_roller/AltinnRolleService.kt
@@ -1,20 +1,40 @@
 package no.nav.arbeidsgiver.notifikasjon.altinn_roller
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.retry
+import kotlinx.coroutines.flow.toList
+import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Altinn
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.AltinnRolle
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.AltinnRolleDefinisjon
 
 interface AltinnRolleService {
     suspend fun lastAltinnroller()
+    suspend fun hentAltinnrollerMedRetry(rolleDefinisjoner: List<AltinnRolleDefinisjon>, retries: Long, delay: Long) : List<AltinnRolle>
 }
 
-class AltinnRolleServiceImpl(val altinn: Altinn, val produsentRepository: ProdusentRepository) : AltinnRolleService {
+class AltinnRolleServiceImpl(val altinn: Altinn, val altinnRolleRepository: AltinnRolleRepository) : AltinnRolleService {
     override suspend fun lastAltinnroller() {
         val ferskeRollerFraAltinn = altinn.hentRoller()
-        val eksisterendeRollerFraDb = produsentRepository.hentAlleAltinnRoller()
-        val nyeRoller = ferskeRollerFraAltinn - eksisterendeRollerFraDb
-        nyeRoller.forEach { rolle ->
-            produsentRepository.leggTilAltinnRolle(rolle)
-        }
+        val eksisterendeRollerFraDb = altinnRolleRepository.hentAlleAltinnRoller()
+        val nyeRoller = ferskeRollerFraAltinn - eksisterendeRollerFraDb.toSet()
+        altinnRolleRepository.leggTilAltinnRoller(nyeRoller)
+    }
+
+    override suspend fun hentAltinnrollerMedRetry(
+        rolleDefinisjoner: List<AltinnRolleDefinisjon>,
+        retries: Long,
+        delay: Long
+    ) : List<AltinnRolle> {
+        return rolleDefinisjoner.asFlow().map {
+            altinnRolleRepository.hentAltinnrolle(it.roleCode)!!
+        }.retry(retries) {
+            Bruker.log.warn("feil ved henting av altinn rolle fra db. forsøker på nytt", it)
+            delay(delay)
+            true
+        }.toList()
     }
 
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.notifikasjon.bruker
 
 import no.nav.arbeidsgiver.notifikasjon.*
+import no.nav.arbeidsgiver.notifikasjon.altinn_roller.AltinnRolleRepository
+import no.nav.arbeidsgiver.notifikasjon.altinn_roller.AltinnRolleRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Transaction
@@ -65,20 +67,25 @@ interface BrukerModel {
             UTFOERT
         }
     }
+}
 
+interface BrukerRepository {
     suspend fun hentNotifikasjoner(
         fnr: String,
-        tilganger: Collection<Tilgang>,
-    ): List<Notifikasjon>
+        tilganger: Collection<BrukerModel.Tilgang>,
+    ): List<BrukerModel.Notifikasjon>
 
     suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse)
     suspend fun virksomhetsnummerForNotifikasjon(notifikasjonsid: UUID): String?
+
+    val altinnRolle : AltinnRolleRepository
 }
 
-class BrukerModelImpl(
+class BrukerRepositoryImpl(
     private val database: Database
-) : BrukerModel {
+) : BrukerRepository {
     private val timer = Health.meterRegistry.timer("query_model_repository_hent_notifikasjoner")
+    override val altinnRolle: AltinnRolleRepository = AltinnRolleRepositoryImpl(database)
 
     override suspend fun hentNotifikasjoner(
         fnr: String,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -266,7 +266,7 @@ class ParameterSetters(
 
     inline fun <reified T> jsonb(value: T) =
         string(
-            laxObjectMapper.writeValueAsStringSupportingTypeInfoInCollections<T>(value)
+            laxObjectMapper.writeValueAsString(value)
         )
 
     fun boolean(newState: Boolean) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -266,7 +266,7 @@ class ParameterSetters(
 
     inline fun <reified T> jsonb(value: T) =
         string(
-            laxObjectMapper.writeValueAsString(value)
+            laxObjectMapper.writeValueAsStringSupportingTypeInfoInCollections(value)
         )
 
     fun boolean(newState: Boolean) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegister.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegister.kt
@@ -1,10 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter
 
-import no.nav.arbeidsgiver.notifikasjon.AltinnMottaker
-import no.nav.arbeidsgiver.notifikasjon.AltinnRolleMottaker
-import no.nav.arbeidsgiver.notifikasjon.AltinnReporteeMottaker
-import no.nav.arbeidsgiver.notifikasjon.Mottaker
-import no.nav.arbeidsgiver.notifikasjon.NærmesteLederMottaker
+import no.nav.arbeidsgiver.notifikasjon.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.AppName
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import java.util.*
@@ -83,6 +79,10 @@ object MottakerRegister {
     val servicecodeDefinisjoner: List<ServicecodeDefinisjon>
         get() {
             return MOTTAKER_REGISTER.filterIsInstance<ServicecodeDefinisjon>()
+        }
+    val rolleDefinisjoner: List<AltinnRolleDefinisjon>
+        get() {
+            return MOTTAKER_REGISTER.filterIsInstance<AltinnRolleDefinisjon>()
         }
 
     fun erDefinert(mottakerDefinisjon: MottakerDefinisjon): Boolean =

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
@@ -91,7 +91,7 @@ class MutationNyBeskjed(
                 id = id,
                 produsentId = produsent.id,
                 kildeAppNavn = context.appName,
-                finnRolleId = produsentRepository::hentAltinnrolle
+                finnRolleId = produsentRepository.altinnRolle::hentAltinnrolle
             )
         } catch (e: UkjentRolleException) {
             return Error.UkjentRolle(e.message!!)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
@@ -91,7 +91,7 @@ class MutationNyOppgave(
                 id = id,
                 produsentId = produsent.id,
                 kildeAppNavn = context.appName,
-                finnRolleId = produsentRepository::hentAltinnrolle
+                finnRolleId = produsentRepository.altinnRolle::hentAltinnrolle
             )
         }catch (e: UkjentRolleException){
             return Error.UkjentRolle(e.message!!)

--- a/app/src/main/resources/db/migration/bruker_model/V11__altinn_roller.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V11__altinn_roller.sql
@@ -1,0 +1,6 @@
+create table altinn_rolle
+(
+    role_definition_id   text not null primary key,
+    role_definition_code text not null unique
+);
+create index role_definition_code_idx on altinn_rolle (role_definition_code);

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/altinn_roller/AltinnRolleServiceImplTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/altinn_roller/AltinnRolleServiceImplTest.kt
@@ -1,0 +1,58 @@
+package no.nav.arbeidsgiver.notifikasjon.altinn_roller
+
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.AltinnRolle
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.AltinnRolleDefinisjon
+
+class AltinnRolleServiceImplTest : DescribeSpec({
+    val altinnRolleRepository = mockk<AltinnRolleRepository>()
+    val subject = AltinnRolleServiceImpl(mockk(), altinnRolleRepository)
+    describe("AltinnRolleService#hentAltinnrollerMedRetry") {
+        beforeContainer {
+            clearMocks(altinnRolleRepository)
+        }
+        context("når alle roller finnes i databasen") {
+            coEvery { altinnRolleRepository.hentAltinnrolle(any()) } returns AltinnRolle("1", "1")
+            val result = subject.hentAltinnrollerMedRetry(listOf(AltinnRolleDefinisjon("FOO")), 1, 0)
+
+            it("returnerer liste av roller for gitte rolledefinisjon") {
+                result shouldBe listOf(AltinnRolle("1", "1"))
+            }
+        }
+
+        context("når roller finnes i databasen etterhvert") {
+            coEvery {
+                altinnRolleRepository.hentAltinnrolle(any())
+            } throws RuntimeException("foo") andThen AltinnRolle("1", "1")
+            val result = subject.hentAltinnrollerMedRetry(listOf(AltinnRolleDefinisjon("FOO")), 1, 0)
+
+            it("returnerer liste av roller for gitte rolledefinisjon") {
+                result shouldBe listOf(AltinnRolle("1", "1"))
+            }
+
+            it("hentAltinnrolle blir kalt to ganger") {
+                coVerify(exactly = 2) {
+                    altinnRolleRepository.hentAltinnrolle(any())
+                }
+            }
+        }
+
+        context("når roller ikke finnes i databasen") {
+            coEvery {
+                altinnRolleRepository.hentAltinnrolle(any())
+            } throws RuntimeException("foo")
+
+            it("throws") {
+                shouldThrowAny {
+                    subject.hentAltinnrollerMedRetry(listOf(AltinnRolleDefinisjon("FOO")), 2, 0)
+                }
+            }
+        }
+    }
+})

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/AltinnReporteeTilgangsstyringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/AltinnReporteeTilgangsstyringTests.kt
@@ -7,7 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.AltinnReporteeMottaker
 import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.OffsetDateTime
@@ -15,7 +15,7 @@ import java.util.*
 
 class AltinnReporteeTilgangsstyringTests : DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val model = BrukerModelImpl(database)
+    val model = BrukerRepositoryImpl(database)
 
     fun lagMelding(id: UUID, fnr: String) = Hendelse.BeskjedOpprettet(
         virksomhetsnummer = "1",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/AltinnRolleTilgangsstyringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/AltinnRolleTilgangsstyringTests.kt
@@ -7,7 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.AltinnRolleMottaker
 import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.OffsetDateTime
@@ -15,7 +15,7 @@ import java.util.*
 
 class AltinnRolleTilgangsstyringTests : DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val model = BrukerModelImpl(database)
+    val model = BrukerRepositoryImpl(database)
 
     fun lagMelding(id: UUID, rolle: String) = Hendelse.BeskjedOpprettet(
         virksomhetsnummer = "1",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/AltinnTilgangsstyringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/AltinnTilgangsstyringTests.kt
@@ -7,7 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.OffsetDateTime
@@ -15,7 +15,7 @@ import java.util.*
 
 class AltinnTilgangsstyringTests : DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val model = BrukerModelImpl(database)
+    val model = BrukerRepositoryImpl(database)
 
     fun lagMelding(id: UUID, serviceCode: String) = Hendelse.BeskjedOpprettet(
         virksomhetsnummer = "1",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerApiTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerApiTests.kt
@@ -10,20 +10,21 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health.meterRegistry
 import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.OffsetDateTime
 import java.util.*
 
 class BrukerApiTests : DescribeSpec({
-    val queryModel: BrukerModelImpl = mockk()
+    val queryModel: BrukerRepositoryImpl = mockk()
 
     val engine = ktorBrukerTestServer(
         brukerGraphQL = BrukerAPI.createBrukerGraphQL(
             altinn = AltinnStub(),
             enhetsregisteret = EnhetsregisteretStub("43" to "el virksomhete"),
-            brukerModel = queryModel,
+            brukerRepository = queryModel,
+            altinnRoller = listOf(),
             kafkaProducer = mockk()
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerKlikkGraphQL_QueryModell_IntegrasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerKlikkGraphQL_QueryModell_IntegrasjonTests.kt
@@ -7,7 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.NærmesteLederMottaker
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModel
 import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModelImpl
 import no.nav.arbeidsgiver.notifikasjon.util.*
@@ -16,7 +16,7 @@ import java.util.*
 
 class BrukerKlikkGraphQL_QueryModell_IntegrasjonTests: DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val queryModel = BrukerModelImpl(database)
+    val queryModel = BrukerRepositoryImpl(database)
     val nærmesteLederModel = NærmesteLederModelImpl(database)
 
     val fnr = "00000000000"
@@ -27,8 +27,9 @@ class BrukerKlikkGraphQL_QueryModell_IntegrasjonTests: DescribeSpec({
     val engine = ktorBrukerTestServer(
         brukerGraphQL = BrukerAPI.createBrukerGraphQL(
             altinn = AltinnStub(),
+            altinnRoller = listOf(),
             enhetsregisteret = EnhetsregisteretStub(),
-            brukerModel = queryModel,
+            brukerRepository = queryModel,
             kafkaProducer = mockk(),
         )
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerModelIdempotensTests.kt
@@ -4,13 +4,13 @@ import io.kotest.core.datatest.forAll
 import io.kotest.core.spec.style.DescribeSpec
 import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 
 class BrukerModelIdempotensTests : DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val queryModel = BrukerModelImpl(database)
+    val queryModel = BrukerRepositoryImpl(database)
 
     describe("Idempotent oppførsel") {
         forAll<Hendelse>(EksempelHendelse.Alle) { hendelse ->

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerModelTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/BrukerModelTests.kt
@@ -6,10 +6,7 @@ import io.kotest.matchers.collections.shouldHaveSingleElement
 import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.NærmesteLederMottaker
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
-import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.*
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.OffsetDateTime
@@ -19,7 +16,7 @@ import java.util.*
 
 class BrukerModelTests : DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val queryModel = BrukerModelImpl(database)
+    val queryModel = BrukerRepositoryImpl(database)
     val nærmesteLederModel = NærmesteLederModelImpl(database)
 
     describe("Beskjed opprettet i BrukerModel") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/FeilhåndteringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/FeilhåndteringTests.kt
@@ -9,20 +9,21 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Altinn
 import no.nav.arbeidsgiver.notifikasjon.util.*
 
 class FeilhåndteringTests : DescribeSpec({
-    val queryModel: BrukerModelImpl = mockk()
+    val queryModel: BrukerRepositoryImpl = mockk()
 
     val altinn: Altinn = mockk()
 
     val engine = ktorBrukerTestServer(
         brukerGraphQL = BrukerAPI.createBrukerGraphQL(
             altinn = altinn,
+            altinnRoller = listOf(),
             enhetsregisteret = EnhetsregisteretStub("43" to "el virksomhete"),
-            brukerModel = queryModel,
+            brukerRepository = queryModel,
             kafkaProducer = mockk(),
         )
     )
@@ -31,7 +32,7 @@ class FeilhåndteringTests : DescribeSpec({
         context("Feil Altinn, DigiSyfo ok") {
 
             coEvery {
-                altinn.hentTilganger(any(), any(), any())
+                altinn.hentTilganger(any(), any(), any(), any())
             } throws RuntimeException("Mock failure")
 
             coEvery {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/HardDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/HardDeleteTests.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.NærmesteLederMottaker
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModel
 import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModelImpl
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -17,7 +17,7 @@ import java.util.*
 
 class HardDeleteTests : DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val queryModel = BrukerModelImpl(database)
+    val queryModel = BrukerRepositoryImpl(database)
     val nærmesteLederModel = NærmesteLederModelImpl(database)
 
     describe("HardDelete av notifikasjon") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/KlikkPåNotifikasjonGraphQLTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/KlikkPåNotifikasjonGraphQLTests.kt
@@ -11,7 +11,7 @@ import io.ktor.http.*
 import io.mockk.*
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLRequest
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.CoroutineKafkaProducer
@@ -21,14 +21,15 @@ import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.util.*
 
 class KlikkPåNotifikasjonGraphQLTests: DescribeSpec({
-    val queryModel: BrukerModelImpl = mockk(relaxed = true)
+    val queryModel: BrukerRepositoryImpl = mockk(relaxed = true)
     val kafkaProducer: CoroutineKafkaProducer<KafkaKey, Hendelse> = mockk()
 
     val engine = ktorBrukerTestServer(
         brukerGraphQL = BrukerAPI.createBrukerGraphQL(
             altinn = AltinnStub(),
+            altinnRoller = listOf(),
             enhetsregisteret = EnhetsregisteretStub(),
-            brukerModel = queryModel,
+            brukerRepository = queryModel,
             kafkaProducer = kafkaProducer,
         ),
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/NærmesteLederTilgangsstyringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/NærmesteLederTilgangsstyringTests.kt
@@ -2,26 +2,23 @@ package no.nav.arbeidsgiver.notifikasjon.bruker_api
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.shouldBeOneOf
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import no.nav.arbeidsgiver.notifikasjon.*
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModel.NærmesteLederFor
 import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModelImpl
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
-import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
 
 class NærmesteLederTilgangsstyringTests: DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val model = BrukerModelImpl(database)
+    val model = BrukerRepositoryImpl(database)
     val nærmesteLederModel = NærmesteLederModelImpl(database)
 
     describe("Tilgangsstyring av nærmeste leder") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/SoftDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker_api/SoftDeleteTests.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import no.nav.arbeidsgiver.notifikasjon.Bruker
 import no.nav.arbeidsgiver.notifikasjon.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.NærmesteLederMottaker
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModelImpl
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModel
 import no.nav.arbeidsgiver.notifikasjon.bruker.NærmesteLederModelImpl
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -17,7 +17,7 @@ import java.util.*
 
 class SoftDeleteTests : DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
-    val queryModel = BrukerModelImpl(database)
+    val queryModel = BrukerRepositoryImpl(database)
     val nærmesteLederModel = NærmesteLederModelImpl(database)
 
     describe("SoftDelete av notifikasjon") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/bruker_api/LocalMainBrukerAPI.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/bruker_api/LocalMainBrukerAPI.kt
@@ -2,7 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.executable.bruker_api
 
 import db.migration.OS
 import no.nav.arbeidsgiver.notifikasjon.Bruker
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel.Tilgang
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.HttpAuthProviders
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.MottakerRegister
 import no.nav.arbeidsgiver.notifikasjon.util.AltinnStub
@@ -37,7 +37,7 @@ fun main(@Suppress("UNUSED_PARAMETER") args: Array<String>) {
             )
             alleOrgnr.flatMap { orgnr ->
                 MottakerRegister.servicecodeDefinisjoner.map { tjeneste ->
-                    Tilgang.Altinn(
+                    BrukerModel.Tilgang.Altinn(
                         virksomhet = orgnr,
                         servicecode = tjeneste.code,
                         serviceedition = tjeneste.version,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/AltinnImplTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/AltinnImplTests.kt
@@ -8,7 +8,7 @@ import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.AltinnReportee
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.ServiceCode
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.ServiceEdition
 import no.nav.arbeidsgiver.altinnrettigheter.proxy.klient.model.Subject
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel.Tilgang
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.ServicecodeDefinisjon
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.unblocking.NonBlockingAltinnrettigheterProxyKlient
 
@@ -54,13 +54,14 @@ class AltinnImplTests : DescribeSpec({
                 true
             )
         } returns listOf(virksomhet2)
+        // TODO: legg til roller
 
-        val tilganger = altinn.hentTilganger(fnr, "token", listOf(def))
+        val tilganger = altinn.hentTilganger(fnr, "token", listOf(def), listOf())
 
         it("returnerer tilganger") {
             tilganger shouldContainExactlyInAnyOrder listOf(
-                Tilgang.Altinn("1", def.code, def.version),
-                Tilgang.AltinnReportee(fnr = fnr, virksomhet = "2")
+                BrukerModel.Tilgang.Altinn("1", def.code, def.version),
+                BrukerModel.Tilgang.AltinnReportee(fnr = fnr, virksomhet = "2")
             )
         }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/AltinnRollerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/AltinnRollerTests.kt
@@ -15,8 +15,9 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 class AltinnRollerTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
     val produsentRepo = ProdusentRepositoryImpl(database)
+    val rolleRepository = produsentRepo.altinnRolle
     val altinn = mockk<Altinn>()
-    val altinnservice = AltinnRolleServiceImpl(altinn, produsentRepo)
+    val altinnservice = AltinnRolleServiceImpl(altinn, rolleRepository)
 
     describe("oppførsel Altinnroller") {
         val altinnRoller = listOf(AltinnRolle("195", "DAGL"), AltinnRolle("196", "BOBE"))
@@ -26,30 +27,29 @@ class AltinnRollerTests : DescribeSpec({
 
             it("altinnservice legger 2 roller inn i db uten å kræsje") {
                 altinnservice.lastAltinnroller()
-                produsentRepo.hentAlleAltinnRoller().size shouldBe 2
+                rolleRepository.hentAlleAltinnRoller().size shouldBe 2
             }
 
             it("altinnservice legger ikke eksisterende roller inn i db") {
                 altinnservice.lastAltinnroller()
-                produsentRepo.hentAlleAltinnRoller().size shouldBe 2
+                rolleRepository.hentAlleAltinnRoller().size shouldBe 2
             }
 
             it("finner ikke ikkeeksisterende rolle") {
-                val dagligLederFraDB = produsentRepo.hentAltinnrolle("DOGL")
+                val dagligLederFraDB = rolleRepository.hentAltinnrolle("DOGL")
                 dagligLederFraDB?.RoleDefinitionId shouldBe null
             }
 
             it("feil hvis man prøver å legg inn eksisterende rolleid med ny rollekode") {
-                shouldThrowAny { produsentRepo.leggTilAltinnRolle(AltinnRolle("195", "DOGL")) }
+                shouldThrowAny { rolleRepository.leggTilAltinnRoller(listOf(AltinnRolle("195", "DOGL"))) }
             }
 
             it("feil hvis man prøver å legg inn eksisterende rollekode med ny rolleid") {
-                shouldThrowAny { produsentRepo.leggTilAltinnRolle(AltinnRolle("197", "DAGL")) }
+                shouldThrowAny { rolleRepository.leggTilAltinnRoller(listOf(AltinnRolle("197", "DAGL"))) }
             }
 
             it("altinnservice kaster en feil når en rolleid har fått ny rollekode") {
-                val altinnRoller = listOf(AltinnRolle("195", "DOGL"))
-                coEvery { altinn.hentRoller() } returns altinnRoller
+                coEvery { altinn.hentRoller() } returns listOf(AltinnRolle("195", "DOGL"))
                 shouldThrowAny { altinnservice.lastAltinnroller() }
             }
         }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyOppgaveFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyOppgaveFlereMottakereTests.kt
@@ -156,11 +156,9 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
     }
 
     describe("sender 1 altinnRolle i 'mottaker'") {
-        listOf(AltinnRolle("196", "DAGL"), AltinnRolle("195", "BOBE")).forEach {
-            produsentRepository.leggTilAltinnRolle(
-                it
-            )
-        }
+        produsentRepository.altinnRolle.leggTilAltinnRoller(
+            listOf(AltinnRolle("196", "DAGL"), AltinnRolle("195", "BOBE"))
+        )
 
         val response = engine.produsentApi(
             nyOppgave(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/TilgangsstyringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/TilgangsstyringTests.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.beOfType
+import io.mockk.every
 import io.mockk.mockk
 import no.nav.arbeidsgiver.notifikasjon.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.Error
@@ -19,7 +20,9 @@ class TilgangsstyringTests : DescribeSpec({
     val engine = ktorProdusentTestServer(
         produsentGraphQL = ProdusentAPI.newGraphQL(
             kafkaProducer = mockk(),
-            produsentRepository = mockk()
+            produsentRepository = mockk {
+                every { altinnRolle } returns mockk()
+            }
         )
     )
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/AltinnStub.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/AltinnStub.kt
@@ -21,7 +21,8 @@ open class AltinnStub(
     override suspend fun hentTilganger(
         fnr: String,
         selvbetjeningsToken: String,
-        tjenester: Iterable<ServicecodeDefinisjon>
+        tjenester: Iterable<ServicecodeDefinisjon>,
+        roller: Iterable<AltinnRolle>,
     ): List<BrukerModel.Tilgang> =
         hentAlleTilgangerImpl(fnr, selvbetjeningsToken)
 


### PR DESCRIPTION
Her er det lagt inn henting av roller fra db med retry, i tilfelle de ikke er blitt populert enda. 
Dersom de ikke dukker opp etter et antall retries så setter vi poden til ikke ready.

Det er også trukket ut en felles AltinnRolleRepository da både bruker-api og produsent-api trenger denne tabellen, repositoryet er komponert inn i BrukerRepo og ProdusentRepo. BrukerModel er endret til å kun omfatte modell klassene, med db access via BrukerRepository.
