### PR TITLE
fjern cleanup processing loop

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -1,6 +1,5 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
@@ -14,7 +13,6 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.HttpAuthProviders
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.JWTAuthentication
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.extractProdusentContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.launchGraphqlServer
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.NOTIFIKASJON_TOPIC
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.lagKafkaHendelseProdusent
@@ -86,70 +84,6 @@ object Produsent {
                 extractContext = extractProdusentContext(produsentRegister),
                 graphql = graphql
             )
-
-            launchProcessingLoop(
-                "cleanup duplicate mottakere nærmeste leder",
-                pauseAfterEach = Duration.ofMillis(200)
-            ) {
-                val db = database.await()
-
-                val duplikateIder = db.nonTransactionalExecuteQuery(
-                    """
-                        select jsonb_agg(id) as idr
-                        from mottaker_digisyfo
-                        group by notifikasjon_id
-                        having count(*) > 1
-                        limit 100
-                    """
-                ) {
-                    laxObjectMapper.readValue<List<Long>>(getString("idr"))
-                }
-
-                val resultat = db.nonTransactionalExecuteBatch("""
-                    delete from mottaker_digisyfo
-                    where id = ?
-                """,
-                    duplikateIder.flatMap { it.sorted().drop(1) }.take(10_000)
-                ) {
-                    long(it)
-                }
-
-                if (duplikateIder.isNotEmpty()) {
-                    log.info("fant ${duplikateIder.size} digisyfo-mottakere med duplikater. slettet ${resultat.sum()} rader av ${resultat.size} forsøkte")
-                }
-            }
-
-            launchProcessingLoop(
-                "cleanup duplicate mottakere altinn",
-                pauseAfterEach = Duration.ofMillis(200)
-            ) {
-                val db = database.await()
-
-                val duplikateIder = db.nonTransactionalExecuteQuery(
-                    """
-                        select jsonb_agg(id) as idr
-                        from mottaker_altinn_enkeltrettighet
-                        group by notifikasjon_id
-                        having count(*) > 1
-                        limit 100
-                    """
-                ) {
-                    laxObjectMapper.readValue<List<Long>>(getString("idr"))
-                }
-
-                val resultat = db.nonTransactionalExecuteBatch("""
-                    delete from mottaker_altinn_enkeltrettighet
-                    where id = ?
-                """,
-                    duplikateIder.flatMap { it.sorted().drop(1) }.take(10_000)
-                ) {
-                    long(it)
-                }
-
-                if (duplikateIder.isNotEmpty()) {
-                    log.info("fant ${duplikateIder.size} altinn-mottakere med duplikater. slettet ${resultat.sum()} rader av ${resultat.size} forsøkte")
-                }
-            }
 
             launch {
                 val altinnRolleService = AltinnRolleServiceImpl(


### PR DESCRIPTION
Ser databasen er på 100% cpu. Er nok fordi vi kjører en sekvensiell scan av hele databasen 10 ganger i minuttet pr pod.

Sjekket at migreringen er fullført i prod. Så skrur av. 