### PR TITLE
Cache calls to tokenx.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -217,6 +217,12 @@
             <artifactId>caffeine</artifactId>
             <version>3.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.sksamuel.aedile</groupId>
+            <artifactId>aedile-core</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
 
         <!-- test dependencies -->
         <dependency>

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
@@ -54,27 +54,27 @@ class TokenXClientImpl(
     private val algorithm: JWSAlgorithm = JWSAlgorithm.RS256
     private val jwsHeader: JWSHeader
 
+    @OptIn(ExperimentalTime::class)
     private val tokenCache = caffeineBuilder<String, AccessToken> {
         maximumSize = 5_000L
 
         expireAfter = (object : Expiry<String, AccessToken> {
-            override fun expireAfterCreate(key: String, response: AccessToken, currentTime: Long): Long {
-                return TimeUnit.SECONDS.toNanos(response.expires_in - cacheExpiryMarginSeconds)
-            }
+            override fun expireAfterCreate(key: String, response: AccessToken, currentTime: Long) =
+                (response.expires_in.seconds - 5.seconds).inWholeNanoseconds
 
             override fun expireAfterUpdate(
                 key: String,
                 value: AccessToken,
                 currentTime: Long,
                 currentDuration: Long
-            ): Long = currentDuration
+            ) = currentDuration
 
             override fun expireAfterRead(
                 key: String,
                 value: AccessToken,
                 currentTime: Long,
                 currentDuration: Long
-            ): Long = currentDuration
+            ) = currentDuration
         })
     }
         .build()

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
@@ -89,7 +89,7 @@ class TokenXClientImpl(
     }
 
     override suspend fun exchange(subjectToken: String, audience: String): String =
-        tokenCache.get(subjectToken) {
+        tokenCache.get("$audience $subjectToken") {
             val assertion = makeClientAssertion()
 
             val accessTokenResponse = httpClient.post(config.tokenEndpoint) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
@@ -23,7 +23,6 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.HttpClientMetricsFeature
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
 import java.time.Instant
 import java.util.*
-import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
@@ -41,11 +40,10 @@ interface TokenXClient {
     suspend fun exchange(subjectToken: String, audience: String): String
 }
 
-private const val cacheExpiryMarginSeconds = 5L
-
 /**
  * lånt med modifikasjon fra https://github.com/navikt/tokendings-latency-tester/tree/master/src/main/kotlin/no/nav
  */
+@OptIn(ExperimentalTime::class)
 class TokenXClientImpl(
     private val httpClient: HttpClient = defaultHttpClient(),
     private val config: TokenXConfig = TokenXConfig(),
@@ -54,7 +52,6 @@ class TokenXClientImpl(
     private val algorithm: JWSAlgorithm = JWSAlgorithm.RS256
     private val jwsHeader: JWSHeader
 
-    @OptIn(ExperimentalTime::class)
     private val tokenCache = caffeineBuilder<String, AccessToken> {
         maximumSize = 5_000L
 
@@ -110,7 +107,6 @@ class TokenXClientImpl(
             .access_token
 
 
-    @OptIn(ExperimentalTime::class)
     private val clientAssertionCache = caffeineBuilder<Unit, String> {
         maximumSize = 1
         expireAfterWrite = 30.seconds


### PR DESCRIPTION
A call for access rights has a 1:N fan-out, where all the calls can share tokenx access token.