### PR TITLE
flat ut argumenter til nySak/nySakStatus mutations

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -19,8 +19,13 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.laxObjectMapper
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import org.intellij.lang.annotations.Language
 
-inline fun <reified T> DataFetchingEnvironment.getTypedArgument(name: String): T =
+inline fun <reified T: Any?> DataFetchingEnvironment.getTypedArgument(name: String): T =
     laxObjectMapper.convertValue(this.getArgument(name))
+
+inline fun <reified T: Any?> DataFetchingEnvironment.getTypedArgumentOrNull(name: String): T? {
+    val value = this.getArgument<Any>(name) ?: return null
+    return laxObjectMapper.convertValue(value)
+}
 
 fun RuntimeWiring.Builder.wire(typeName: String, config: TypeRuntimeWiring.Builder.() -> Unit) {
     this.type(typeName) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -14,6 +14,7 @@ import no.nav.arbeidsgiver.notifikasjon.HendelseModel.SakOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.AltinnRolle
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgumentOrNull
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.CoroutineKafkaProducer
@@ -38,7 +39,19 @@ class MutationNySak(
             coDataFetcher("nySak") { env ->
                 nySak(
                     context = env.getContext(),
-                    nySak = env.getTypedArgument("sak")
+                    nySak = NySakInput(
+                        grupperingsid = env.getTypedArgument("grupperingsid"),
+                        merkelapp = env.getTypedArgument("merkelapp"),
+                        virksomhetsnummer = env.getTypedArgument("virksomhetsnummer"),
+                        mottakere = env.getTypedArgument("mottakere"),
+                        tittel = env.getTypedArgument("tittel"),
+                        lenke = env.getTypedArgument("lenke"),
+                        status = SaksStatusInput(
+                            status = env.getTypedArgument("initiell_status"),
+                            tidspunkt = env.getTypedArgumentOrNull("tidspunkt"),
+                            overstyrStatustekstMed = env.getTypedArgumentOrNull("overstyrStatustekstMed"),
+                        )
+                    )
                 )
             }
         }

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -207,38 +207,6 @@ enum EksterntVarselStatus {
     FEILET
 }
 
-input NySakInput {
-    """
-    Grupperings-id-en knytter en sak og notifikasjoner sammen.
-    Den skal være unik for saker innenfor merkelappen.
-    Et naturlig valg av grupperingsid er f.eks. et saksnummer.
-    """
-    grupperingsid: String!
-
-    """Merkelapp som saken skal assossieres med."""
-    merkelapp: String!
-
-    """Virksomhetsnummeret til virksomheten som saken omhandler."""
-    virksomhetsnummer: String!
-
-    """
-    Hvem som skal få se saken.
-
-    NB. At en bruker har tilgang til en sak påvirker ikke om de har tilgang
-    til en notifikasjon. De tilgangsstyres hver for seg.
-    """
-    mottakere: [MottakerInput!]!
-
-    """En tittel på saken, som vises til brukeren."""
-    tittel: String!
-
-    """Her oppgir dere en lenke som brukeren kan klikke på for å komme rett til saken."""
-    lenke: String!
-
-    """Status saken starter med."""
-    status: SaksStatusInput!
-}
-
 union NySakResultat =
     | NySakVellykket
     | UgyldigMerkelapp
@@ -249,30 +217,6 @@ union NySakResultat =
 
 type NySakVellykket {
     id: ID!
-}
-
-input NyStatusSakInput {
-    status: SaksStatusInput!
-
-    """
-    Dere kan bruke dette feltet for å få idempotent oppførsel på statusoppdateringe.
-    Hvis en sak får to oppdateringer med samme idempotencyKey, så anser vi oppdateringene
-    for som de samme. Vi sjekker kun for duplikate idempotencyKey i den aktuelle saken, ikke
-    på tvers av saker.
-
-    Det kan f.eks. brukes for å ha en retry-logikk ved feil eller å lettere kunne håndtere
-    at-least-once oppførsel ved bruk av hendelses-strømmer som Kafka.
-
-    Obs. Hvis dere har protenisielt repretereende statusoppdateringer
-    i sakene deres (f.eks. at inngåelsen av en avtale veksler mellom
-    statusene "klar-for"underskriving" og "kladd"), så må dere passe
-    på at dere ikke oppgir samme nøkkel flere ganger ved en feil,
-    slik at to oppdateringer som er forskjellige blir slått sammen
-    til en.
-
-    Feltet er frivillig. Det vises ikke til brukere.
-    """
-    idempotencyKey: String
 }
 
 union NyStatusSakResultat =
@@ -313,23 +257,6 @@ enum SaksStatus {
     FERDIG
 }
 
-input SaksStatusInput {
-    status: SaksStatus!
-
-    """
-    Når endringen skjedde. Det kan godt være i fortiden.
-    Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
-    kallet på.
-    """
-    tidspunkt: ISO8601DateTime
-
-    """
-    Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
-    til brukeren. Se `SaksStatus` for default tekster.
-    """
-    overstyrStatustekstMed: String
-}
-
 type StatusOppdatering {
     status: SaksStatus!
     tidspunkt: ISO8601DateTime!
@@ -341,11 +268,91 @@ Dette er roten som alle endringer ("mutations") starter fra. Endringer inkludere
 å opprette nye ting.
 """
 type Mutation {
-    nySak(sak: NySakInput!): NySakResultat!
+    nySak(
+        """
+        Grupperings-id-en knytter en sak og notifikasjoner sammen.
+        Den skal være unik for saker innenfor merkelappen.
+        Et naturlig valg av grupperingsid er f.eks. et saksnummer.
+        """
+        grupperingsid: String!
 
-    nyStatusSak(id: ID!, status: NyStatusSakInput!): NyStatusSakResultat!
+        """Merkelapp som saken skal assossieres med."""
+        merkelapp: String!
 
-    nyStatusSakByGrupperingsid(grupperingsid: String!, merkelapp: String!, status: NyStatusSakInput!): NyStatusSakResultat!
+        """Virksomhetsnummeret til virksomheten som saken omhandler."""
+        virksomhetsnummer: String!
+
+        """
+        Hvem som skal få se saken.
+
+        NB. At en bruker har tilgang til en sak påvirker ikke om de har tilgang
+        til en notifikasjon. De tilgangsstyres hver for seg.
+        """
+        mottakere: [MottakerInput!]!
+
+        """En tittel på saken, som vises til brukeren."""
+        tittel: String!
+
+        """Her oppgir dere en lenke som brukeren kan klikke på for å komme rett til saken."""
+        lenke: String!
+
+        """
+        """
+        initiell_status: SaksStatus!
+
+        """
+        Når endringen skjedde. Det kan godt være i fortiden.
+        Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
+        kallet på.
+        """
+        tidspunkt: ISO8601DateTime
+
+        """
+        Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
+        til brukeren. Se `SaksStatus` for default tekster.
+        """
+        overstyrStatustekstMed: String
+    ): NySakResultat!
+
+    nyStatusSak(
+        idempotencyKey: String
+        id: ID!
+        ny_status: SaksStatus!
+
+        """
+        Når endringen skjedde. Det kan godt være i fortiden.
+        Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
+        kallet på.
+        """
+        tidspunkt: ISO8601DateTime
+
+        """
+        Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
+        til brukeren. Se `SaksStatus` for default tekster.
+        """
+        overstyrStatustekstMed: String
+    ): NyStatusSakResultat!
+
+    nyStatusSakByGrupperingsid(
+        idempotencyKey: String
+        grupperingsid: String!
+        merkelapp: String!
+
+        ny_status: SaksStatus!
+
+        """
+        Når endringen skjedde. Det kan godt være i fortiden.
+        Dette feltet er frivillig. Hvis feltet ikke er oppgitt, bruker vi tidspunktet dere gjør
+        kallet på.
+        """
+        tidspunkt: ISO8601DateTime
+
+        """
+        Dette feltet er frivillig. Det lar deg overstyre hvilken tekst vi viser
+        til brukeren. Se `SaksStatus` for default tekster.
+        """
+        overstyrStatustekstMed: String
+    ): NyStatusSakResultat!
 
     """
     Opprett en ny beskjed.

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NySakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NySakTests.kt
@@ -104,7 +104,7 @@ private fun TestApplicationEngine.nySak(
     produsentApi(
         """
             mutation {
-                nySak(sak: {
+                nySak(
                     virksomhetsnummer: "1"
                     merkelapp: "$merkelapp"
                     grupperingsid: "$grupperingsid"
@@ -114,12 +114,11 @@ private fun TestApplicationEngine.nySak(
                             serviceEdition: "1"
                         }
                     }]
-                    status: {
-                        status: $status
-                    }
+                    initiell_status: $status
+                    tidspunkt: "2020-01-01T01:01Z"
                     tittel: "$tittel"
                     lenke: "$lenke"
-                }) {
+                ) {
                     __typename
                     ... on NySakVellykket {
                         id

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyStatusSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent_api/NyStatusSakTests.kt
@@ -81,22 +81,14 @@ private fun TestApplicationEngine.nyStatusSak(
     id: UUID,
     status: SaksStatus,
     idempotencyKey: String? = null,
-) =
-    produsentApi(
+): TestApplicationResponse {
+    return produsentApi(
         """
             mutation {
                 nyStatusSak(
                     id: "$id"
-                    status: {
-                        status: {
-                            status: $status
-                        }
-                        ${ if (idempotencyKey != null)
-                                """idempotencyKey: "$idempotencyKey" """
-                            else
-                                ""
-                        }
-                    }
+                    idempotencyKey: ${idempotencyKey?.let { "\"$it\"" }}
+                    ny_status: $status
                 ) {
                     __typename
                     ... on NyStatusSakVellykket {
@@ -106,6 +98,7 @@ private fun TestApplicationEngine.nyStatusSak(
             }
         """
     )
+}
 
 
 private fun TestApplicationEngine.nySak(
@@ -114,7 +107,7 @@ private fun TestApplicationEngine.nySak(
     produsentApi(
         """
             mutation {
-                nySak(sak: {
+                nySak(
                     virksomhetsnummer: "1"
                     merkelapp: "tag"
                     grupperingsid: "grupperingsid"
@@ -124,12 +117,10 @@ private fun TestApplicationEngine.nySak(
                             serviceEdition: "1"
                         }
                     }]
-                    status: {
-                        status: $status
-                    }
+                    initiell_status: $status
                     tittel: "tittel"
                     lenke: "lenke"
-                }) {
+                ) {
                     __typename
                     ... on NySakVellykket {
                         id


### PR DESCRIPTION
Vi så på hvordan vi kan flate ut input-ene til `nySak` og `nyStatusSak(ByGrupperingsid)`. Vi så egentlig ikke noe behov for å ha input-structene. Så vi gikk for en flat modell.