### PR TITLE
endre ebrake sjekk slik at den ikke slås på når idle

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
@@ -249,7 +249,7 @@ class EksternVarslingRepository(
     suspend fun detectEmptyDatabase() {
         database.transaction {
             val databaseIsEmpty = executeQuery(
-                """select 1 from ekstern_varsel_kontaktinfo limit 1""", transform = {}
+                """select 1 from emergency_break limit 1""", transform = {}
             ).isEmpty()
 
             if (databaseIsEmpty) {


### PR DESCRIPTION
siden vi sletter kontaktinfo når ekstern varsling er sendt og kvittert i db, så vil ebrake skrus på med en gang vi ikke har noe aktive utsendinger.
Intensjonen med ebrake var å detektere at vi hadde mistet databasen og på den måten unngå utsending av allerede utsendte notifikasjoner.
Endrer derfor til å sjekke om det finnes en rad i ebrake. Denne tømmes aldri og er populert av migreringsscriptene.

TAG-1892