### PR TITLE
ignorer brukerklikk hvor aggregat ikke finnes lenger

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktModel.kt
@@ -294,7 +294,11 @@ class DataproduktModel(
                 database.nonTransactionalExecuteUpdate(
                     """
                         insert into notifikasjon_klikk (hendelse_id, notifikasjon_id, fnr, klikket_paa_tidspunkt) 
-                        values (?, ?, ?, ?)
+                        select val.hendelse_id, val.notifikasjon_id, val.fnr, val.klikket_paa_tidspunkt
+                        from  (
+                          values (?, ?, ?, ?)
+                        ) val (hendelse_id, notifikasjon_id, fnr, klikket_paa_tidspunkt)
+                        join  notifikasjon using (notifikasjon_id)
                         on conflict do nothing
                     """
                 ) {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
@@ -444,6 +444,13 @@ object EksempelHendelse {
         kildeAppNavn = "1",
         fnr = "42"
     )
+    val BrukerKlikketPåDeletedNotifikasjon = HendelseModel.BrukerKlikket(
+        virksomhetsnummer = "1",
+        notifikasjonId = UUID.randomUUID(),
+        hendelseId = hendelseId.next(),
+        kildeAppNavn = "1",
+        fnr = "42"
+    )
     val EksterntVarselVellykket = HendelseModel.EksterntVarselVellykket(
         virksomhetsnummer = "1",
         notifikasjonId = uuid("1"),
@@ -586,6 +593,7 @@ object EksempelHendelse {
         SoftDelete,
         HardDelete,
         BrukerKlikket,
+        BrukerKlikketPåDeletedNotifikasjon,
         EksterntVarselVellykket,
         EksterntVarselFeilet,
         SakOpprettet,


### PR DESCRIPTION
Dette er feks tilfelle etter hard delete.
Vi kan enten fjerne fremmednøkkel, men da må vi slette manuelt i stedet for cascade delete eller så kan vi beholde fremmednøkkel og droppe inserts hvor aggregat ikke finnes.

Man kunne vurdert å beholde aggregat idene som er slettet, og hoppe over kun hvis vi vet at aggregatet er slettet ved å sjekke mot slettede ider. Men dette er kanskje godt nok for å få bort blokkeringen.