### PR TITLE
unngå repeated send ved exception i serialisering av respons

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/AltinnVarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/AltinnVarselKlient.kt
@@ -2,7 +2,9 @@ package no.nav.arbeidsgiver.notifikasjon.ekstern_varsling
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.databind.node.TextNode
 import io.ktor.http.HttpHeaders.Authorization
+import io.ktor.util.logging.*
 import kotlinx.coroutines.runBlocking
 import no.altinn.schemas.serviceengine.formsengine._2009._10.TransportType
 import no.altinn.schemas.services.serviceengine.notification._2009._10.*
@@ -278,7 +280,12 @@ class AltinnVarselKlientImpl(
                 )
                 Result.success(
                     AltinnVarselKlient.AltinnResponse.Ok(
-                        rå = laxObjectMapper.valueToTree(response),
+                        rå = try {
+                            laxObjectMapper.valueToTree(response)
+                        } catch (e: Throwable) {
+                            log.error(e)
+                            TextNode(e.message)
+                        },
                     )
                 )
             } catch (e: INotificationAgencyExternalBasicSendStandaloneNotificationBasicV3AltinnFaultFaultFaultMessage) {


### PR DESCRIPTION
Oppdaget i test at dersom serilisering feiler så går det i loop på send. dette skjedde når vi testet en annen serialisering (ifbm #115)