### PR TITLE
når cicd dispatches hopper vi over deploy selv om vi er på main

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -90,7 +90,7 @@ jobs:
   deploy:
     needs: [build]
     runs-on: ubuntu-20.04
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     strategy:
       matrix:
         cluster:


### PR DESCRIPTION
Endre slik at hvis vi manuelt trigger cicd på main så blir det også deployet

Jeg tror vi hadde denne begrensningen for å kunne dele opp build og deploy i dev, og manuelt kunne trigge build/cicd
Dersom noe feiler på main så er det kjekt å kunne trigge den hvis manuelt når det er forstyrrelser feks på github.
I de tilfellene så gir det ikke mening å hoppe over selve deployen tenker jeg. build av main manuelt bør føre til deploy.

oppdaget dette mens jeg forsøkte å teste/fikse deploy oppsettet