### PR TITLE
legg til feilhåndtering ved uhåndtert feil

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -59,8 +59,8 @@ class UnhandledGraphQLExceptionError(
 
 fun <T> TypeRuntimeWiring.Builder.coDataFetcher(
     fieldName: String,
-    internFeilHandler: (exception: Exception) -> DataFetcherResult<*> = { exception ->
-        handleUnexepctedError(exception, UnhandledGraphQLExceptionError(exception))
+    exceptionHandler: (exception: Exception) -> DataFetcherResult<*> = { exception ->
+        handleUnexpectedError(exception, UnhandledGraphQLExceptionError(exception))
     },
     fetcher: suspend (DataFetchingEnvironment) -> T,
 ) {
@@ -70,15 +70,15 @@ fun <T> TypeRuntimeWiring.Builder.coDataFetcher(
             try {
                 fetcher(env)
             } catch (e: GraphqlErrorException) {
-                handleUnexepctedError(e, e)
+                handleUnexpectedError(e, e)
             } catch (e: Exception) {
-                internFeilHandler(e)
+                exceptionHandler(e)
             }
         }
     }
 }
 
-fun handleUnexepctedError(exception: Exception, error: GraphQLError): DataFetcherResult<*> {
+fun handleUnexpectedError(exception: Exception, error: GraphQLError): DataFetcherResult<*> {
     GraphQLLogger.log.error(
         "unhandled exception while executing coDataFetcher: {}",
         exception.javaClass.canonicalName,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -59,6 +59,9 @@ class UnhandledGraphQLExceptionError(
 
 fun <T> TypeRuntimeWiring.Builder.coDataFetcher(
     fieldName: String,
+    internFeilHandler: (exception: Exception) -> DataFetcherResult<*> = { exception ->
+        handleUnexepctedError(exception, UnhandledGraphQLExceptionError(exception))
+    },
     fetcher: suspend (DataFetchingEnvironment) -> T,
 ) {
     dataFetcher(fieldName) { env ->
@@ -69,7 +72,7 @@ fun <T> TypeRuntimeWiring.Builder.coDataFetcher(
             } catch (e: GraphqlErrorException) {
                 handleUnexepctedError(e, e)
             } catch (e: Exception) {
-                handleUnexepctedError(e, UnhandledGraphQLExceptionError(e))
+                internFeilHandler(e)
             }
         }
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQLValidation.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQLValidation.kt
@@ -1,9 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql
 
-import graphql.ErrorClassification
-import graphql.ErrorType
-import graphql.GraphQLError
-import graphql.language.SourceLocation
+import graphql.GraphqlErrorException
 import graphql.schema.*
 import graphql.schema.idl.SchemaDirectiveWiring
 import graphql.schema.idl.SchemaDirectiveWiringEnvironment
@@ -211,12 +208,4 @@ private val VALIDATORS = listOf(
     }
 ).associateBy { it.name }
 
-/**
- * lånt fra https://github.com/graphql-java/graphql-java/issues/1022#issuecomment-723369519
- * workaround for mismatch mellom kotlin og hvordan graphql eksponerer custom feil
- */
-class ValideringsFeil(@JvmField override val message: String) : RuntimeException(message), GraphQLError {
-    override fun getMessage(): String? = super.message
-    override fun getLocations(): MutableList<SourceLocation> = mutableListOf()
-    override fun getErrorType(): ErrorClassification = ErrorType.DataFetchingException
-}
+class ValideringsFeil(message: String): GraphqlErrorException(newErrorException().message(message))

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
@@ -2,6 +2,8 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
+import graphql.execution.DataFetcherResult
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "__typename")
 internal sealed class Error {
@@ -111,5 +113,25 @@ internal sealed class Error {
         override val feilmelding: String,
     ):  Error(),
         MutationOppgaveUtgaatt.OppgaveUtgaattResultat
+
+
+    @JsonTypeName("InternFeil")
+    data class InternFeil(
+        override val feilmelding: String
+    ) :
+        Error(),
+        MutationNySak.NySakResultat,
+        MutationNyBeskjed.NyBeskjedResultat,
+        MutationNyOppgave.NyOppgaveResultat {
+        companion object {
+            private val log = logger()
+            fun exceptionHandler(e: Exception): DataFetcherResult<Error> {
+                log.error("Intern feil håndtert: {}", e.message, e)
+                return DataFetcherResult.newResult<Error>()
+                    .data(InternFeil(e.message ?: e.javaClass.canonicalName))
+                    .build()
+            }
+        }
+    }
 }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
@@ -3,7 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import graphql.execution.DataFetcherResult
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLLogger
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "__typename")
 internal sealed class Error {
@@ -124,9 +124,8 @@ internal sealed class Error {
         MutationNyBeskjed.NyBeskjedResultat,
         MutationNyOppgave.NyOppgaveResultat {
         companion object {
-            private val log = logger()
             fun exceptionHandler(e: Exception): DataFetcherResult<Error> {
-                log.error("Intern feil håndtert: {}", e.message, e)
+                GraphQLLogger.log.error("Intern feil håndtert: {}", e.message, e)
                 return DataFetcherResult.newResult<Error>()
                     .data(InternFeil(e.message ?: e.javaClass.canonicalName))
                     .build()

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
@@ -2,8 +2,6 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
-import graphql.execution.DataFetcherResult
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLLogger
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "__typename")
 internal sealed class Error {
@@ -114,23 +112,5 @@ internal sealed class Error {
     ):  Error(),
         MutationOppgaveUtgaatt.OppgaveUtgaattResultat
 
-
-    @JsonTypeName("InternFeil")
-    data class InternFeil(
-        override val feilmelding: String
-    ) :
-        Error(),
-        MutationNySak.NySakResultat,
-        MutationNyBeskjed.NyBeskjedResultat,
-        MutationNyOppgave.NyOppgaveResultat {
-        companion object {
-            fun exceptionHandler(e: Exception): DataFetcherResult<Error> {
-                GraphQLLogger.log.error("Intern feil håndtert: {}", e.message, e)
-                return DataFetcherResult.newResult<Error>()
-                    .data(InternFeil(e.message ?: e.javaClass.canonicalName))
-                    .build()
-            }
-        }
-    }
 }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
@@ -5,10 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import graphql.schema.idl.RuntimeWiring
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnRolle
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.produsent.tilProdusentModel
@@ -23,7 +20,7 @@ internal class MutationNyBeskjed(
     fun wire(runtime: RuntimeWiring.Builder) {
         runtime.resolveSubtypes<NyBeskjedResultat>()
         runtime.wire("Mutation") {
-            safeCoDataFetcher("nyBeskjed") { env ->
+            coDataFetcher("nyBeskjed") { env ->
                 nyBeskjed(
                     env.notifikasjonContext(),
                     env.getTypedArgument("nyBeskjed"),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import graphql.schema.idl.RuntimeWiring
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnRolle
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
@@ -24,7 +23,7 @@ internal class MutationNyBeskjed(
     fun wire(runtime: RuntimeWiring.Builder) {
         runtime.resolveSubtypes<NyBeskjedResultat>()
         runtime.wire("Mutation") {
-            coDataFetcher("nyBeskjed") { env ->
+            safeCoDataFetcher("nyBeskjed") { env ->
                 nyBeskjed(
                     env.notifikasjonContext(),
                     env.getTypedArgument("nyBeskjed"),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
@@ -10,10 +10,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.PåminnelseTidspu
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.PåminnelseTidspunkt.Companion.createAndValidateKonkret
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.ISO8601Period
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnRolle
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
@@ -33,7 +30,7 @@ internal class MutationNyOppgave(
         runtime.resolveSubtypes<NyOppgaveResultat>()
 
         runtime.wire("Mutation") {
-            safeCoDataFetcher("nyOppgave") { env ->
+            coDataFetcher("nyOppgave") { env ->
                 nyOppgave(
                     env.notifikasjonContext(),
                     env.getTypedArgument("nyOppgave"),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
@@ -1,6 +1,5 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import graphql.schema.idl.RuntimeWiring
@@ -11,7 +10,6 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.PåminnelseTidspu
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.PåminnelseTidspunkt.Companion.createAndValidateKonkret
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.ISO8601Period
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnRolle
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
@@ -35,7 +33,7 @@ internal class MutationNyOppgave(
         runtime.resolveSubtypes<NyOppgaveResultat>()
 
         runtime.wire("Mutation") {
-            coDataFetcher("nyOppgave") { env ->
+            safeCoDataFetcher("nyOppgave") { env ->
                 nyOppgave(
                     env.notifikasjonContext(),
                     env.getTypedArgument("nyOppgave"),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -28,7 +28,7 @@ internal class MutationNySak(
         runtime.resolveSubtypes<NySakResultat>()
 
         runtime.wire("Mutation") {
-            safeCoDataFetcher("nySak") { env ->
+            coDataFetcher("nySak") { env ->
                 nySak(
                     context = env.notifikasjonContext(),
                     nySak = NySakInput(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -11,12 +11,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NyStatusSak
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NærmesteLederMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnRolle
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgumentOrNull
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
@@ -33,7 +28,7 @@ internal class MutationNySak(
         runtime.resolveSubtypes<NySakResultat>()
 
         runtime.wire("Mutation") {
-            coDataFetcher("nySak") { env ->
+            safeCoDataFetcher("nySak") { env ->
                 nySak(
                     context = env.notifikasjonContext(),
                     nySak = NySakInput(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import graphql.schema.DataFetchingEnvironment
+import graphql.schema.idl.TypeRuntimeWiring
 import kotlinx.coroutines.CoroutineScope
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
@@ -57,3 +58,8 @@ object ProdusentAPI {
         )
     }
 }
+
+fun <T> TypeRuntimeWiring.Builder.safeCoDataFetcher(
+    fieldName: String,
+    fetcher: suspend (DataFetchingEnvironment) -> T,
+) = coDataFetcher(fieldName, Error.InternFeil::exceptionHandler, fetcher)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
@@ -1,7 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import graphql.schema.DataFetchingEnvironment
-import graphql.schema.idl.TypeRuntimeWiring
 import kotlinx.coroutines.CoroutineScope
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
@@ -58,8 +57,3 @@ object ProdusentAPI {
         )
     }
 }
-
-fun <T> TypeRuntimeWiring.Builder.safeCoDataFetcher(
-    fieldName: String,
-    fetcher: suspend (DataFetchingEnvironment) -> T,
-) = coDataFetcher(fieldName, Error.InternFeil::exceptionHandler, fetcher)

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -229,7 +229,6 @@ union NySakResultat =
     | DuplikatGrupperingsid
     | UkjentProdusent
     | UkjentRolle
-    | InternFeil
 
 type NySakVellykket {
     id: ID!
@@ -1156,7 +1155,6 @@ union NyOppgaveResultat =
     | UkjentProdusent
     | UkjentRolle
     | UgyldigPaaminnelseTidspunkt
-    | InternFeil
 
 union NyBeskjedResultat =
     | NyBeskjedVellykket
@@ -1165,7 +1163,6 @@ union NyBeskjedResultat =
     | DuplikatEksternIdOgMerkelapp
     | UkjentProdusent
     | UkjentRolle
-    | InternFeil
 
 type NyBeskjedVellykket {
     id: ID!
@@ -1259,13 +1256,6 @@ type UgyldigPaaminnelseTidspunkt implements Error {
 Oppgitt informasjon samsvarer ikke med tidligere informasjon som er oppgitt.
 """
 type Konflikt implements Error {
-    feilmelding: String!
-}
-
-"""
-Det har skjedd en uforventet intern feil. Dette er nok vår skyld, skal helst ikke skje.
-"""
-type InternFeil implements Error {
     feilmelding: String!
 }
 

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -229,6 +229,7 @@ union NySakResultat =
     | DuplikatGrupperingsid
     | UkjentProdusent
     | UkjentRolle
+    | InternFeil
 
 type NySakVellykket {
     id: ID!
@@ -1155,6 +1156,7 @@ union NyOppgaveResultat =
     | UkjentProdusent
     | UkjentRolle
     | UgyldigPaaminnelseTidspunkt
+    | InternFeil
 
 union NyBeskjedResultat =
     | NyBeskjedVellykket
@@ -1163,6 +1165,7 @@ union NyBeskjedResultat =
     | DuplikatEksternIdOgMerkelapp
     | UkjentProdusent
     | UkjentRolle
+    | InternFeil
 
 type NyBeskjedVellykket {
     id: ID!
@@ -1256,6 +1259,13 @@ type UgyldigPaaminnelseTidspunkt implements Error {
 Oppgitt informasjon samsvarer ikke med tidligere informasjon som er oppgitt.
 """
 type Konflikt implements Error {
+    feilmelding: String!
+}
+
+"""
+Det har skjedd en uforventet intern feil. Dette er nok vår skyld, skal helst ikke skje.
+"""
+type InternFeil implements Error {
     feilmelding: String!
 }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationExceptionTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationExceptionTests.kt
@@ -1,0 +1,134 @@
+package no.nav.arbeidsgiver.notifikasjon.produsent.api
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.instanceOf
+import io.mockk.coEvery
+import io.mockk.mockk
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.util.getGraphqlErrors
+import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
+import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import java.util.*
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+class MutationExceptionTests : DescribeSpec({
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+    val kafkaProducer = mockk<HendelseProdusent>()
+    val engine = ktorProdusentTestServer(
+        kafkaProducer = kafkaProducer,
+        produsentRepository = produsentRepository,
+    )
+
+    val gyldigeMutations = listOf(
+        "nyBeskjed" to """mutation {
+            nyBeskjed(nyBeskjed: {
+                mottaker: {
+                    naermesteLeder: {
+                        naermesteLederFnr: "12345678910",
+                        ansattFnr: "321"
+                    } 
+                }
+                notifikasjon: {
+                    lenke: "https://foo.bar",
+                    tekst: "hello world",
+                    merkelapp: "tag",
+                }
+                metadata: {
+                    eksternId: "${UUID.randomUUID()}",
+                    opprettetTidspunkt: "2019-10-12T07:20:50.52Z"
+                    virksomhetsnummer: "42"
+                    hardDelete: {
+                      den: "2019-10-13T07:20:50.52"
+                    }
+                }
+            }) {
+                __typename
+                ... on NyBeskjedVellykket {
+                    id
+                }
+                ... on Error {
+                    feilmelding
+                }
+            }
+        }""",
+
+        "nyOppgave" to """mutation { 
+            nyOppgave(nyOppgave: {
+                mottaker: {
+                    naermesteLeder: {
+                        naermesteLederFnr: "12345678910",
+                        ansattFnr: "321"
+                    } 
+                }
+                notifikasjon: {
+                    lenke: "https://foo.bar",
+                    tekst: "hello world",
+                    merkelapp: "tag",
+                }
+                metadata: {
+                    eksternId: "${UUID.randomUUID()}",
+                    opprettetTidspunkt: "2019-10-12T07:20:50.52Z"
+                    virksomhetsnummer: "42"
+                    hardDelete: {
+                      den: "2019-10-13T07:20:50.52"
+                    }
+                }
+            }) {
+                __typename
+                ... on NyOppgaveVellykket {
+                    id
+                }
+                ... on Error {
+                    feilmelding
+                }
+            }
+        }""",
+
+        "nySak" to """mutation {
+                nySak(
+                    virksomhetsnummer: "1"
+                    merkelapp: "tag"
+                    grupperingsid: "42"
+                    mottakere: [{
+                        altinn: {
+                            serviceCode: "5441"
+                            serviceEdition: "1"
+                        }
+                    }]
+                    initiellStatus: MOTTATT
+                    tidspunkt: "2020-01-01T01:01Z"
+                    tittel: "foo"
+                    lenke: "https://foo.no"
+                ) {
+                    __typename
+                    ... on NySakVellykket {
+                        id
+                    }
+                    
+                    ... on Error {
+                        feilmelding
+                    }
+                }
+        }""",
+    )
+
+    describe("robusthet ved intern feil") {
+        withData(gyldigeMutations) { (name, query) ->
+            coEvery { kafkaProducer.send(any()) }.throws(RuntimeException("woops!"))
+            val response = engine.produsentApi(query)
+            response.getGraphqlErrors() should beEmpty()
+            val err = response.getTypedContent<Error>(name)
+            err shouldBe instanceOf<Error.InternFeil>()
+        }
+    }
+})
+

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
@@ -53,6 +53,7 @@ fun TestApplicationResponse.getGraphqlErrors(): List<GraphQLError> {
         throw NullPointerException("content is null. status:${status()}")
     }
     val tree = laxObjectMapper.readTree(this.content!!)
+    logger().info("content: $tree")
     val errors = tree.get("errors")
     return if (errors == null) emptyList() else laxObjectMapper.convertValue(errors)
 }


### PR DESCRIPTION
Når det oppstår en uhåndtert feil i kall til produsent api, så bryter vi kontrakt P.T. som resulterer i en misvisende feilmelding til produsent da vi ikek oppfyller kontrakt pga null data, og bare returnerer error.  Dette kommer av en bug i vår kode hvor vi ikke angir hvilket felt feilen er koblet til.

bund ukjent feil til korrekt path

Dersom path ikke er angitt blir det ansett som en ugyldig respons da null ikke er tillatt i skjemadeklarasjonen. 
Mekanismen GraphQL specen angir for å kunne kommunisere at null er korrekt er via path:
Fra spec: 
> If an error can be associated to a particular field in the GraphQL result, it must contain an entry with the key path that details the path of the response field which experienced the error. This allows clients to identify whether a null result is intentional or caused by a runtime error.

https://spec.graphql.org/June2018/#sec-Errors