### PR TITLE
feil i prod hvor to det opprettes statusoppdatering på sakid som ikke finnes

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
@@ -24,7 +24,7 @@ object ProdusentModel {
         val mottakere: List<Mottaker>,
         val opprettetTidspunkt: OffsetDateTime,
     ) {
-        fun statusoppdateringIkkeRegistrert() =
+        fun statusoppdateringRegistrert() =
             statusoppdateringer.any { it.idempotencyKey.startsWith(IdempotenceKey.initial()) }
     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -104,7 +104,7 @@ internal class MutationNySak(
             nySak.erDuplikatAv(eksisterende) -> {
                 if (eksisterende.statusoppdateringIkkeRegistrert()) {
                     log.info("statusoppdatering ikke registrert for duplisert opprettelse av sak med id ${eksisterende.id}")
-                    hendelseDispatcher.send(statusoppdateringHendelse)
+                    hendelseDispatcher.send(statusoppdateringHendelse.copy(sakId = eksisterende.id))
                 } else {
                     log.info("duplisert opprettelse av sak med id ${eksisterende.id}")
                 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -102,11 +102,11 @@ internal class MutationNySak(
                 )
             }
             nySak.erDuplikatAv(eksisterende) -> {
-                if (eksisterende.statusoppdateringIkkeRegistrert()) {
+                if (eksisterende.statusoppdateringRegistrert()) {
+                    log.info("duplisert opprettelse av sak med id ${eksisterende.id}")
+                } else {
                     log.info("statusoppdatering ikke registrert for duplisert opprettelse av sak med id ${eksisterende.id}")
                     hendelseDispatcher.send(statusoppdateringHendelse.copy(sakId = eksisterende.id))
-                } else {
-                    log.info("duplisert opprettelse av sak med id ${eksisterende.id}")
                 }
 
                 NySakVellykket(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/autoslett/AutoSlettServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/autoslett/AutoSlettServiceTest.kt
@@ -8,7 +8,7 @@ import io.mockk.mockk
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem.AUTOSLETT_SERVICE
-import no.nav.arbeidsgiver.notifikasjon.util.StubbedHendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.Duration
 import java.time.Instant
@@ -18,7 +18,7 @@ import java.util.*
 
 class AutoSlettServiceTest : DescribeSpec({
 
-    val kafkaProducer = StubbedHendelseProdusent()
+    val kafkaProducer = FakeHendelseProdusent()
     val repo = mockk<AutoSlettRepository>()
     val service = AutoSlettService(repo, kafkaProducer)
     val nåTidspunkt = Instant.parse("2020-01-01T20:20:01.01Z")

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NyLenkeTilSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NyLenkeTilSakTests.kt
@@ -2,10 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.bruker
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import no.nav.arbeidsgiver.notifikasjon.bruker.Bruker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.IdempotenceKey
 import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.OffsetDateTime

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
@@ -15,7 +15,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.EksterntVarselVel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SmsVarselKontaktinfo
 import no.nav.arbeidsgiver.notifikasjon.tid.LokalOsloTid
-import no.nav.arbeidsgiver.notifikasjon.util.StubbedHendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.LocalDateTime
@@ -27,7 +27,7 @@ import kotlin.time.ExperimentalTime
 class EksternVarslingServiceTests : DescribeSpec({
     val database = testDatabase(EksternVarsling.databaseConfig)
     val repository = EksternVarslingRepository(database)
-    val hendelseProdusent = StubbedHendelseProdusent()
+    val hendelseProdusent = FakeHendelseProdusent()
     val meldingSendt = AtomicBoolean(false)
 
     val service = EksternVarslingService(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakDuplisertTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakDuplisertTests.kt
@@ -1,0 +1,120 @@
+package no.nav.arbeidsgiver.notifikasjon.produsent.api
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
+import io.ktor.server.testing.*
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
+import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.util.*
+import java.time.OffsetDateTime
+import java.util.*
+
+private val sakOpprettet = HendelseModel.SakOpprettet(
+    hendelseId = uuid("1"),
+            virksomhetsnummer = "1",
+            produsentId = "1",
+            kildeAppNavn = "test",
+            sakId = uuid("1"),
+            grupperingsid = "grupperingsid",
+            merkelapp = "tag",
+            mottakere = listOf(HendelseModel.AltinnMottaker(
+                serviceCode = "5441",
+                serviceEdition = "1",
+                virksomhetsnummer = "1"
+            )),
+            tittel = "foo",
+            lenke = "#foo",
+            oppgittTidspunkt = null,
+            mottattTidspunkt = OffsetDateTime.now(),
+            hardDelete = null,
+)
+
+class NySakDuplisertTests: DescribeSpec({
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+    val hendelseProdusent = FakeHendelseProdusent()
+    val engine = ktorProdusentTestServer(
+        kafkaProducer = hendelseProdusent,
+        produsentRepository = produsentRepository,
+    )
+
+    describe("opprett nySak to ganger med samme input") {
+        val response1 = engine.nySak()
+        it("should be successfull") {
+            response1.getTypedContent<String>("$.nySak.__typename") shouldBe "NySakVellykket"
+        }
+        val id1 = response1.getTypedContent<UUID>("$.nySak.id")
+
+        val response2 = engine.nySak()
+        it("opprett enda en sak should be successfull") {
+            response2.getTypedContent<String>("$.nySak.__typename") shouldBe "NySakVellykket"
+        }
+        val id2 = response2.getTypedContent<UUID>("$.nySak.id")
+
+        it("samme id") {
+            id1 shouldBe id2
+        }
+
+        it("det er to hendelser med samme sakId i kafka") {
+            hendelseProdusent.hendelser shouldHaveSize 2
+            hendelseProdusent.hendelser[0].aggregateId shouldBe id1
+            hendelseProdusent.hendelser[1].aggregateId shouldBe id1
+        }
+    }
+
+    describe("opprett ny sak og det finnes en delvis feilet saksopprettelse") {
+        hendelseProdusent.clear()
+        hendelseProdusent.hendelser.add(sakOpprettet)
+        produsentRepository.oppdaterModellEtterHendelse(sakOpprettet)
+
+        val response1 = engine.nySak()
+        it("should be successfull") {
+            response1.getTypedContent<String>("$.nySak.__typename") shouldBe "NySakVellykket"
+        }
+        val id1 = response1.getTypedContent<UUID>("$.nySak.id")
+        it("opprinnelig sakId returneres") {
+            id1 shouldBe sakOpprettet.sakId
+        }
+        it("statushendelsen i kafka har opprinelig sakId") {
+            hendelseProdusent.hendelser shouldHaveSize 2
+            hendelseProdusent.hendelser[0].aggregateId shouldBe id1
+            hendelseProdusent.hendelser[1].aggregateId shouldBe id1
+            hendelseProdusent.hendelser[0] should beInstanceOf<HendelseModel.SakOpprettet>()
+            hendelseProdusent.hendelser[1] should beInstanceOf<HendelseModel.NyStatusSak>()
+        }
+    }
+})
+
+
+private fun TestApplicationEngine.nySak(
+    status: SaksStatus = SaksStatus.MOTTATT,
+) =
+    produsentApi(
+        """
+            mutation {
+                nySak(
+                    virksomhetsnummer: "${sakOpprettet.virksomhetsnummer}"
+                    merkelapp: "${sakOpprettet.merkelapp}"
+                    grupperingsid: "${sakOpprettet.grupperingsid}"
+                    mottakere: [{
+                        altinn: {
+                            serviceCode: "5441"
+                            serviceEdition: "1"
+                        }
+                    }]
+                    initiellStatus: $status
+                    tittel: "${sakOpprettet.tittel}"
+                    lenke: "${sakOpprettet.lenke}"
+                ) {
+                    __typename
+                    ... on NySakVellykket {
+                        id
+                    }
+                }
+            }
+        """
+    )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakTests.kt
@@ -9,7 +9,7 @@ import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
-import no.nav.arbeidsgiver.notifikasjon.util.StubbedHendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -19,7 +19,7 @@ import java.util.*
 class NySakTests: DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
     val produsentRepository = ProdusentRepositoryImpl(database)
-    val stubbedKafkaProducer = StubbedHendelseProdusent()
+    val stubbedKafkaProducer = FakeHendelseProdusent()
     val engine = ktorProdusentTestServer(
         kafkaProducer = stubbedKafkaProducer,
         produsentRepository = produsentRepository,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
@@ -14,7 +14,7 @@ import java.time.LocalDateTime
 import java.util.*
 
 class NyStatusSakTests: DescribeSpec({
-    val stubbedKafkaProducer = StubbedHendelseProdusent()
+    val stubbedKafkaProducer = FakeHendelseProdusent()
 
     val database = testDatabase(Produsent.databaseConfig)
     val produsentRepository = ProdusentRepositoryImpl(database)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/OppgaveUtførtTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/OppgaveUtførtTests.kt
@@ -10,7 +10,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveUtført
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
-import no.nav.arbeidsgiver.notifikasjon.util.StubbedHendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -21,7 +21,7 @@ import java.util.*
 class OppgaveUtførtTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
     val produsentModel = ProdusentRepositoryImpl(database)
-    val stubbedKafkaProducer = StubbedHendelseProdusent()
+    val stubbedKafkaProducer = FakeHendelseProdusent()
 
     val engine = ktorProdusentTestServer(
         kafkaProducer = stubbedKafkaProducer,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/FakeHendelseProdusent.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/FakeHendelseProdusent.kt
@@ -4,7 +4,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import java.util.*
 
-class StubbedHendelseProdusent: HendelseProdusent {
+class FakeHendelseProdusent: HendelseProdusent {
     val hendelser = mutableListOf<HendelseModel.Hendelse>()
 
     inline fun <reified T> hendelserOfType() = hendelser.filterIsInstance<T>()
@@ -17,5 +17,9 @@ class StubbedHendelseProdusent: HendelseProdusent {
         hendelser.removeIf {
             it.hendelseId == key
         }
+    }
+
+    fun clear() {
+        hendelser.clear()
     }
 }


### PR DESCRIPTION
Fra det jeg kan se er dette en bug som skjer dersom to like saker forsøkes opprettes. Denne endringen sørger for at sakId blir riktig på statusoppdateringen, men jeg lurer på om problemet egentlig er logikken i statusoppdateringIkkeRegistrert 🤔

se også:
* https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/307