### PR TITLE
http client metric cleanup

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpClientMetricsFeature.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/HttpClientMetricsFeature.kt
@@ -89,7 +89,7 @@ class HttpClientMetricsFeature internal constructor(
     }
 
     private fun HttpRequestBuilder.urlTagValue() =
-        "${url.let { "${it.protocol.name}://${it.host}${it.port}" }}${attributes[measureKey].path}"
+        "${url.let { "${it.protocol.name}://${it.host}:${it.port}" }}${attributes[measureKey].path}"
 }
 
 private data class ClientCallMeasure(


### PR DESCRIPTION
fjern active requests
featuren ser ut til å fungere lokalt på tvers av klienter.
i dev ser jeg kun metrikker på en klient
i prod ser alle metrikkene ut til å være flate med 0 eller 1 verdi

🤔 