### PR TITLE
partial replay on harddeleted aggregates fails in production

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/HardDeletedRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/HardDeletedRepository.kt
@@ -1,0 +1,26 @@
+package no.nav.arbeidsgiver.notifikasjon.hendelse
+
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
+import java.util.*
+
+open class HardDeletedRepository(private val database: Database) {
+    suspend fun erHardDeleted(aggregateId: UUID) =
+        database.nonTransactionalExecuteQuery("""
+            select * from hard_deleted_aggregates where aggregate_id = ?
+            """,
+            { uuid(aggregateId) }
+        ) {}.isNotEmpty()
+
+    suspend fun registrerHardDelete(hendelse: HendelseModel.Hendelse) {
+        if (hendelse !is HendelseModel.HardDelete) {
+            return
+        }
+
+        database.nonTransactionalExecuteUpdate("""
+            insert into hard_deleted_aggregates(aggregate_id) values (?)
+            on conflict do nothing
+        """) {
+            uuid(hendelse.aggregateId)
+        }
+    }
+}

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModel.kt
@@ -96,8 +96,9 @@ class KafkaReaperModelImpl(
     override suspend fun fjernRelasjon(hendelseId: UUID) {
         database.nonTransactionalExecuteUpdate(
             """
-                DELETE FROM notifikasjon_hendelse_relasjon
-                WHERE hendelse_id = ?
+                delete from notifikasjon_hendelse_relasjon
+                where hendelse_id = ? 
+                and hendelse_type != 'HardDelete'
             """
         ) {
             uuid(hendelseId)

--- a/app/src/main/resources/db/migration/bruker_model/V27__hard_deleted_aggregates.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V27__hard_deleted_aggregates.sql
@@ -1,0 +1,3 @@
+create table hard_deleted_aggregates(
+    aggregate_id uuid not null primary key
+)

--- a/app/src/main/resources/db/migration/dataprodukt_model/V12__hard_deleted_aggregates.sql
+++ b/app/src/main/resources/db/migration/dataprodukt_model/V12__hard_deleted_aggregates.sql
@@ -1,0 +1,3 @@
+create table hard_deleted_aggregates(
+    aggregate_id uuid not null primary key
+)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt
@@ -40,4 +40,16 @@ class BrukerModelIdempotensTests : DescribeSpec({
             }
         }
     }
+
+    describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
+        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
+            context("$i - ${hendelse.typeNavn}") {
+                queryModel.oppdaterModellEtterHendelse(EksempelHendelse.HardDelete.copy(
+                    virksomhetsnummer = hendelse.virksomhetsnummer,
+                    aggregateId = hendelse.aggregateId,
+                ))
+                queryModel.oppdaterModellEtterHendelse(hendelse)
+            }
+        }
+    }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt
@@ -33,14 +33,6 @@ class BrukerModelIdempotensTests : DescribeSpec({
 
     }
 
-    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
-        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
-            context("$i - ${hendelse.typeNavn}") {
-                queryModel.oppdaterModellEtterHendelse(hendelse)
-            }
-        }
-    }
-
     describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
         EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
             context("$i - ${hendelse.typeNavn}") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt
@@ -3,6 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon.bruker
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import no.nav.arbeidsgiver.notifikasjon.kafka_reaper.typeNavn
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 
@@ -27,6 +28,15 @@ class BrukerModelIdempotensTests : DescribeSpec({
                 ) {
                 }.size
                 antallMottakere shouldBe 1
+            }
+        }
+
+    }
+
+    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
+        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
+            context("$i - ${hendelse.typeNavn}") {
+                queryModel.oppdaterModellEtterHendelse(hendelse)
             }
         }
     }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktIdempotensTests.kt
@@ -28,4 +28,16 @@ class DataproduktIdempotensTests : DescribeSpec({
             }
         }
     }
+
+    describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
+        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
+            context("$i - ${hendelse.typeNavn}") {
+                subject.oppdaterModellEtterHendelse(EksempelHendelse.HardDelete.copy(
+                    virksomhetsnummer = hendelse.virksomhetsnummer,
+                    aggregateId = hendelse.aggregateId,
+                ), metadata)
+                subject.oppdaterModellEtterHendelse(hendelse, metadata)
+            }
+        }
+    }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktIdempotensTests.kt
@@ -21,14 +21,6 @@ class DataproduktIdempotensTests : DescribeSpec({
         }
     }
 
-    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
-        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
-            context("$i - ${hendelse.typeNavn}") {
-                subject.oppdaterModellEtterHendelse(hendelse, metadata)
-            }
-        }
-    }
-
     describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
         EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
             context("$i - ${hendelse.typeNavn}") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingIdempotensTests.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.ekstern_varsling
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
+import no.nav.arbeidsgiver.notifikasjon.kafka_reaper.typeNavn
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 
@@ -13,6 +14,14 @@ class EksternVarslingIdempotensTests : DescribeSpec({
         withData(EksempelHendelse.Alle) { hendelse ->
             repository.oppdaterModellEtterHendelse(hendelse)
             repository.oppdaterModellEtterHendelse(hendelse)
+        }
+    }
+
+    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
+        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
+            context("$i - ${hendelse.typeNavn}") {
+                repository.oppdaterModellEtterHendelse(hendelse)
+            }
         }
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingIdempotensTests.kt
@@ -17,14 +17,6 @@ class EksternVarslingIdempotensTests : DescribeSpec({
         }
     }
 
-    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
-        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
-            context("$i - ${hendelse.typeNavn}") {
-                repository.oppdaterModellEtterHendelse(hendelse)
-            }
-        }
-    }
-
     describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
         EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
             context("$i - ${hendelse.typeNavn}") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingIdempotensTests.kt
@@ -24,4 +24,16 @@ class EksternVarslingIdempotensTests : DescribeSpec({
             }
         }
     }
+
+    describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
+        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
+            context("$i - ${hendelse.typeNavn}") {
+                repository.oppdaterModellEtterHendelse(EksempelHendelse.HardDelete.copy(
+                    virksomhetsnummer = hendelse.virksomhetsnummer,
+                    aggregateId = hendelse.aggregateId,
+                ))
+                repository.oppdaterModellEtterHendelse(hendelse)
+            }
+        }
+    }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModelIdempotensTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModelIdempotensTest.kt
@@ -16,9 +16,13 @@ class KafkaReaperModelIdempotensTest : DescribeSpec({
         }
     }
 
-    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
+    describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
         EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
             context("$i - ${hendelse.typeNavn}") {
+                model.oppdaterModellEtterHendelse(EksempelHendelse.HardDelete.copy(
+                    virksomhetsnummer = hendelse.virksomhetsnummer,
+                    aggregateId = hendelse.aggregateId,
+                ))
                 model.oppdaterModellEtterHendelse(hendelse)
             }
         }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModelIdempotensTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModelIdempotensTest.kt
@@ -5,7 +5,7 @@ import io.kotest.datatest.withData
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 
-class KafkaReaperModelTest : DescribeSpec({
+class KafkaReaperModelIdempotensTest : DescribeSpec({
     val database = testDatabase(KafkaReaper.databaseConfig)
     val model = KafkaReaperModelImpl(database)
 
@@ -13,6 +13,14 @@ class KafkaReaperModelTest : DescribeSpec({
         withData(EksempelHendelse.Alle) { hendelse ->
             model.oppdaterModellEtterHendelse(hendelse)
             model.oppdaterModellEtterHendelse(hendelse)
+        }
+    }
+
+    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
+        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
+            context("$i - ${hendelse.typeNavn}") {
+                model.oppdaterModellEtterHendelse(hendelse)
+            }
         }
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
@@ -63,14 +63,6 @@ class ProdusentModelIdempotensTests : DescribeSpec({
         }
     }
 
-    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
-        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
-            context("$i - ${hendelse.typeNavn}") {
-                produsentModel.oppdaterModellEtterHendelse(hendelse)
-            }
-        }
-    }
-
     describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
         EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
             context("$i - ${hendelse.typeNavn}") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
@@ -3,11 +3,11 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import no.nav.arbeidsgiver.notifikasjon.kafka_reaper.typeNavn
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
-import no.nav.arbeidsgiver.notifikasjon.util.uuid
 
 class ProdusentModelIdempotensTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
@@ -32,6 +32,14 @@ class ProdusentModelIdempotensTests : DescribeSpec({
                 ) {
                 }.size
                 antallMottakere shouldBe 1
+            }
+        }
+    }
+
+    describe("Håndterer partial replay hvor midt i hendelsesforløp") {
+        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
+            context("$i - ${hendelse.typeNavn}") {
+                produsentModel.oppdaterModellEtterHendelse(hendelse)
             }
         }
     }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
@@ -43,4 +43,16 @@ class ProdusentModelIdempotensTests : DescribeSpec({
             }
         }
     }
+
+    describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
+        EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
+            context("$i - ${hendelse.typeNavn}") {
+                produsentModel.oppdaterModellEtterHendelse(EksempelHendelse.HardDelete.copy(
+                    virksomhetsnummer = hendelse.virksomhetsnummer,
+                    aggregateId = hendelse.aggregateId,
+                ))
+                produsentModel.oppdaterModellEtterHendelse(hendelse)
+            }
+        }
+    }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
@@ -22,7 +22,7 @@ object EksempelHendelse {
         .map { uuid(it.toString()) }
         .iterator()
 
-    private fun <T> withId(blokk: (id: UUID)-> T ) : T = hendelseId.next().let { blokk.invoke(it) }
+    private fun <T> withId(blokk: (id: UUID)-> T) : T = hendelseId.next().let { blokk.invoke(it) }
 
     val BeskjedOpprettet = withId { id ->
         BeskjedOpprettet(


### PR DESCRIPTION
we have seen partial replays get stuck on hard deleted aggregates i production.
This can typically become an issue when the hard delete is very close to the origin/create event. Then a partial replay moves the offset to an event on the same aggregate after the create, but prior to the hard delete. This in turn makes the consumer stuck as it can not apply the change event on the aggregate that is deleted. 

```
#example pseudo
offset=0: [origin-event] 
offset=1: [change-event]
offset=2: [hard-delete] <- current-offset
state = deleted

replay to offset=1
PSQL unable to insert fkey missing
```

To remedy this we can track the hard deleted aggregates, and if we encounter an event on a hard deleted aggregate skip the processing. 