### PR TITLE
reduser kardinalitet på tag i prometheus

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Enhetsregisteret.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Enhetsregisteret.kt
@@ -50,6 +50,7 @@ class EnhetsregisteretImpl(
         }
         install(HttpClientMetricsFeature) {
             registry = Metrics.meterRegistry
+            staticPath = "/enhetsregisteret/api/underenheter/"
         }
         expectSuccess = false
     }


### PR DESCRIPTION
Siden orgnr er en del av path-en i kall mot enhetsregisteret, så blir det alt for stor kardinalitet på eventene (en for hvert orgnr).