### PR TITLE
legg til try catch rundt exchange

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
@@ -121,7 +121,7 @@ class TokenXClientImpl(
                         successCounter.increment()
                     }
             } catch (e: Exception) {
-                log.info("tokene exchange failed (audience='{}').", audience, e)
+                log.info("token exchange failed (audience='{}').", audience, e)
                 failCounter.increment()
                 throw e
             }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXPlugin.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXPlugin.kt
@@ -53,8 +53,12 @@ class TokenXPlugin internal constructor(
                 if (subjectToken == null) {
                     log.warn("subjectToken not present. skipping exchange for audience {}", plugin.audience)
                 } else {
-                    val accessToken = plugin.tokenXClient.exchange(subjectToken, plugin.audience)
-                    context.bearerAuth(accessToken)
+                    try {
+                        val accessToken = plugin.tokenXClient.exchange(subjectToken, plugin.audience)
+                        context.bearerAuth(accessToken)
+                    } catch (e: Exception) {
+                        log.warn("failed to set bearer auth header due to exception in exchange ${e.message}", e)
+                    }
                 }
 
                 proceed()


### PR DESCRIPTION
Det ser ut som et av cache loader kallene feiler, og så havner vi i en bad state. Dette har vi sett tidligere. Alle påfølgende kall feiler med connection is closed og ParentJob is cancelled, uten at det er så lett å se hvorfor.