### PR TITLE
Revert "legg til maskering av throwableproxy.message også"

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/MaskingAppender.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/MaskingAppender.kt
@@ -1,11 +1,10 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging
 
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.spi.IThrowableProxy
 import ch.qos.logback.core.Appender
 import ch.qos.logback.core.AppenderBase
 
-class MaskingAppender : AppenderBase<ILoggingEvent>() {
+class MaskingAppender: AppenderBase<ILoggingEvent>() {
 
     var appender: Appender<ILoggingEvent>? = null
 
@@ -14,12 +13,6 @@ class MaskingAppender : AppenderBase<ILoggingEvent>() {
             object : ILoggingEvent by event {
                 override fun getFormattedMessage(): String? =
                     mask(event.formattedMessage)
-
-                override fun getThrowableProxy(): IThrowableProxy =
-                    object : IThrowableProxy by event.throwableProxy {
-                        override fun getMessage(): String? =
-                            mask(event.throwableProxy.message)
-                    }
             }
         )
     }


### PR DESCRIPTION
Reverts navikt/arbeidsgiver-notifikasjon-produsent-api#295

Noe gikk veldig galt her som resulterer i at loggene blir tomme. 