### PR TITLE
Paaminnelse produsent api

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
@@ -17,6 +17,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.WithCoroutineScope
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.createGraphQL
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import java.time.LocalDate
@@ -169,7 +170,7 @@ object BrukerAPI {
 
             wire("Query") {
                 dataFetcher("whoami") {
-                    it.getContext<Context>().fnr
+                    it.notifikasjonContext<Context>().fnr
                 }
 
                 queryNotifikasjoner(
@@ -216,7 +217,7 @@ object BrukerAPI {
     ) {
         coDataFetcher("notifikasjoner") { env ->
 
-            val context = env.getContext<Context>()
+            val context = env.notifikasjonContext<Context>()
             val tilganger = tilgangerService.hentTilganger(context)
 
             val notifikasjoner = brukerRepository
@@ -278,7 +279,7 @@ object BrukerAPI {
         tilgangerService: TilgangerService,
     ) {
         coDataFetcher("saker") { env ->
-            val context = env.getContext<Context>()
+            val context = env.notifikasjonContext<Context>()
             val virksomhetsnummer = env.getArgument<String>("virksomhetsnummer")
             val tekstsoek = env.getArgumentOrDefault<String>("tekstsoek", null)
             val sortering = env.getTypedArgument<SakSortering>("sortering")
@@ -329,7 +330,7 @@ object BrukerAPI {
         hendelseProdusent: HendelseProdusent,
     ) {
         coDataFetcher("notifikasjonKlikketPaa") { env ->
-            val context = env.getContext<Context>()
+            val context = env.notifikasjonContext<Context>()
             val notifikasjonsid = env.getTypedArgument<UUID>("id")
 
             val virksomhetsnummer = brukerRepository.virksomhetsnummerForNotifikasjon(notifikasjonsid)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -62,7 +62,7 @@ fun <T> TypeRuntimeWiring.Builder.coDataFetcher(
     fetcher: suspend (DataFetchingEnvironment) -> T,
 ) {
     dataFetcher(fieldName) { env ->
-        val ctx = env.getContext<WithCoroutineScope>()
+        val ctx = env.notifikasjonContext<WithCoroutineScope>()
         ctx.coroutineScope.future(Dispatchers.IO) {
             try {
                 fetcher(env)
@@ -137,6 +137,9 @@ inline fun requireGraphql(check: Boolean, message: () -> String) {
     }
 }
 
+fun <T> DataFetchingEnvironment.notifikasjonContext(): T =
+    this.graphQlContext["context"]
+
 class TypedGraphQL<T : WithCoroutineScope>(
     private val graphQL: GraphQL
 ) {
@@ -162,7 +165,7 @@ class TypedGraphQL<T : WithCoroutineScope>(
                     variables(it)
                 }
 
-                context(context)
+                graphQLContext(mapOf("context" to context))
             }.build()
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
@@ -79,6 +79,7 @@ object ProdusentModel {
         override val eksterneVarsler: List<EksterntVarsel>,
         override val virksomhetsnummer: String,
         val frist: LocalDate?,
+        val påminnelseEksterneVarsler: List<EksterntVarsel>,
     ) : Notifikasjon {
 
         enum class Tilstand {
@@ -152,6 +153,9 @@ fun OppgaveOpprettet.tilProdusentModel(): ProdusentModel.Oppgave =
         eksterneVarsler = eksterneVarsler.map(EksterntVarsel::tilProdusentModel),
         virksomhetsnummer = this.virksomhetsnummer,
         frist = this.frist,
+        påminnelseEksterneVarsler = this.påminnelse?.eksterneVarsler
+            .orEmpty()
+            .map(EksterntVarsel::tilProdusentModel),
     )
 
 fun EksterntVarsel.tilProdusentModel(): ProdusentModel.EksterntVarsel {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -500,12 +500,30 @@ class ProdusentRepositoryImpl(
         ) {
             uuid(eksterntVarselVellykket.varselId)
         }
+        database.nonTransactionalExecuteUpdate(
+            """
+            update paaminnelse_eksternt_varsel set status = 'SENDT' where varsel_id = ?
+            """
+        ) {
+            uuid(eksterntVarselVellykket.varselId)
+        }
     }
 
     private suspend fun oppdaterModellEtterEksterntVarselFeilet(eksterntVarselFeilet: EksterntVarselFeilet) {
         database.nonTransactionalExecuteUpdate(
             """
             update eksternt_varsel 
+            set status = 'FEILET',
+                feilmelding = ?  
+            where varsel_id = ?
+            """
+        ) {
+            string(eksterntVarselFeilet.feilmelding)
+            uuid(eksterntVarselFeilet.varselId)
+        }
+        database.nonTransactionalExecuteUpdate(
+            """
+            update paaminnelse_eksternt_varsel 
             set status = 'FEILET',
                 feilmelding = ?  
             where varsel_id = ?

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationHardDeleteNotifikasjon.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationHardDeleteNotifikasjon.kt
@@ -6,6 +6,7 @@ import graphql.schema.idl.RuntimeWiring
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HardDelete
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
@@ -23,13 +24,13 @@ internal class MutationHardDeleteNotifikasjon(
         runtime.wire("Mutation") {
             coDataFetcher("hardDeleteNotifikasjon") { env ->
                 hardDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     id = env.getTypedArgument("id")
                 )
             }
             coDataFetcher("hardDeleteNotifikasjonByEksternId") { env ->
                 hardDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     eksternId = env.getTypedArgument("eksternId"),
                     merkelapp = env.getTypedArgument("merkelapp"),
                 )
@@ -37,7 +38,7 @@ internal class MutationHardDeleteNotifikasjon(
 
             coDataFetcher("hardDeleteNotifikasjonByEksternId_V2") { env ->
                 hardDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     eksternId = env.getTypedArgument("eksternId"),
                     merkelapp = env.getTypedArgument("merkelapp"),
                 )

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationHardDeleteSak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationHardDeleteSak.kt
@@ -6,6 +6,7 @@ import graphql.schema.idl.RuntimeWiring
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HardDelete
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
@@ -23,13 +24,13 @@ internal class MutationHardDeleteSak(
         runtime.wire("Mutation") {
             coDataFetcher("hardDeleteSak") { env ->
                 hardDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     id = env.getTypedArgument("id")
                 )
             }
             coDataFetcher("hardDeleteSakByGrupperingsid") { env ->
                 hardDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     grupperingsid = env.getTypedArgument("grupperingsid"),
                     merkelapp = env.getTypedArgument("merkelapp"),
                 )

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
@@ -7,6 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnRolle
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
@@ -25,7 +26,7 @@ internal class MutationNyBeskjed(
         runtime.wire("Mutation") {
             coDataFetcher("nyBeskjed") { env ->
                 nyBeskjed(
-                    env.getContext(),
+                    env.notifikasjonContext(),
                     env.getTypedArgument("nyBeskjed"),
                 )
             }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
@@ -40,7 +40,7 @@ internal class MutationNyBeskjed(
     @JsonTypeName("NyBeskjedVellykket")
     data class NyBeskjedVellykket(
         val id: UUID,
-        val eksterneVarsler: List<NyEksternVarselResultat>
+        val eksterneVarsler: List<NyEksterntVarselResultat>
     ) : NyBeskjedResultat
 
     data class NyBeskjedInput(
@@ -115,7 +115,7 @@ internal class MutationNyBeskjed(
                 NyBeskjedVellykket(
                     id = id,
                     eksterneVarsler = domeneNyBeskjed.eksterneVarsler.map {
-                        NyEksternVarselResultat(it.varselId)
+                        NyEksterntVarselResultat(it.varselId)
                     }
                 )
             }
@@ -124,7 +124,7 @@ internal class MutationNyBeskjed(
                 NyBeskjedVellykket(
                     id = eksisterende.id,
                     eksterneVarsler = eksisterende.eksterneVarsler.map {
-                        NyEksternVarselResultat(it.varselId)
+                        NyEksterntVarselResultat(it.varselId)
                     }
                 )
             }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
@@ -9,6 +9,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.ISO8601Period
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnRolle
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
@@ -31,7 +32,7 @@ internal class MutationNyOppgave(
         runtime.wire("Mutation") {
             coDataFetcher("nyOppgave") { env ->
                 nyOppgave(
-                    env.getContext(),
+                    env.notifikasjonContext(),
                     env.getTypedArgument("nyOppgave"),
                 )
             }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -14,6 +14,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnRolle
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgumentOrNull
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
@@ -34,7 +35,7 @@ internal class MutationNySak(
         runtime.wire("Mutation") {
             coDataFetcher("nySak") { env ->
                 nySak(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     nySak = NySakInput(
                         grupperingsid = env.getTypedArgument("grupperingsid"),
                         merkelapp = env.getTypedArgument("merkelapp"),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyStatusSak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyStatusSak.kt
@@ -8,6 +8,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NyStatusSak
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgumentOrNull
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
@@ -38,14 +39,14 @@ internal class MutationNyStatusSak(
         runtime.wire("Mutation") {
             coDataFetcher("nyStatusSak") { env ->
                 nyStatusSak(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     id = env.getTypedArgument("id"),
                     status = env.getStatus(),
                 )
             }
             coDataFetcher("nyStatusSakByGrupperingsid") { env ->
                 nyStatusSakByGrupperingsid(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     grupperingsid = env.getTypedArgument("grupperingsid"),
                     merkelapp = env.getTypedArgument("merkelapp"),
                     status = env.getStatus(),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationOppgaveUtfoert.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationOppgaveUtfoert.kt
@@ -26,7 +26,7 @@ internal class MutationOppgaveUtfoert(
         runtime.wire("Mutation") {
             coDataFetcher("oppgaveUtfoert") { env ->
                 oppgaveUtført(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     id = env.getTypedArgument("id"),
                     hardDelete = env.getTypedArgumentOrNull<HardDeleteUpdateInput>("hardDelete"),
                 )
@@ -43,7 +43,7 @@ internal class MutationOppgaveUtfoert(
 
     private suspend fun oppgaveUtfoertByEksternId(env: DataFetchingEnvironment) =
         oppgaveUtført(
-            context = env.getContext(),
+            context = env.notifikasjonContext(),
             eksternId = env.getTypedArgument("eksternId"),
             merkelapp = env.getTypedArgument("merkelapp"),
             hardDelete = env.getTypedArgumentOrNull("hardDelete")

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationOppgaveUtgaatt.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationOppgaveUtgaatt.kt
@@ -27,7 +27,7 @@ internal class MutationOppgaveUtgaatt(
         runtime.wire("Mutation") {
             coDataFetcher("oppgaveUtgaatt") { env ->
                 oppgaveUtgått(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     id = env.getTypedArgument("id"),
                     hardDelete = env.getTypedArgumentOrNull<HardDeleteUpdateInput>("hardDelete"),
                 )
@@ -41,7 +41,7 @@ internal class MutationOppgaveUtgaatt(
 
     private suspend fun oppgaveUtgaattByEksternId(env: DataFetchingEnvironment) =
         oppgaveUtgått(
-            context = env.getContext(),
+            context = env.notifikasjonContext(),
             eksternId = env.getTypedArgument("eksternId"),
             merkelapp = env.getTypedArgument("merkelapp"),
             hardDelete = env.getTypedArgumentOrNull("hardDelete")

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationSoftDeleteNotifikasjon.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationSoftDeleteNotifikasjon.kt
@@ -6,6 +6,7 @@ import graphql.schema.idl.RuntimeWiring
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SoftDelete
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
@@ -23,20 +24,20 @@ internal class MutationSoftDeleteNotifikasjon(
         runtime.wire("Mutation") {
             coDataFetcher("softDeleteNotifikasjon") { env ->
                 softDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     id = env.getTypedArgument("id")
                 )
             }
             coDataFetcher("softDeleteNotifikasjonByEksternId") { env ->
                 softDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     eksternId = env.getTypedArgument("eksternId"),
                     merkelapp = env.getTypedArgument("merkelapp"),
                 )
             }
             coDataFetcher("softDeleteNotifikasjonByEksternId_V2") { env ->
                 softDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     eksternId = env.getTypedArgument("eksternId"),
                     merkelapp = env.getTypedArgument("merkelapp"),
                 )

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationSoftDeleteSak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationSoftDeleteSak.kt
@@ -6,6 +6,7 @@ import graphql.schema.idl.RuntimeWiring
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SoftDelete
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
@@ -23,13 +24,13 @@ internal class MutationSoftDeleteSak(
         runtime.wire("Mutation") {
             coDataFetcher("softDeleteSak") { env ->
                 softDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     id = env.getTypedArgument("id")
                 )
             }
             coDataFetcher("softDeleteSakByGrupperingsid") { env ->
                 softDelete(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     grupperingsid = env.getTypedArgument("grupperingsid"),
                     merkelapp = env.getTypedArgument("merkelapp"),
                 )

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyNotifikasjonFelles.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyNotifikasjonFelles.kt
@@ -189,7 +189,7 @@ internal data class MetadataInput(
     val hardDelete: FutureTemporalInput?,
 )
 
-internal data class NyEksternVarselResultat(
+internal data class NyEksterntVarselResultat(
     val id: UUID,
 )
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
@@ -24,7 +24,7 @@ object ProdusentAPI {
 
         fun queryWhoami(env: DataFetchingEnvironment): String {
             // TODO: returner hele context objectet som struct
-            return env.getContext<Context>().appName
+            return env.notifikasjonContext<Context>().appName
         }
 
         return TypedGraphQL(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/QueryMineNotifikasjoner.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/QueryMineNotifikasjoner.kt
@@ -22,7 +22,7 @@ internal class QueryMineNotifikasjoner(
         runtime.wire("Query") {
             coDataFetcher("mineNotifikasjoner") { env ->
                 mineNotifikasjoner(
-                    context = env.getContext(),
+                    context = env.notifikasjonContext(),
                     inputMerkelapp = env.getArgument<String?>("merkelapp"),
                     inputMerkelapper = env.getArgument<List<String>?>("merkelapper"),
                     grupperingsid = env.getArgument<String>("grupperingsid"),

--- a/app/src/main/resources/db/migration/produsent_model/V13__paaminnelse_eksterne_varsler.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V13__paaminnelse_eksterne_varsler.sql
@@ -1,2 +1,0 @@
-alter table notifikasjon
-    add column frist date null default null;

--- a/app/src/main/resources/db/migration/produsent_model/V14__paaminnelse_eksterne_varsler.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V14__paaminnelse_eksterne_varsler.sql
@@ -1,0 +1,22 @@
+
+create table paaminnelse_eksternt_varsel
+(
+    varsel_id uuid not null primary key,
+    notifikasjon_id uuid not null,
+    status eksternt_varsel_status not null,
+    feilmelding text
+);
+
+create view paaminnelse_eksterne_varsler_json as
+select
+    notifikasjon_id,
+    json_agg(
+            json_build_object(
+                    'varselId', varsel_id,
+                    'status', status,
+                    'feilmelding', feilmelding
+                )
+        ) as paaminnelse_eksterne_varsler_json
+from paaminnelse_eksternt_varsel
+group by notifikasjon_id;
+

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -1176,6 +1176,11 @@ type NyEksterntVarselResultat {
 type NyOppgaveVellykket {
     id: ID!
     eksterneVarsler: [NyEksterntVarselResultat!]!
+    paaminnelse: PaaminnelseResultat
+}
+
+type PaaminnelseResultat {
+    eksterneVarsler: [NyEksterntVarselResultat!]!
 }
 
 """

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgavePaaminnelseTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgavePaaminnelseTests.kt
@@ -1,7 +1,10 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
@@ -173,7 +176,162 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
         }
     }
 
-    // TODO: med eksternevarsler
+    describe("ekstern varlser med tom liste") {
+        val response = engine.produsentApi(
+            nyOppgave(
+                "2020-01-01T00:00:00Z",
+                """
+                    frist: "2021-01-01"
+                    paaminnelse: {
+                        tidspunkt: {
+                            foerFrist: "P2DT3H4M"
+                        }
+                        eksterneVarsler: []
+                    }
+                """,
+            )
+        )
+        it("opprettelse uten varsler") {
+            response.getTypedContent<MutationNyOppgave.NyOppgaveVellykket>("nyOppgave")
+            val hendelse = (stubbedKafkaProducer.hendelser[0] as HendelseModel.OppgaveOpprettet)
+            hendelse.påminnelse!!.eksterneVarsler shouldBe emptyList()
+        }
+    }
+
+    describe("ekstern varlser med 1 sms") {
+        val response = engine.produsentApi(
+            nyOppgave(
+                "2020-01-01T00:00:00Z",
+                """
+                    frist: "2021-01-01"
+                    paaminnelse: {
+                        tidspunkt: {
+                            foerFrist: "P2DT3H4M"
+                        }
+                        eksterneVarsler: [
+                            { 
+                                sms: {
+                                    mottaker: {
+                                        kontaktinfo: {
+                                            tlf: "1234"
+                                        }
+                                    }
+                                    smsTekst: "hei"
+                                    sendevindu: NKS_AAPNINGSTID
+                                }
+                            }
+                        ]
+                    }
+                """,
+            )
+        )
+        it("opprettelse ok, med en sms") {
+            response.getTypedContent<MutationNyOppgave.NyOppgaveVellykket>("nyOppgave")
+            val hendelse = (stubbedKafkaProducer.hendelser[0] as HendelseModel.OppgaveOpprettet)
+            hendelse.påminnelse?.eksterneVarsler?.size shouldBe 1
+            val varsel = hendelse.påminnelse!!.eksterneVarsler[0]
+            varsel shouldBe HendelseModel.SmsVarselKontaktinfo(
+                varselId = varsel.varselId,
+                tlfnr = "1234",
+                fnrEllerOrgnr = "0",
+                smsTekst = "hei",
+                sendevindu = HendelseModel.EksterntVarselSendingsvindu.NKS_ÅPNINGSTID,
+                sendeTidspunkt = null,
+            )
+        }
+    }
+
+    describe("ekstern varlser med 1 epost") {
+        val response = engine.produsentApi(
+            nyOppgave(
+                "2020-01-01T00:00:00Z",
+                """
+                    frist: "2021-01-01"
+                    paaminnelse: {
+                        tidspunkt: {
+                            foerFrist: "P2DT3H4M"
+                        }
+                        eksterneVarsler: [
+                            { 
+                                epost: {
+                                    mottaker: {
+                                        kontaktinfo: {
+                                            epostadresse: "1234@1234.no"
+                                        }
+                                    }
+                                    epostTittel: "hei"
+                                    epostHtmlBody: "body"
+                                    sendevindu: NKS_AAPNINGSTID
+                                }
+                            }
+                        ]
+                    }
+                """,
+            )
+        )
+        it("opprettelse ok, med en epost") {
+            response.getTypedContent<MutationNyOppgave.NyOppgaveVellykket>("nyOppgave")
+            val hendelse = (stubbedKafkaProducer.hendelser[0] as HendelseModel.OppgaveOpprettet)
+            hendelse.påminnelse?.eksterneVarsler?.size shouldBe 1
+            val varsel = hendelse.påminnelse!!.eksterneVarsler[0]
+            varsel shouldBe HendelseModel.EpostVarselKontaktinfo(
+                varselId = varsel.varselId,
+                epostAddr = "1234@1234.no",
+                fnrEllerOrgnr = "0",
+                tittel = "hei",
+                htmlBody = "body",
+                sendevindu = HendelseModel.EksterntVarselSendingsvindu.NKS_ÅPNINGSTID,
+                sendeTidspunkt = null,
+            )
+        }
+    }
+
+    describe("ekstern varlser med epost og sms") {
+        val response = engine.produsentApi(
+            nyOppgave(
+                "2020-01-01T00:00:00Z",
+                """
+                    frist: "2021-01-01"
+                    paaminnelse: {
+                        tidspunkt: {
+                            foerFrist: "P2DT3H4M"
+                        }
+                        eksterneVarsler: [
+                            { 
+                                epost: {
+                                    mottaker: {
+                                        kontaktinfo: {
+                                            epostadresse: "1234@1234.no"
+                                        }
+                                    }
+                                    epostTittel: "hei"
+                                    epostHtmlBody: "body"
+                                    sendevindu: NKS_AAPNINGSTID
+                                }
+                            }
+                            {
+                                sms: {
+                                    mottaker: {
+                                        kontaktinfo: {
+                                            tlf: "1234"
+                                        }
+                                    }
+                                    smsTekst: "hei"
+                                    sendevindu: NKS_AAPNINGSTID
+                                }
+                            }
+                        ]
+                    }
+                """,
+            )
+        )
+        it("opprettelse ok, med sms og epost") {
+            response.getTypedContent<MutationNyOppgave.NyOppgaveVellykket>("nyOppgave")
+            // TODO: sjekke at ID-er for eksterne varsler blir generert og returnert?
+            val hendelse = (stubbedKafkaProducer.hendelser[0] as HendelseModel.OppgaveOpprettet)
+            hendelse.påminnelse?.eksterneVarsler?.size shouldBe 2
+        }
+    }
 })
 
 private fun nyOppgave(opprettetTidspunkt: String, fragment: String) = """


### PR DESCRIPTION
- fikser deprecated bruk av getContext
- lagrer info om eksterne varsler, og produsent-api returnerer varsel-id-ene i nyOppgave.

Produsent-api sjekker ikke påminnelse-informasjon i idempotens-logikken. Det påvirker ikke de som bruker API-et korrekt, kun dersom noen prøver å oppdatere en oppgave med "nyOppgave" ved å endre påminnelse-feltet.