### PR TITLE
Metrics for poll-body. Single thread for kafka-consumer.

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelsesstrøm.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelsesstrøm.kt
@@ -5,12 +5,12 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HendelseMetadata
 import java.util.concurrent.atomic.AtomicBoolean
 
 interface Hendelsesstrøm {
-    suspend fun forEach(
+    fun forEach(
         stop: AtomicBoolean = AtomicBoolean(false),
         body: suspend (Hendelse, HendelseMetadata) -> Unit
     )
 
-    suspend fun forEach(
+    fun forEach(
         stop: AtomicBoolean = AtomicBoolean(false),
         body: suspend (Hendelse) -> Unit
     ) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -111,7 +111,7 @@ private constructor(
         stop: AtomicBoolean = AtomicBoolean(false),
         body: suspend (ConsumerRecord<K, V>) -> Unit
     ) {
-        thread(name = "kafka-consumer") {
+        val t = thread(name = "kafka-consumer") {
             while (!stop.get() && !Health.terminating) {
                 replayer.replayWhenLeap()
                 consumer.resume(resumeQueue.pollAll())
@@ -127,6 +127,7 @@ private constructor(
                 })
             }
         }
+        t.join()
     }
 
     private fun forEachRecord(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -2,11 +2,16 @@ package no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka
 
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.Timer
 import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.toThePowerOf
 import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
@@ -23,6 +28,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.schedule
+import kotlin.concurrent.thread
 
 class CoroutineKafkaConsumer<K, V>
 private constructor(
@@ -36,6 +42,9 @@ private constructor(
     private val onPartitionRevoked: ((partition: TopicPartition) -> Unit)?,
     private val configure: Properties.() -> Unit = {},
 ) {
+    private val pollBodyTimer = Timer.builder("kafka.poll.body")
+        .register(Metrics.meterRegistry)
+
     companion object {
         fun <K, V, KS : Deserializer<K>, VS: Deserializer<V>> new(
             topic: String,
@@ -98,32 +107,29 @@ private constructor(
         enabled = replayPeriodically,
     )
 
-
-    suspend fun forEach(
+    fun forEach(
         stop: AtomicBoolean = AtomicBoolean(false),
         body: suspend (ConsumerRecord<K, V>) -> Unit
     ) {
-        while (!stop.get() && !Health.terminating) {
-            replayer.replayWhenLeap()
-            consumer.resume(resumeQueue.pollAll())
-            val records = try {
-                poll(Duration.ofMillis(1000))
-            } catch (e: Exception) {
-                log.error("Unrecoverable error during poll {}", consumer.assignment(), e)
-                throw e
-            }
+        thread(name = "kafka-consumer") {
+            while (!stop.get() && !Health.terminating) {
+                replayer.replayWhenLeap()
+                consumer.resume(resumeQueue.pollAll())
+                val records = try {
+                    consumer.poll(Duration.ofMillis(1000))
+                } catch (e: Exception) {
+                    log.error("Unrecoverable error during poll {}", consumer.assignment(), e)
+                    throw e
+                }
 
-            forEachRecord(records, body)
+                pollBodyTimer.record(Runnable {
+                    forEachRecord(records, body)
+                })
+            }
         }
-        log.info("kafka consumer stopped")
     }
 
-    private suspend fun poll(timeout: Duration): ConsumerRecords<K, V> =
-        withContext(Dispatchers.IO) {
-            consumer.poll(timeout)
-        }
-
-    private suspend fun forEachRecord(
+    private fun forEachRecord(
         records: ConsumerRecords<K, V>,
         body: suspend (ConsumerRecord<K, V>) -> Unit
     ) {
@@ -136,7 +142,9 @@ private constructor(
             records.records(partition).forEach currentRecord@{ record ->
                 try {
                     log.info("processing {}", record.loggableToString())
-                    body(record)
+                    runBlocking(Dispatchers.IO) {
+                        body(record)
+                    }
                     consumer.commitSync(mapOf(partition to OffsetAndMetadata(record.offset() + 1)))
                     log.info("successfully processed {}", record.loggableToString())
                     retries.set(0)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
@@ -28,7 +28,7 @@ class HendelsesstrømKafkaImpl(
         configure = configure,
     )
 
-    override suspend fun forEach(
+    override fun forEach(
         stop: AtomicBoolean,
         body: suspend (Hendelse, HendelseMetadata) -> Unit
     ) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/JsonNodeHendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/JsonNodeHendelsesstrømKafkaImpl.kt
@@ -23,7 +23,7 @@ class JsonNodeKafkaConsumer(
         configure = configure,
     )
 
-    suspend fun forEach(
+    fun forEach(
         body: suspend (JsonNode) -> Unit
     ) {
         consumer.forEach { record ->

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/KafkaHendelsesstrømTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/KafkaHendelsesstrømTests.kt
@@ -29,14 +29,14 @@ class KafkaHendelsesstrømTests: DescribeSpec({
         hendelsesstrøm.forEach(stop) { hendelse ->
             receivedHendelse.add(hendelse)
             received.add(hendelse.hendelseId)
-            if (sent == received || (received - sent).isNotEmpty() ) {
+            if (sent == received || (received - sent).isNotEmpty()) {
                 stop.set(true)
             }
         }
 
         it("should have exactly the same ids and events we sent") {
-            sent shouldBe received
-            EksempelHendelse.Alle shouldContainExactlyInAnyOrder receivedHendelse
+            received shouldBe sent
+            receivedHendelse shouldContainExactlyInAnyOrder EksempelHendelse.Alle
         }
     }
 })


### PR DESCRIPTION
Kafka-consumer har ikke kjørt parallelt, men har brukt Dispatcher.IO, så poll kan ha skjedd med forskjellige tråder. Bruker derfor thread for å sikre at Kafka-consumer altid kjører i samme tråd.