### PR TITLE
PeriodicReplayer: Automatisk delvis replay av hendelser

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -80,8 +80,8 @@ private constructor(
         consumer,
         isBigLeap = { t -> t.minute % 30 == 0 },
         isSmallLeap = { t -> t.minute % 2 == 0 },
-        bigLeap = 10,
-        smallLeap = 1,
+        bigLeap = 1000,
+        smallLeap = 10,
         enabled = replayPeriodically,
     )
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -162,6 +162,16 @@ private constructor(
             }
         )
     }
+
+    fun replayPeriodically() {
+        PeriodicReplayer(
+            consumer,
+            isBigLeap = { t -> t.hour == 5 && t.minute == 0 },
+            isSmallLeap = { t -> t.hour != 5 && t.minute != 0 },
+            bigLeap = 10_000,
+            smallLeap = 100,
+        ).start()
+    }
 }
 
 private fun <T> ConcurrentLinkedQueue<T>.pollAll(): List<T> =

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -43,10 +43,10 @@ private constructor(
             keyDeserializer: Class<KS>,
             valueDeserializer: Class<VS>,
             seekToBeginning: Boolean = false,
-            periodicReplay: Boolean = false,
+            replayPeriodically: Boolean = false,
             configure: Properties.() -> Unit = {},
         ): CoroutineKafkaConsumer<K, V> = CoroutineKafkaConsumer(
-            topic, groupId, keyDeserializer, valueDeserializer, seekToBeginning, periodicReplay, configure
+            topic, groupId, keyDeserializer, valueDeserializer, seekToBeginning, replayPeriodically, configure
         )
     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -166,8 +166,8 @@ private constructor(
     fun replayPeriodically() {
         PeriodicReplayer(
             consumer,
-            isBigLeap = { t -> t.hour == 5 && t.minute == 0 },
-            isSmallLeap = { t -> t.hour != 5 && t.minute != 0 },
+            isBigLeap = { t -> t.minute % 30 == 0 },
+            isSmallLeap = { t -> t.minute % 2 == 0 },
             bigLeap = 10_000,
             smallLeap = 100,
         ).start()

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -79,9 +79,9 @@ private constructor(
     private val replayer = PeriodicReplayer(
         consumer,
         isBigLeap = { t -> t.hour == 5 && t.minute == 0 },
-        isSmallLeap = { t -> t.minute == 0 },
+        isSmallLeap = { t -> t.minute % 15 == 0 },
         bigLeap = 10_000,
-        smallLeap = 100,
+        smallLeap = 500,
         enabled = replayPeriodically,
     )
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -78,10 +78,10 @@ private constructor(
 
     private val replayer = PeriodicReplayer(
         consumer,
-        isBigLeap = { t -> t.minute % 30 == 0 },
-        isSmallLeap = { t -> t.minute % 2 == 0 },
-        bigLeap = 1000,
-        smallLeap = 10,
+        isBigLeap = { t -> t.hour == 5 && t.minute == 0 },
+        isSmallLeap = { t -> t.minute == 0 },
+        bigLeap = 10_000,
+        smallLeap = 100,
         enabled = replayPeriodically,
     )
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -79,9 +79,9 @@ private constructor(
     private val replayer = PeriodicReplayer(
         consumer,
         isBigLeap = { t -> t.hour == 5 && t.minute == 0 },
-        isSmallLeap = { t -> t.minute % 15 == 0 },
+        isSmallLeap = { t -> t.minute == 0 },
         bigLeap = 10_000,
-        smallLeap = 500,
+        smallLeap = 100,
         enabled = replayPeriodically,
     )
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
@@ -38,6 +38,10 @@ class HendelsesstrømKafkaImpl(
             }
         }
     }
+
+    fun replayPeriodically() {
+        consumer.replayPeriodically()
+    }
 }
 
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class HendelsesstrømKafkaImpl(
     groupId: String,
     seekToBeginning: Boolean = false,
-    periodicReplay: Boolean = false,
+    replayPeriodically: Boolean = false,
     configure: Properties.() -> Unit = {},
 ): Hendelsesstrøm {
     private val log = logger()
@@ -23,7 +23,7 @@ class HendelsesstrømKafkaImpl(
         keyDeserializer = StringDeserializer::class.java,
         valueDeserializer = ValueDeserializer::class.java,
         seekToBeginning = seekToBeginning,
-        periodicReplay = periodicReplay,
+        replayPeriodically = replayPeriodically,
         configure = configure,
     )
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 class HendelsesstrømKafkaImpl(
     groupId: String,
     seekToBeginning: Boolean = false,
+    periodicReplay: Boolean = false,
     configure: Properties.() -> Unit = {},
 ): Hendelsesstrøm {
     private val log = logger()
@@ -22,6 +23,7 @@ class HendelsesstrømKafkaImpl(
         keyDeserializer = StringDeserializer::class.java,
         valueDeserializer = ValueDeserializer::class.java,
         seekToBeginning = seekToBeginning,
+        periodicReplay = periodicReplay,
         configure = configure,
     )
 
@@ -37,10 +39,6 @@ class HendelsesstrømKafkaImpl(
                 body(recordValue, HendelseMetadata(Instant.ofEpochMilli(record.timestamp())))
             }
         }
-    }
-
-    fun replayPeriodically() {
-        consumer.replayPeriodically()
     }
 }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PeriodicReplayer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PeriodicReplayer.kt
@@ -1,0 +1,64 @@
+package no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka
+
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import org.apache.kafka.clients.consumer.Consumer
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.*
+import java.util.function.Predicate
+import kotlin.concurrent.scheduleAtFixedRate
+
+class PeriodicReplayer<K, V>(
+    private val consumer: Consumer<K, V>,
+    private val isBigLeap: Predicate<LocalDateTime>,
+    private val isSmallLeap: Predicate<LocalDateTime>,
+    private val bigLeap: Long,
+    private val smallLeap: Long,
+) {
+    private val log = logger()
+
+    fun start() {
+        val start = Date()
+        val period = Duration.ofMinutes(1).toMillis()
+
+        Timer("PeriodicReplayer", false).scheduleAtFixedRate(time = start, period = period) {
+            val now = LocalDateTime.now()
+
+            if (isBigLeap.test(now)) {
+                log.info("replaying big leap")
+                consumer.replay(bigLeap)
+
+            } else if (isSmallLeap.test(now)) {
+                log.info("replaying small leap")
+                consumer.replay(smallLeap)
+
+            } else {
+                // nothing to do
+                log.info("idling")
+            }
+        }
+    }
+}
+
+fun <K, V> Consumer<K, V>.replay(numberOfRecords: Long) {
+    assignment().forEach {
+        val currentPosition = position(it)
+        val newPosition = (currentPosition - numberOfRecords).coerceAtLeast(0)
+        seek(it, newPosition)
+    }
+}
+
+//fun main() {
+//    val startAt = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)//.plusMinutes(5)
+//    val interval = Duration.ofSeconds(5)// .ofMinutes(1)
+//
+//    val replayer = PeriodicReplayer<String, String>(
+//        consumer = MockConsumer(OffsetResetStrategy.EARLIEST),
+//        isBigLeap = { t -> t.hour == 5 && t.minute == 0 },
+//        isSmallLeap = { t -> t.hour != 5 && t.minute != 0 },
+//        bigLeap = 10_000,
+//        smallLeap = 100,
+//    )
+//    replayer.schedule(startAt, interval)
+//
+//}

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PeriodicReplayer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PeriodicReplayer.kt
@@ -24,7 +24,7 @@ class PeriodicReplayer<K, V>(
         }
 
         val now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)
-        if (now == lastTick.get()) {
+        if (now == lastTick.getAndSet(now)) {
             // noop
         } else if (isBigLeap.test(now)) {
             log.info("replaying big leap")
@@ -34,7 +34,6 @@ class PeriodicReplayer<K, V>(
             log.info("replaying small leap")
             consumer.replay(smallLeap)
         }
-        lastTick.set(now)
     }
 }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PeriodicReplayer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PeriodicReplayer.kt
@@ -47,18 +47,3 @@ fun <K, V> Consumer<K, V>.replay(numberOfRecords: Long) {
         seek(it, newPosition)
     }
 }
-
-//fun main() {
-//    val startAt = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)//.plusMinutes(5)
-//    val interval = Duration.ofSeconds(5)// .ofMinutes(1)
-//
-//    val replayer = PeriodicReplayer<String, String>(
-//        consumer = MockConsumer(OffsetResetStrategy.EARLIEST),
-//        isBigLeap = { t -> t.hour == 5 && t.minute == 0 },
-//        isSmallLeap = { t -> t.hour != 5 && t.minute != 0 },
-//        bigLeap = 10_000,
-//        smallLeap = 100,
-//    )
-//    replayer.schedule(startAt, interval)
-//
-//}

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -25,7 +25,7 @@ import java.time.Duration
 object Produsent {
     val databaseConfig = Database.config("produsent_model")
     private val log = logger()
-    private val hendelsesstrøm by lazy { HendelsesstrømKafkaImpl("produsent-model-builder", periodicReplay = true) }
+    private val hendelsesstrøm by lazy { HendelsesstrømKafkaImpl("produsent-model-builder", replayPeriodically = true) }
 
     private val defaultAuthProviders = when (val name = System.getenv("NAIS_CLUSTER_NAME")) {
         "prod-gcp" -> listOf(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -64,6 +64,10 @@ object Produsent {
                 }
             }
 
+            launch {
+                hendelsesstrøm.replayPeriodically()
+            }
+
             val graphql = async {
                 ProdusentAPI.newGraphQL(
                     kafkaProducer = lagKafkaHendelseProdusent(),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -25,7 +25,7 @@ import java.time.Duration
 object Produsent {
     val databaseConfig = Database.config("produsent_model")
     private val log = logger()
-    private val hendelsesstrøm by lazy { HendelsesstrømKafkaImpl("produsent-model-builder") }
+    private val hendelsesstrøm by lazy { HendelsesstrømKafkaImpl("produsent-model-builder", periodicReplay = true) }
 
     private val defaultAuthProviders = when (val name = System.getenv("NAIS_CLUSTER_NAME")) {
         "prod-gcp" -> listOf(
@@ -62,10 +62,6 @@ object Produsent {
                 hendelsesstrøm.forEach { event ->
                     produsentRepository.oppdaterModellEtterHendelse(event)
                 }
-            }
-
-            launch {
-                hendelsesstrøm.replayPeriodically()
             }
 
             val graphql = async {


### PR DESCRIPTION
komponent som trigges hver loop og sjekker om den skal seeke. 
Nå er den satt opp til å seeke 10_000 records tilbake kl 0500 og 100 records tilbake hver time utenfor det. 
Slik det er nå er den ikke default på, men optes inn i hver app

https://prometheus.dev-gcp.nais.io/graph?g0.expr=sum(kafka_consumer_group_offset%7Btopic%3D%22fager.notifikasjon%22%2Cname%3D%22produsent-model-builder%22%7D)&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=2h
<img width="2014" alt="image" src="https://user-images.githubusercontent.com/189395/196958629-260090c2-a11e-4f24-9e5e-512fd4970e0a.png">
