### PR TITLE
ny fiks for maskering av fnr i stacktraces, denne gangen nullsafe

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/MaskingAppender.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/MaskingAppender.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging
 
 import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.IThrowableProxy
 import ch.qos.logback.core.Appender
 import ch.qos.logback.core.AppenderBase
 
@@ -13,6 +14,17 @@ class MaskingAppender: AppenderBase<ILoggingEvent>() {
             object : ILoggingEvent by event {
                 override fun getFormattedMessage(): String? =
                     mask(event.formattedMessage)
+
+                override fun getThrowableProxy(): IThrowableProxy? {
+                    if (event.throwableProxy == null) {
+                        return null
+                    }
+                    return object : IThrowableProxy by event.throwableProxy {
+                        override fun getMessage(): String? =
+                            mask(event.throwableProxy.message)
+                    }
+                }
+
             }
         )
     }


### PR DESCRIPTION
I forrige episode forsøkte jeg å fikse fnr i stacktrace men endte med å fjerne logging 🤦‍♂️ 
i denne episoden tar vi høyde for null og fikser problemet uten å fjerne all logging 