### PR TITLE
Fix bq connection

### DIFF
--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -27,10 +27,12 @@ resource "google_bigquery_connection" "this" {
   location      = var.region
   project       = var.project
 
+
   cloud_sql {
-    instance_id = data.google_sql_database_instance.this.connection_name
-    database    = "dataprodukt-model"
-    type        = "POSTGRES"
+    service_account_id = google_service_account.sa-notifikasjon-dataprodukt.email
+    instance_id        = data.google_sql_database_instance.this.connection_name
+    database           = "dataprodukt-model"
+    type               = "POSTGRES"
     credential {
       username = google_sql_user.this.name
       password = google_sql_user.this.password

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -42,7 +42,7 @@ resource "google_bigquery_connection" "this" {
 
 resource "google_project_iam_member" "sa-bq-roles" {
   for_each = toset([
-    "roles/bigquery.connectionAdmin",
+    "bigquery.connectionAdmin",
     "cloudsql.client",
   ])
   project = var.project

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -47,7 +47,7 @@ resource "google_project_iam_member" "sa-bq-roles" {
   ])
   project = var.project
   role    = "roles/${each.key}"
-  member  = "serviceAccount:${google_bigquery_connection.this.cloud_sql.service_account_id}"
+  member  = "serviceAccount:${google_bigquery_connection.this.cloud_sql[0].service_account_id}"
 }
 
 resource "google_bigquery_table" "notifikasjon" {

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -40,6 +40,16 @@ resource "google_bigquery_connection" "this" {
   }
 }
 
+resource "google_project_iam_member" "sa-bq-roles" {
+  for_each = toset([
+    "roles/bigquery.connectionAdmin",
+    "cloudsql.client",
+  ])
+  project = var.project
+  role    = "roles/${each.key}"
+  member  = "serviceAccount:${google_bigquery_connection.this.cloud_sql.service_account_id}"
+}
+
 resource "google_bigquery_table" "notifikasjon" {
   dataset_id          = google_bigquery_dataset.this.dataset_id
   table_id            = "notifikasjon"

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -30,9 +30,9 @@ resource "google_bigquery_connection" "this" {
 
 
   cloud_sql {
-    instance_id        = data.google_sql_database_instance.this.connection_name
-    database           = "dataprodukt-model"
-    type               = "POSTGRES"
+    instance_id = data.google_sql_database_instance.this.connection_name
+    database    = "dataprodukt-model"
+    type        = "POSTGRES"
     credential {
       username = google_sql_user.this.name
       password = google_sql_user.this.password

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -25,6 +25,8 @@ resource "google_bigquery_connection" "this" {
   friendly_name = "Notifikasjon dataprodukt connection"
   description   = "Connection mot postgresql-databasen til notifikasjon dataprodukt"
   location      = var.region
+  project       = var.project
+
   cloud_sql {
     instance_id = data.google_sql_database_instance.this.connection_name
     database    = "dataprodukt-model"
@@ -34,6 +36,22 @@ resource "google_bigquery_connection" "this" {
       password = google_sql_user.this.password
     }
   }
+}
+
+resource "google_bigquery_connection_iam_member" "sa_bq_connection_admin" {
+  project       = google_bigquery_connection.this.project
+  location      = google_bigquery_connection.this.location
+  connection_id = google_bigquery_connection.this.connection_id
+  role          = "roles/bigquery.connectionAdmin"
+  member        = "serviceAccount:${google_service_account.sa-notifikasjon-dataprodukt.email}"
+}
+
+resource "google_bigquery_connection_iam_member" "sa_bq_cloudsql_client" {
+  project       = google_bigquery_connection.this.project
+  location      = google_bigquery_connection.this.location
+  connection_id = google_bigquery_connection.this.connection_id
+  role          = "roles/cloudsql.client"
+  member        = "serviceAccount:${google_service_account.sa-notifikasjon-dataprodukt.email}"
 }
 
 resource "google_bigquery_table" "notifikasjon" {

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -38,22 +38,6 @@ resource "google_bigquery_connection" "this" {
   }
 }
 
-resource "google_bigquery_connection_iam_member" "sa_bq_connection_admin" {
-  project       = google_bigquery_connection.this.project
-  location      = google_bigquery_connection.this.location
-  connection_id = google_bigquery_connection.this.connection_id
-  role          = "roles/bigquery.connectionAdmin"
-  member        = "serviceAccount:${google_service_account.sa-notifikasjon-dataprodukt.email}"
-}
-
-resource "google_bigquery_connection_iam_member" "sa_bq_cloudsql_client" {
-  project       = google_bigquery_connection.this.project
-  location      = google_bigquery_connection.this.location
-  connection_id = google_bigquery_connection.this.connection_id
-  role          = "roles/cloudsql.client"
-  member        = "serviceAccount:${google_service_account.sa-notifikasjon-dataprodukt.email}"
-}
-
 resource "google_bigquery_table" "notifikasjon" {
   dataset_id          = google_bigquery_dataset.this.dataset_id
   table_id            = "notifikasjon"

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -2,11 +2,12 @@ resource "google_bigquery_dataset" "this" {
   dataset_id    = "notifikasjon_platform_dataset"
   friendly_name = "Notifikasjon platform dataset"
   location      = var.region
-  #  project       = var.project
+  project       = var.project
 }
 
 data "google_sql_database_instance" "this" {
-  name = "notifikasjon-dataprodukt"
+  name    = "notifikasjon-dataprodukt"
+  project = var.project
 }
 
 resource "random_password" "this" {
@@ -29,7 +30,6 @@ resource "google_bigquery_connection" "this" {
 
 
   cloud_sql {
-    service_account_id = google_service_account.sa-notifikasjon-dataprodukt.email
     instance_id        = data.google_sql_database_instance.this.connection_name
     database           = "dataprodukt-model"
     type               = "POSTGRES"

--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -11,7 +11,6 @@ resource "google_project_iam_member" "sa-notifikasjon-dataprodukt-roles" {
     "bigquery.metadataViewer",
     "bigquery.connectionUser",
     "bigquery.dataEditor",
-    "bigquery.connections.setIamPolicy",
     "cloudsql.client",
   ])
   project = var.project

--- a/terraform/service_account.tf
+++ b/terraform/service_account.tf
@@ -11,6 +11,7 @@ resource "google_project_iam_member" "sa-notifikasjon-dataprodukt-roles" {
     "bigquery.metadataViewer",
     "bigquery.connectionUser",
     "bigquery.dataEditor",
+    "bigquery.connections.setIamPolicy",
     "cloudsql.client",
   ])
   project = var.project


### PR DESCRIPTION
Det ser ut som cloud_sql ender med en generert service bruker som ikek er en del av prosjektet. 
Hvorfor dette funker i dev og ikke i prod er fortsatt et mysterie.

Tror dette muligens skaø løse problemet.

Hvis det gjør det kan vi kanskje fjerne den andre service brukeren "sa-notifikasjon-dataprodukt"