### PR TITLE
stop timer of partition revoked

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PartitionAwareHendelsesstrøm.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PartitionAwareHendelsesstrøm.kt
@@ -62,6 +62,7 @@ class PartitionAwareHendelsesstrøm<PartitionState: Any>(
         onPartitionRevoked = { partition: TopicPartition ->
             val p = partitionInfo.remove(partition)
             p?.processingJob?.cancel()
+            p?.catchupTimerSample?.stop()
         }
     )
 


### PR DESCRIPTION
Må fjerne timeren hvis vi mister partisjonen. Hadde vært best med `cancel`, men det finnes ikke.