### PR TITLE
Database-indekser for dataprodukt

### DIFF
--- a/app/src/main/resources/db/migration/dataprodukt_model/V6__indexes_for_deletion.sql
+++ b/app/src/main/resources/db/migration/dataprodukt_model/V6__indexes_for_deletion.sql
@@ -1,0 +1,25 @@
+-- index for query:
+--     DELETE FROM aggregat_hendelse WHERE aggregat_id = $1
+create index aggregat_hendelse_aggregat_id_idx on
+    aggregat_hendelse (aggregat_id);
+
+-- index for query:
+--     DELETE FROM notifikasjon WHERE notifikasjon_id = $1
+create index notifikasjon_notifikasojn_id_idx on
+    notifikasjon (notifikasjon_id);
+
+-- index for query:
+--     DELETE FROM sak WHERE sak_id = $1
+create index sak_sak_id_idx on
+    sak (sak_id);
+
+
+-- Index for query:
+--     UPDATE ekstern_varsel
+--     SET status_utsending = $2
+--     WHERE
+--           notifikasjon_id = $1
+--       AND opprinnelse = $3
+--       AND status_utsending = $4
+create index ekstern_varsel_notifikasjon_id_idx on
+    ekstern_varsel (notifikasjon_id);


### PR DESCRIPTION
dataprodukt-appen er tregere enn andre apps på replay av kafka. Ser i query insight at det nok er fordi vi ikke har noen indekser for sletting/oppdatering av eksisterende rader.