### PR TITLE
Test som reproduserer situasjon i dev

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
@@ -36,7 +36,6 @@ class HendelsesstrømKafkaImpl(
      */
     private val brokenHendelseId: Set<UUID> = setOf(
         UUID.fromString("75977ac3-5ccd-42d2-ada0-93482462b8a9"),
-        UUID.fromString("32a62734-95db-433d-8e39-b0dbcea57939"),
     )
 
     override suspend fun forEach(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -246,14 +246,19 @@ class ProdusentRepositoryImpl(
                 jsonb(sakOpprettet.mottakere)
                 text(sakOpprettet.tittel)
                 text(sakOpprettet.lenke)
-            }
-
-            executeUpdate("""
-                insert into sak_id (incoming_sak_id, sak_id) values (?, ?)
-                on conflict do nothing
-            """) {
-                uuid(sakOpprettet.sakId)
-                uuid(sakOpprettet.sakId)
+            }.also {
+                if (it == 0) {
+                    // TODO: dersom dette er via HendelseDispatcher bør det propageres som en forretningsfeil
+                    // TODO: dersom det er via consumer så bør vi bare gå videre, evt logge det
+                } else {
+                    executeUpdate("""
+                        insert into sak_id (incoming_sak_id, sak_id) values (?, ?)
+                        on conflict do nothing
+                    """) {
+                        uuid(sakOpprettet.sakId)
+                        uuid(sakOpprettet.sakId)
+                    }
+                }
             }
         }
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -248,8 +248,7 @@ class ProdusentRepositoryImpl(
                 text(sakOpprettet.lenke)
             }.also {
                 if (it == 0) {
-                    // TODO: dersom dette er via HendelseDispatcher bør det propageres som en forretningsfeil
-                    // TODO: dersom det er via consumer så bør vi bare gå videre, evt logge det
+                    // noop. saken finnes allerede
                 } else {
                     executeUpdate("""
                         insert into sak_id (incoming_sak_id, sak_id) values (?, ?)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -92,6 +92,13 @@ internal class MutationNySak(
             eksisterende == null -> {
                 log.info("oppretter ny sak med id $sakId")
                 hendelseDispatcher.send(sakOpprettetHendelse, statusoppdateringHendelse)
+                check(produsentRepository.hentSak(sakId) == null) {
+                    """
+                        Sak med id $sakId ble produsert til kafka men ble ikke lagret i produsent-databasen. 
+                        Dette er sannsynligvis en race condition to saker med samme koordinat opprettet samtidig.
+                    """
+                }
+
                 NySakVellykket(
                     id = sakId,
                 )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
@@ -3,11 +3,12 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
-import no.nav.arbeidsgiver.notifikasjon.util.uuid
+import java.util.*
 
 class ProdusentModelIdempotensTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
@@ -32,6 +33,31 @@ class ProdusentModelIdempotensTests : DescribeSpec({
                 ) {
                 }.size
                 antallMottakere shouldBe 1
+            }
+        }
+
+        /**
+         * Dette skal egentlig ikke skje, men pga en race condition har det skjedd i dev-gcp.
+         * Kan også skje i prod. Resultatet burde være at produsent får fornuftig feilmelding, men pga race condition
+         * blir hendelsene opprettet på kafka og det siste kallet feiler med
+         * Exception while fetching data (/nySak) : ERROR: insert or update on table "sak_id" violates foreign key constraint "sak_id_sak_id_fkey"
+         * Dette burde egentlig blitt kommunisert som Duplikatgrupperingsid til produsent.
+         */
+        context("sak opprettet med forskjellig virksomhetsnummer men samme merkelapp og grupperingsid") {
+            val sakId1 = UUID.randomUUID()
+            val sakId2 = UUID.randomUUID()
+            produsentModel.oppdaterModellEtterHendelse(EksempelHendelse.SakOpprettet.copy(
+                sakId = sakId1,
+                virksomhetsnummer = "42"
+            ))
+            produsentModel.oppdaterModellEtterHendelse(EksempelHendelse.SakOpprettet.copy(
+                sakId = sakId2,
+                virksomhetsnummer = "44"
+            ))
+
+            it("kun en sak opprettes") {
+                produsentModel.hentSak(sakId1) shouldNotBe null
+                produsentModel.hentSak(sakId2) shouldBe null
             }
         }
     }


### PR DESCRIPTION
inkluderer fiks for blokkert partisjon
mangler mapping til fornuftig feilmelding dersom race condition skjer i api. Ikke sikkert vi skal legge så mye energi i det.

Har forsøkt å reprodusere race condition på api i unit testuten hell. Feilen har oppstått da jeg via perftest opprettet et sett med saker hvor flere hadde samme merkelapp og grupperingsid. Ikke veldig sannsynlig at noen ville gjort det samme i prod, men det kan skje.