### PR TITLE
forsøk på å fikse slik at samtidige kall ikke avbryter andre ved feil

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/altinn/Altinn.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/altinn/Altinn.kt
@@ -5,7 +5,6 @@ import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.Caffeine
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.supervisorScope
@@ -50,7 +49,7 @@ class AltinnImpl(
         roller: Iterable<AltinnRolle>,
     ): Tilganger =
         timer.coRecord {
-            coroutineScope {
+            supervisorScope {
                 val tjenesteTilganger = tjenester.map {
                     val (code, version) = it
                     async {
@@ -66,7 +65,7 @@ class AltinnImpl(
                 val reporteeTilganger = async {
                     hentTilganger(fnr, selvbetjeningsToken)
                 }
-                return@coroutineScope tjenesteTilganger.awaitAll().flatten() +
+                return@supervisorScope tjenesteTilganger.awaitAll().flatten() +
                         reporteeTilganger.await() +
                         rolleTilganger.awaitAll().flatten()
             }


### PR DESCRIPTION
hentTilganger kaller altinn med concurrency og hvis en av disse feiler så blir parent job canceled og hele kallet feiler. Dersom en av de andre sibling coroutines fortsatt pågår,blir denne avbrutt av parenten. Dette er det vi ser i prod i dag.

Vi er litt usikker på akkurat hva som forårsaker feilsituasjonen, men mistenker at det har noe med token exchange og cachingen av dette å gjøre (kanskje i samspill med ktor plugin vi laget). Virker som det av og til havner i en rar state, og da feiler alle påfølgende kall, og en restart av poden løser det.

Oppførselen vi ser står veldig godt beskrevet under Structured concurrency i Coroutines kapittelet i Kotlin Design Patterns and Best Practices:

> It is a very common practice to spawn coroutines from inside another coroutine.
> The first rule of structured concurrency is that the parent coroutine should always wait for all its children to complete. This prevents resource leaks, which is very common in languages that don't have the structured concurrency concept.
> ... Now, let's decide that one of the coroutines throws an exception after some time: ...
> If you run this code, something interesting happens. Not only does the coroutine itself terminate, but also all its siblings are terminated as well.
>  What happens here is that an uncaught exception bubbles up to the parent coroutine and cancels it. Then, the parent coroutine terminates all the other child coroutines to prevent any resource leaks.
>  Usually, this is the desired behavior. If we'd like to prevent child exceptions from stopping the parent as well, we can use supervisorScope