### PR TITLE
Bruk camel-case i graphql-api.

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -43,7 +43,7 @@ internal class MutationNySak(
                         tittel = env.getTypedArgument("tittel"),
                         lenke = env.getTypedArgument("lenke"),
                         status = SaksStatusInput(
-                            status = env.getTypedArgument("initiell_status"),
+                            status = env.getTypedArgument("initiellStatus"),
                             tidspunkt = env.getTypedArgumentOrNull("tidspunkt"),
                             overstyrStatustekstMed = env.getTypedArgumentOrNull("overstyrStatustekstMed"),
                         ),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyStatusSak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyStatusSak.kt
@@ -23,7 +23,7 @@ internal class MutationNyStatusSak(
     private fun DataFetchingEnvironment.getStatus() =
         NyStatusSakInput(
             status = SaksStatusInput(
-                status = getTypedArgument("ny_status"),
+                status = getTypedArgument("nyStatus"),
                 tidspunkt = getTypedArgumentOrNull("tidspunkt"),
                 overstyrStatustekstMed = getTypedArgumentOrNull("overstyrStatustekstMed"),
             ),

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -303,7 +303,7 @@ type Mutation {
 
         """
         """
-        initiell_status: SaksStatus!
+        initiellStatus: SaksStatus!
 
         """
         Når endringen skjedde. Det kan godt være i fortiden.
@@ -327,7 +327,7 @@ type Mutation {
     nyStatusSak(
         idempotencyKey: String
         id: ID!
-        ny_status: SaksStatus!
+        nyStatus: SaksStatus!
 
         """
         Når endringen skjedde. Det kan godt være i fortiden.
@@ -361,7 +361,7 @@ type Mutation {
         grupperingsid: String!
         merkelapp: String!
 
-        ny_status: SaksStatus!
+        nyStatus: SaksStatus!
 
         """
         Når endringen skjedde. Det kan godt være i fortiden.

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/perftest/PerfTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/perftest/PerfTest.kt
@@ -221,7 +221,7 @@ suspend fun nySak(count: Int, api: Api = Api.PRODUSENT_GCP) {
                               
                               tittel: \"${genererTittel()}\",                              
                               lenke: \"https://min-side-arbeidsgiver.dev.nav.no/min-side-arbeidsgiver/?bedrift=$virksomhet\",
-                              initiell_status: MOTTATT
+                              initiellStatus: MOTTATT
                           ) {
                               __typename
                               ... on NySakVellykket {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakTests.kt
@@ -126,7 +126,7 @@ private fun TestApplicationEngine.nySak(
                             serviceEdition: "1"
                         }
                     }]
-                    initiell_status: $status
+                    initiellStatus: $status
                     tidspunkt: "2020-01-01T01:01Z"
                     tittel: "$tittel"
                     lenke: "$lenke"

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
@@ -97,7 +97,7 @@ private fun TestApplicationEngine.nyStatusSak(
                 nyStatusSak(
                     id: "$id"
                     idempotencyKey: ${idempotencyKey?.let { "\"$it\"" }}
-                    ny_status: $status
+                    nyStatus: $status
                     ${hardDelete?.let {"""
                         hardDelete: {
                             nyTid: {
@@ -135,7 +135,7 @@ private fun TestApplicationEngine.nySak(
                             serviceEdition: "1"
                         }
                     }]
-                    initiell_status: $status
+                    initiellStatus: $status
                     tittel: "tittel"
                     lenke: "lenke"
                 ) {


### PR DESCRIPTION
Denne endringer er ikke bakoverkompatibel. Men, det er ingen som bruker
dette i prod. Vi har snakket med de to teamene som snart skal deploye til
prod, og de syntes det var greit.

- https://github.com/navikt/permitteringsmelding-notifikasjon/pull/2
- https://github.com/navikt/helse-arbeidsgiver-felles-backend/pull/50