### PR TITLE
Fjern støtte for søk i status, reset text-søk ved replay

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -571,10 +571,14 @@ class BrukerRepositoryImpl(
 
             executeUpdate(
                 """
-                insert into sak_search(id, text) values (?, lower(?)) on conflict do nothing
+                insert into sak_search(id, text)
+                values (?, lower(?)) 
+                on conflict (id) do update
+                set text = lower(?)
             """
             ) {
                 uuid(sakOpprettet.sakId)
+                text("${sakOpprettet.tittel} ${sakOpprettet.merkelapp}")
                 text("${sakOpprettet.tittel} ${sakOpprettet.merkelapp}")
             }
 
@@ -606,17 +610,6 @@ class BrukerRepositoryImpl(
                 timestamp_with_timezone(nyStatusSak.oppgittTidspunkt ?: nyStatusSak.mottattTidspunkt)
             }
 
-            executeUpdate(
-                """
-                update sak_search
-                set text =  text || ' ' || lower(?) || ' ' || lower(coalesce(?, ''))
-                where id = ?
-            """
-            ) {
-                text(nyStatusSak.status.name)
-                nullableText(nyStatusSak.overstyrStatustekstMed)
-                uuid(nyStatusSak.sakId)
-            }
             if (nyStatusSak.nyLenkeTilSak != null) {
                 executeUpdate(
                     """

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
@@ -199,14 +199,14 @@ class QuerySakerTests : DescribeSpec({
                 saker.first().id shouldBe sak1.sakId
             }
 
-            it("søk på status returnerer riktig sak") {
+            xit("søk på status returnerer riktig sak") {
                 val response = engine.hentSaker(tekstsoek = "ferdig")
                 val saker = response.getTypedContent<List<BrukerAPI.Sak>>("saker/saker")
                 saker shouldHaveSize 1
                 saker.first().id shouldBe sak2.sakId
             }
 
-            it("søk på statustekst returnerer riktig sak") {
+            xit("søk på statustekst returnerer riktig sak") {
                 val response = engine.hentSaker(tekstsoek = "avblåst")
                 val saker = response.getTypedContent<List<BrukerAPI.Sak>>("saker/saker")
                 saker shouldHaveSize 1


### PR DESCRIPTION
Nå så blir status-feltete duplisert når vi replayer en topic (eller deler av den). Skrur derfor av støtten for å søke i status-tekst, og klargjør for å kjøre en replay hvor søke-teksten blir resatt til sak-tittelen.