### PR TITLE
set mer aggresiv timeout i ereg klient

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Enhetsregisteret.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Enhetsregisteret.kt
@@ -68,7 +68,7 @@ class EnhetsregisteretImpl(
         engine {
             socketTimeout = 1000
             connectTimeout = 1000
-            connectionRequestTimeout = 1000
+            connectionRequestTimeout = 2000
         }
     }
 


### PR DESCRIPTION
vi gjør potensielt mange kall til ereg per request fra bruker, som kan ende med heng dersom mange av disse blir stående å vente på default rimeout som er 10 sekunder for socket og connect og 20 sekunder for request