### PR TITLE
oppdater til ny client id for å støtte kall gjennom saas-proxy

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegisterImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegisterImpl.kt
@@ -144,7 +144,7 @@ val ARBEIDSGIVERDIALOG = Produsent(
     accessPolicy = basedOnEnv(
         prod = { listOf() },
         other = { listOf(
-            "dev-gcp:team-dialog:crm-arbeidsgiver-notifikasjon",
+            "dev-external:teamcrm:salesforce",
         ) },
     ),
     tillatteMerkelapper = listOf(

--- a/config/dev-gcp-produsent-api.yaml
+++ b/config/dev-gcp-produsent-api.yaml
@@ -74,9 +74,14 @@ spec:
         - application: toi-arbeidsgiver-notifikasjon
           namespace: toi
           cluster: dev-gcp
-
-        - application: crm-arbeidsgiver-notifikasjon
-          namespace: team-dialog
+          
+        - application: saas-proxy
+          namespace: teamcrm
           cluster: dev-gcp
+
+        - application: salesforce
+          namespace: teamcrm
+          cluster: dev-external
+
   envFrom:
     - secret: notifikasjon-produsent-api-secrets


### PR DESCRIPTION
team dialog kommer til å identifisere seg som salesforce. 

ref: 
* https://confluence.adeo.no/x/ydKwGQ
* https://nav-it.slack.com/archives/C02F7211DQ8/p1676983114598859