### PR TITLE
hopepr over statusoppdateringer hvos sak ikke finnes

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -495,6 +495,20 @@ class BrukerRepositoryImpl(
     }
 
     private suspend fun oppdaterModellEtterNyStatusSak(nyStatusSak: NyStatusSak) {
+        val sakFinnes = database.nonTransactionalExecuteQuery(
+            """
+                    select exists(select 1 from sak where id=?) as exists
+                """, {
+                uuid(nyStatusSak.sakId)
+            }) {
+            getBoolean("exists")
+        }[0]
+
+        if (!sakFinnes) {
+            log.warn("hopper over oppdaterModellEtterNyStatusSak for sak {} som ikke finnes", nyStatusSak.sakId)
+            return
+        }
+
         database.transaction {
             executeUpdate(
                 """

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelTests.kt
@@ -3,11 +3,10 @@ package no.nav.arbeidsgiver.notifikasjon.bruker
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldHaveSingleElement
-import no.nav.arbeidsgiver.notifikasjon.bruker.Bruker
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel.Tilganger
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NærmesteLederMottaker
-import no.nav.arbeidsgiver.notifikasjon.bruker.*
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel.Tilganger
+import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.OffsetDateTime
@@ -110,6 +109,20 @@ class BrukerModelTests : DescribeSpec({
                     id = uuid,
                     klikketPaa = false
                 )
+            }
+        }
+
+        context("prodfeil: statusoppdatering på sak som ikke finnes") {
+            /**
+             * underliggende årsak diskuteres her:
+             * https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/306
+             */
+            queryModel.oppdaterModellEtterHendelse(EksempelHendelse.NyStatusSak)
+
+            it("oppdaterModellEtterHendelse feiler ikke") {
+                shouldNotThrowAny {
+                    queryModel.oppdaterModellEtterHendelse(event)
+                }
             }
         }
     }


### PR DESCRIPTION
Denne PRen løser proppen på partisjonen i prod ved at vi hopper over statusoppdateringer på saker som ikke finnes i bruker-api. 

Underliggende feil diskuteres og løses her:
* https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/306