### PR TITLE
Unngå dobbel logging

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/LogConfig.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/LogConfig.kt
@@ -49,7 +49,7 @@ class LogConfig : ContextAwareBase(), Configurator {
         if (naisCluster == null || naisCluster == "dev-gcp") {
             lc.getLogger("io.ktor.auth.jwt").level = Level.TRACE
         }
-        return ExecutionStatus.NEUTRAL
+        return ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY
     }
 }
 


### PR DESCRIPTION
Ser ut som noe ble endret i logback som gjør at logconfig stackes. Dvs at det nå er dobbeltlogging både lokalt og i dev/prod.

Har debugget litt og ser at både DefaultJoranConfigurator og BasicConfigurator blir invokert ved oppstart. BasicConfigurator setter da opp en rootlogger med TTLLLayout som er det vi ser lokalt og i prod. Endrer derfor slik at ingen flere configurators invokeres etter vår.

exs:
```
notifikasjon-produsent-api-59979fbcd-qfv45 notifikasjon-produsent-api {"@timestamp":"2022-10-21T08:15:17.333+02:00","@version":"1","message":"processing ConsumerRecord(\n    topic = fager.notifikasjon,\n    partition = 3, \n    offset = 73,\n    timestamp = 1652868287503,\n    key = f7efc02c-6788-45f8-b7ed-a0cb37b94d0e\n)","logger_name":"no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.CoroutineKafkaConsumer","thread_name":"DefaultDispatcher-worker-4","level":"INFO","level_value":20000}
notifikasjon-produsent-api-59979fbcd-qfv45 notifikasjon-produsent-api 08:15:17.333 [DefaultDispatcher-worker-4] INFO no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.CoroutineKafkaConsumer - processing ConsumerRecord(
notifikasjon-produsent-api-59979fbcd-qfv45 notifikasjon-produsent-api     topic = fager.notifikasjon,
notifikasjon-produsent-api-59979fbcd-qfv45 notifikasjon-produsent-api     partition = 3,
notifikasjon-produsent-api-59979fbcd-qfv45 notifikasjon-produsent-api     offset = 73,
notifikasjon-produsent-api-59979fbcd-qfv45 notifikasjon-produsent-api     timestamp = 1652868287503,
notifikasjon-produsent-api-59979fbcd-qfv45 notifikasjon-produsent-api     key = f7efc02c-6788-45f8-b7ed-a0cb37b94d0e
notifikasjon-produsent-api-59979fbcd-qfv45 notifikasjon-produsent-api )
```

<img width="937" alt="image" src="https://user-images.githubusercontent.com/189395/197128142-d9da9daf-5859-4b99-8db3-ff9d034ca7ce.png">
