### PR TITLE
Oppdater eksisterende saker i brukermodel

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -588,6 +588,23 @@ class BrukerRepositoryImpl(
                 instantAsText((sakOpprettet.oppgittTidspunkt ?: sakOpprettet.mottattTidspunkt).toInstant())
             }
 
+
+            /** Slettes etter migrering er kjørt og feltene har fått "not null"-constraint.
+             *  NB. `greatest('foo', null) = 'foo'`, og `least('foo', null) = 'foo'`.
+             **/
+            executeUpdate("""
+                update sak
+                set 
+                    sist_endret_tidspunkt = greatest(sist_endret_tidspunkt, ?),
+                    opprettet_tidspunkt = least(opprettet_tidspunkt, ?)
+                where 
+                    id = ?
+            """) {
+                instantAsText((sakOpprettet.oppgittTidspunkt ?: sakOpprettet.mottattTidspunkt).toInstant())
+                instantAsText((sakOpprettet.oppgittTidspunkt ?: sakOpprettet.mottattTidspunkt).toInstant())
+                uuid(sakOpprettet.sakId)
+            }
+
             executeUpdate(
                 """
                 insert into sak_search(id, text)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerWriter.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerWriter.kt
@@ -34,7 +34,7 @@ object BrukerWriter {
     private val rebuildQueryModel by lazy {
         HendelsesstrømKafkaImpl(
             topic = NOTIFIKASJON_TOPIC,
-            groupId = "bruker-model-builder-2-rebuild-august-2023",
+            groupId = "bruker-model-builder-2-rebuild-august-2023-2",
             replayPeriodically = false,
         )
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerWriter.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerWriter.kt
@@ -58,7 +58,7 @@ object BrukerWriter {
             launch {
                 val brukerRepository = brukerRepositoryAsync.await()
                 rebuildQueryModel.forEach { event, metadata ->
-                    if (event is HendelseModel.SakOpprettet || event is HendelseModel.NyStatusSak) {
+                    if (event is HendelseModel.SakOpprettet) {
                         brukerRepository.oppdaterModellEtterHendelse(event, metadata)
                     }
                 }


### PR DESCRIPTION
Ny replay av topic, som fyller sak-tabellen. Nesten alle saker eksisterer, så med `on conflict do nothing` skjer det jo lite.

Alert i grafana er allerede oppdatert mtp den nye consumer group navnet.