### PR TITLE
gjør conflict sjekk helt generell

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:12.10
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -410,9 +410,8 @@ class BrukerRepositoryImpl(
     private suspend fun oppdaterModellEtterBrukerKlikket(brukerKlikket: BrukerKlikket) {
         database.nonTransactionalExecuteUpdate(
             """
-            INSERT INTO brukerklikk(fnr, notifikasjonsid) VALUES (?, ?)
-            ON CONFLICT ON CONSTRAINT brukerklikk_pkey
-            DO NOTHING
+            insert into brukerklikk(fnr, notifikasjonsid) values (?, ?)
+            on conflict do nothing
         """
         ) {
             string(brukerKlikket.fnr)
@@ -437,7 +436,7 @@ class BrukerRepositoryImpl(
                     virksomhetsnummer
                 )
                 values ('BESKJED', 'NY', ?, ?, ?, ?, ?, ?, ?, ?)
-                on conflict on constraint notifikasjon_pkey do nothing;
+                on conflict do nothing;
             """
             ) {
                 uuid(beskjedOpprettet.notifikasjonId)
@@ -468,7 +467,7 @@ class BrukerRepositoryImpl(
                     id, virksomhetsnummer, tittel, lenke, merkelapp
                 )
                 values (?, ?, ? ,?, ?)
-                on conflict on constraint sak_pkey do nothing;
+                on conflict do nothing;
             """
             ) {
                 uuid(sakOpprettet.sakId)
@@ -503,7 +502,7 @@ class BrukerRepositoryImpl(
                     id, sak_id, status, overstyrt_statustekst, tidspunkt 
                 )
                 values (?, ?, ?, ?, ?)
-                on conflict on constraint sak_status_pkey do nothing;
+                on conflict do nothing;
             """
             ) {
                 uuid(nyStatusSak.hendelseId)
@@ -649,7 +648,7 @@ class BrukerRepositoryImpl(
                     virksomhetsnummer
                 )
                 values ('OPPGAVE', 'NY', ?, ?, ?, ?, ?, ?, ?, ?)
-                on conflict on constraint notifikasjon_pkey do nothing;
+                on conflict do nothing;
             """
             ) {
                 uuid(oppgaveOpprettet.notifikasjonId)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
@@ -163,7 +163,7 @@ class EksternVarslingRepository(
                 ?, /* sendetidspunkt */
                 'NY' /* tilstand */
             )
-            ON CONFLICT (varsel_id) DO NOTHING;
+            ON CONFLICT DO NOTHING;
         """) {
             uuid(varsel.varselId)
             uuid(notifikasjonsId)
@@ -210,7 +210,7 @@ class EksternVarslingRepository(
                 ?, /* sendetidspunkt */
                 'NY' /* tilstand */
             )
-            ON CONFLICT (varsel_id) DO NOTHING;
+            ON CONFLICT DO NOTHING;
         """) {
             uuid(varsel.varselId)
             uuid(notifikasjonsId)
@@ -485,7 +485,7 @@ class EksternVarslingRepository(
                 ) 
                 insert into job_queue (varsel_id, locked) 
                 select varsel_id, false as locked from selected
-                on conflict (varsel_id) do nothing
+                on conflict do nothing
             """,
         ) {
             timestamp(scheduledAt)
@@ -539,7 +539,7 @@ internal fun Transaction.putOnJobQueue(varselId: UUID) {
     executeUpdate(
         """
             insert into job_queue(varsel_id, locked) values (?, false)
-            on conflict (varsel_id) do nothing;
+            on conflict do nothing;
         """
     ) {
         uuid(varselId)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -235,7 +235,7 @@ class ProdusentRepositoryImpl(
             executeUpdate("""
                     insert into sak(id, merkelapp, grupperingsid, virksomhetsnummer, mottakere, tittel, lenke, tidspunkt_mottatt)
                     values (?, ?, ?, ?, ?::jsonb, ?, ?, now())
-                    on conflict on constraint grupperingsid_unique do nothing
+                    on conflict do nothing
                 """
             ) {
                 uuid(sakOpprettet.sakId)
@@ -249,7 +249,7 @@ class ProdusentRepositoryImpl(
 
             executeUpdate("""
                 insert into sak_id (incoming_sak_id, sak_id) values (?, ?)
-                on conflict on constraint sak_id_pkey do nothing
+                on conflict do nothing
             """) {
                 uuid(sakOpprettet.sakId)
                 uuid(sakOpprettet.sakId)
@@ -275,7 +275,7 @@ class ProdusentRepositoryImpl(
                 insert into sak_status
                 (id, idempotence_key, sak_id, status, overstyr_statustekst_med, tidspunkt_oppgitt, tidspunkt_mottatt)
                 values (?, ?, ?, ?, ?, ?, ?)
-                on conflict on constraint sak_status_pkey do nothing;
+                on conflict do nothing;
             """) {
                 uuid(nyStatusSak.hendelseId)
                 string(nyStatusSak.idempotensKey)
@@ -364,7 +364,7 @@ class ProdusentRepositoryImpl(
                     virksomhetsnummer
                 )
                 values ('BESKJED', 'NY', ?, ?, ?, ?, ?, ?, ?, ?)
-                on conflict on constraint notifikasjon_pkey do nothing;
+                on conflict do nothing;
             """
             ) {
                 uuid(beskjedOpprettet.notifikasjonId)
@@ -389,7 +389,7 @@ class ProdusentRepositoryImpl(
                     status
                 )
                 values (?, ?, 'NY')
-                on conflict on constraint eksternt_varsel_pkey do nothing;
+                on conflict do nothing;
                 """,
                 beskjedOpprettet.eksterneVarsler
             ) { eksterntVarsel ->
@@ -416,7 +416,7 @@ class ProdusentRepositoryImpl(
                     virksomhetsnummer
                 )
                 values ('OPPGAVE', 'NY', ?, ?, ?, ?, ?, ?, ?, ?)
-                on conflict on constraint notifikasjon_pkey do nothing;
+                on conflict do nothing;
             """
             ) {
                 uuid(oppgaveOpprettet.notifikasjonId)
@@ -441,7 +441,7 @@ class ProdusentRepositoryImpl(
                     status
                 )
                 values (?, ?, 'NY')
-                on conflict on constraint eksternt_varsel_pkey do nothing;
+                on conflict do nothing;
                 """,
                 oppgaveOpprettet.eksterneVarsler
             ) { eksterntVarsel ->

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/statistikk/StatistikkModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/statistikk/StatistikkModel.kt
@@ -261,7 +261,7 @@ class StatistikkModel(
                     insert into notifikasjon 
                         (produsent_id, notifikasjon_id, notifikasjon_type, merkelapp, mottaker, checksum, opprettet_tidspunkt)
                     values (?, ?, 'beskjed', ?, ?, ?, ?)
-                    on conflict on constraint notifikasjon_pkey do nothing;
+                    on conflict do nothing;
                     """
                 ) {
                     string(hendelse.produsentId)
@@ -292,7 +292,7 @@ class StatistikkModel(
                     )
                     values
                     (?, ?, 'oppgave', ?, ?, ?, ?)
-                    on conflict on constraint notifikasjon_pkey do nothing;
+                    on conflict do nothing;
                     """
                 ) {
                     string(hendelse.produsentId)
@@ -327,7 +327,7 @@ class StatistikkModel(
                     insert into notifikasjon_klikk 
                         (hendelse_id, notifikasjon_id, klikket_paa_tidspunkt)
                     values (?, ?, ?)
-                    on conflict on constraint notifikasjon_klikk_pkey do nothing;
+                    on conflict do nothing;
                     """
                 ) {
                     uuid(hendelse.hendelseId)
@@ -342,7 +342,7 @@ class StatistikkModel(
                         (hendelse_id, varsel_id, notifikasjon_id, produsent_id, status)
                     values
                     (?, ?, ?, ?, 'vellykket')
-                    on conflict on constraint varsel_resultat_pkey do nothing;
+                    on conflict do nothing;
                     """
                 ) {
                     uuid(hendelse.hendelseId)
@@ -358,7 +358,7 @@ class StatistikkModel(
                         (hendelse_id, varsel_id, notifikasjon_id, produsent_id, status, feilkode)
                     values
                         (?, ?, ?, ?, 'feilet', ?)
-                    on conflict on constraint varsel_resultat_pkey do nothing;
+                    on conflict do nothing;
                     """
                 ) {
                     uuid(hendelse.hendelseId)
@@ -400,7 +400,7 @@ class StatistikkModel(
                     insert into sak 
                         (produsent_id, sak_id, merkelapp, mottaker, opprettet_tidspunkt)
                     values (?, ?, ?, ?, ?)
-                    on conflict on constraint sak_pkey do nothing;
+                    on conflict do nothing;
                     """
                 ) {
                     string(hendelse.produsentId)
@@ -427,7 +427,7 @@ class StatistikkModel(
                 (varsel_id, varsel_type, notifikasjon_id, produsent_id, mottaker)
             values
                 (?, ?, ?, ?, ?)
-            on conflict (varsel_id) do nothing;
+            on conflict do nothing;
             """,
             iterable
         ) { eksterntVarsel ->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   postgres:
-    image: "postgres"
+    image: "postgres:12.10"
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
det virker som at rekkefølgen på constraint sjekkene ikke er deterministiske. I prod har dette ført til at man har intermittent feil som løser seg selv ved retry av en consumer record.
Litt kjipere er det når feilen oppstår på selve api kallet og vi returnerer feilmelding til produsenten. Da virker det for dem som det feilet, men det gikk faktisk bra likevel.
Denne endringen bør løse det problemet.