### PR TITLE
Tag 2123 sqlytelse bruker api

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -338,6 +338,7 @@ class BrukerRepositoryImpl(
                                 merkelapp,
                                 grupperingsid,
                                 sist_endret_tidspunkt,
+                                opprettet_tidspunkt,
                                 count(*) filter (where oppgave_tilstand = 'NY') as nye_oppgaver,
                                 min(oppgave_frist) filter (where oppgave_tilstand = 'NY') as tidligste_frist,
                                 case
@@ -350,7 +351,7 @@ class BrukerRepositoryImpl(
                                     ) order by oppgave_frist nulls last    
                                 ) end as oppgaver
                             from mine_saker_filtrert
-                            group by id, virksomhetsnummer, tittel, lenke, merkelapp, grupperingsid, sist_endret_tidspunkt
+                            group by id, virksomhetsnummer, tittel, lenke, merkelapp, grupperingsid, sist_endret_tidspunkt, opprettet_tidspunkt
                         ),
                         mine_saker_paginert as (
                             select 
@@ -571,9 +572,9 @@ class BrukerRepositoryImpl(
             executeUpdate(
                 """
                 insert into sak(
-                    id, virksomhetsnummer, tittel, lenke, merkelapp, grupperingsid, sist_endret_tidspunkt
+                    id, virksomhetsnummer, tittel, lenke, merkelapp, grupperingsid, sist_endret_tidspunkt, opprettet_tidspunkt
                 )
-                values (?, ?, ? ,?, ?, ?, ?)
+                values (?, ?, ? ,?, ?, ?, ?, ?)
                 on conflict do nothing;
             """
             ) {
@@ -583,6 +584,7 @@ class BrukerRepositoryImpl(
                 text(sakOpprettet.lenke)
                 text(sakOpprettet.merkelapp)
                 text(sakOpprettet.grupperingsid)
+                instantAsText((sakOpprettet.oppgittTidspunkt ?: sakOpprettet.mottattTidspunkt).toInstant())
                 instantAsText((sakOpprettet.oppgittTidspunkt ?: sakOpprettet.mottattTidspunkt).toInstant())
             }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -84,7 +84,10 @@ class Database private constructor(
             }
         }
 
-        suspend fun openDatabase(config: Config): Database {
+        suspend fun openDatabase(
+            config: Config,
+            flywayAction: Flyway.() -> Unit = { migrate () },
+        ): Database {
             val hikariConfig = config.asHikariConfig()
 
             /* When the application runs in kubernetes and connects to the
@@ -105,7 +108,7 @@ class Database private constructor(
 
             val dataSource = NonBlockingDataSource(HikariDataSource(hikariConfig))
             dataSource.withFlyway(config.migrationLocations) {
-                migrate()
+                flywayAction()
             }
 
             return Database(config, dataSource)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -10,11 +10,15 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NyStatusSak
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NærmesteLederMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.coDataFetcher
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgument
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.getTypedArgumentOrNull
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.notifikasjonContext
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.resolveSubtypes
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.wire
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
-import java.lang.RuntimeException
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -146,7 +150,7 @@ internal class MutationNySak(
             sakId = id,
             grupperingsid = grupperingsid,
             merkelapp = merkelapp,
-        mottakere = mottakere.map { it.tilDomene(virksomhetsnummer) },
+            mottakere = mottakere.map { it.tilDomene(virksomhetsnummer) },
             tittel = tittel,
             lenke = lenke,
             oppgittTidspunkt = status.tidspunkt,

--- a/app/src/main/resources/db/migration/bruker_model/V32__sist_endret_paa_sak.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V32__sist_endret_paa_sak.sql
@@ -1,0 +1,2 @@
+alter table sak
+add column sist_endret_tidspunkt text;

--- a/app/src/main/resources/db/migration/bruker_model/V33__opprettet_tidspunkt_paa_sak.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V33__opprettet_tidspunkt_paa_sak.sql
@@ -1,0 +1,2 @@
+alter table sak
+add column opprettet_tidspunkt text;

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.ktor.server.testing.*
+import io.ktor.server.testing.TestApplicationEngine
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.SakSortering.OPPRETTET
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel.Tilgang
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerModel.Tilganger
@@ -17,7 +17,12 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakStatus
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakStatus.FERDIG
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLRequest
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.IdempotenceKey
-import no.nav.arbeidsgiver.notifikasjon.util.*
+import no.nav.arbeidsgiver.notifikasjon.util.AltinnStub
+import no.nav.arbeidsgiver.notifikasjon.util.brukerApi
+import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
+import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.Duration
 import java.time.OffsetDateTime
 import java.util.*
@@ -199,19 +204,24 @@ class QuerySakerTests : DescribeSpec({
                 saker.first().id shouldBe sak1.sakId
             }
 
-            xit("søk på status returnerer riktig sak") {
-                val response = engine.hentSaker(tekstsoek = "ferdig")
-                val saker = response.getTypedContent<List<BrukerAPI.Sak>>("saker/saker")
-                saker shouldHaveSize 1
-                saker.first().id shouldBe sak2.sakId
-            }
-
-            xit("søk på statustekst returnerer riktig sak") {
-                val response = engine.hentSaker(tekstsoek = "avblåst")
-                val saker = response.getTypedContent<List<BrukerAPI.Sak>>("saker/saker")
-                saker shouldHaveSize 1
-                saker.first().id shouldBe sak2.sakId
-            }
+            /** TAG-2137 ignored: vi skrudde av tekstsøk for status, siden vi hadde en
+             * resource leak i forbindelse med replay av hendelser. Søketeksten
+             * ble lengere for hver replay. Quick-fix var å bare bruke tittelen
+             * på saken.
+             */
+            //xit("søk på status returnerer riktig sak") {
+            //    val response = engine.hentSaker(tekstsoek = "ferdig")
+            //    val saker = response.getTypedContent<List<BrukerAPI.Sak>>("saker/saker")
+            //    saker shouldHaveSize 1
+            //    saker.first().id shouldBe sak2.sakId
+            //}
+            //
+            //xit("søk på statustekst returnerer riktig sak") {
+            //    val response = engine.hentSaker(tekstsoek = "avblåst")
+            //    val saker = response.getTypedContent<List<BrukerAPI.Sak>>("saker/saker")
+            //    saker shouldHaveSize 1
+            //    saker.first().id shouldBe sak2.sakId
+            //}
         }
 
         context("søk på tvers av virksomheter") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
@@ -352,9 +352,11 @@ private suspend fun BrukerRepository.opprettSakForTekstsøk(
 
 private suspend fun BrukerRepository.opprettSakMedTidspunkt(
     sakId: UUID,
-    vararg shift: Duration,
+    opprettetShift: Duration,
+    vararg restShift: Duration,
 ) {
-    val oppgittTidspunkt = OffsetDateTime.parse("2022-01-01T13:37:30+02:00")
+    val shift = listOf(opprettetShift) + restShift
+    val mottattTidspunkt = OffsetDateTime.parse("2022-01-01T13:37:30+02:00")
     val sak = SakOpprettet(
         hendelseId = sakId,
         sakId = sakId,
@@ -366,8 +368,8 @@ private suspend fun BrukerRepository.opprettSakMedTidspunkt(
         mottakere = listOf(AltinnMottaker("5441", "1", "42")),
         tittel = "er det no sak",
         lenke = "#foo",
-        oppgittTidspunkt = oppgittTidspunkt,
-        mottattTidspunkt = OffsetDateTime.now(),
+        oppgittTidspunkt = null,
+        mottattTidspunkt = mottattTidspunkt.plus(opprettetShift),
         hardDelete = null,
     ).also {
         oppdaterModellEtterHendelse(it)
@@ -381,9 +383,9 @@ private suspend fun BrukerRepository.opprettSakMedTidspunkt(
             sakId = sak.sakId,
             status = SakStatus.MOTTATT,
             overstyrStatustekstMed = "noe",
-            mottattTidspunkt = oppgittTidspunkt.plus(it),
-            idempotensKey = IdempotenceKey.initial(),
             oppgittTidspunkt = null,
+            mottattTidspunkt = mottattTidspunkt.plus(it),
+            idempotensKey = IdempotenceKey.initial(),
             hardDelete = null,
             nyLenkeTilSak = null,
         ).also { hendelse ->

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/PostgresTestListener.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/PostgresTestListener.kt
@@ -10,11 +10,14 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 fun TestConfiguration.testDatabase(config: Database.Config): Database =
     runBlocking {
         Database.openDatabase(
-            config.copy(
+            config = config.copy(
                 // https://github.com/flyway/flyway/issues/2323#issuecomment-804495818
                 jdbcOpts = mapOf("preparedStatementCacheQueries" to 0),
                 port = "1337",
-            )
+            ),
+            flywayAction = {
+                /* noop. stuff happens in PostgresTestListener.beforeContainer. */
+            }
         )
     }
         .also { listener(PostgresTestListener(it)) }


### PR DESCRIPTION
Legger grunnlaget for at vi kan sortere saker ut fra `sak`-tabellen uten å merge-joine med `sak_status`-tabellen.

Det kommer PR senere som bruker de nye kolonnene.