### PR TITLE
Faktoriser ut berikelse av saker i egen sql-spørring

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
@@ -361,6 +361,8 @@ object BrukerAPI {
                 limit = env.getArgumentOrDefault("limit", 3) ?: 3,
                 oppgaveTilstand = env.getTypedArgumentOrNull("oppgaveTilstand"),
             )
+            val berikelser = brukerRepository.berikSaker(sakerResultat.saker)
+                .associateBy { it.sakId }
             val saker = sakerResultat.saker.map {
                 Sak(
                     id = it.sakId,
@@ -370,14 +372,14 @@ object BrukerAPI {
                     virksomhet = Virksomhet(
                         virksomhetsnummer = it.virksomhetsnummer,
                     ),
-                    sisteStatus = it.statuser.map { sakStatus ->
+                    sisteStatus = berikelser[it.sakId]!!.sisteStatus.let { sakStatus ->
                         val type = SakStatusType.fraModel(sakStatus.status)
                         SakStatus(
                             type = type,
                             tekst = sakStatus.overstyrtStatustekst ?: type.visningsTekst,
                             tidspunkt = sakStatus.tidspunkt
                         )
-                    }.first(),
+                    },
                     frister = it.oppgaver.filter { o -> o.tilstand == BrukerModel.Oppgave.Tilstand.NY } .map { o -> o.frist },
                     oppgaver = it.oppgaver.map { o -> OppgaveMetadata(
                         tilstand = o.tilstand.tilBrukerAPI(),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon.bruker
 
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -75,6 +76,7 @@ object BrukerModel {
         val lenke: String,
         val merkelapp: String,
         val oppgaver: List<OppgaveMetadata>,
+        val opprettetTidspunkt: Instant,
     )
 
     data class Sakberikelse(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
@@ -74,12 +74,15 @@ object BrukerModel {
         val tittel: String,
         val lenke: String,
         val merkelapp: String,
-        val statuser: List<SakStatus>,
         val oppgaver: List<OppgaveMetadata>,
     )
 
+    data class Sakberikelse(
+        val sakId: UUID,
+        val sisteStatus: SakStatus,
+    )
+
     data class SakStatus(
-        val sakStatusId: UUID,
         val status: HendelseModel.SakStatus,
         val overstyrtStatustekst: String?,
         val tidspunkt: OffsetDateTime

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -372,9 +372,9 @@ class BrukerRepositoryImpl(
                                 sak.tittel,
                                 sak.lenke,
                                 sak.merkelapp,
-                                sak.oppgaver
+                                sak.oppgaver,
+                                sak.opprettet_tidspunkt
                             from mine_saker_aggregerte_oppgaver_uten_statuser sak
-                            join sak_status_json as js on js.sak_id = id
                             order by ${
                                 when (sortering) {
                                     BrukerAPI.SakSortering.OPPDATERT -> "sak.sist_endret_tidspunkt desc"
@@ -408,7 +408,8 @@ class BrukerRepositoryImpl(
                                 'tittel', tittel,
                                 'lenke', lenke,
                                 'merkelapp', merkelapp,
-                                'oppgaver', oppgaver
+                                'oppgaver', oppgaver,
+                                'opprettetTidspunkt', opprettet_tidspunkt
                             )), '[]'::jsonb) 
                             from mine_saker_paginert
                         ) as saker

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -327,4 +327,16 @@ class ParameterSetters(
             textArray(value)
         }
     }
+
+    fun uuidArray(value: Collection<UUID>) {
+        val array = preparedStatement.connection.createArrayOf(
+            "uuid",
+            value.toTypedArray()
+        )
+        preparedStatement.setArray(index++, array)
+    }
 }
+
+
+fun ResultSet.getUuid(column: String): UUID =
+    getObject(column, UUID::class.java)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
@@ -28,6 +28,8 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class QuerySakerTests : DescribeSpec({
+    val fallbackTimeNotUsed = OffsetDateTime.parse("2020-01-01T01:01:01Z")
+
     val database = testDatabase(Bruker.databaseConfig)
     val brukerRepository = BrukerRepositoryImpl(database)
 
@@ -77,8 +79,14 @@ class QuerySakerTests : DescribeSpec({
             val response = engine.hentSaker()
 
             it("response inneholder riktig data") {
-                val saker = response.getTypedContent<List<Any>>("saker/saker")
-                saker should beEmpty()
+                val sak = response.getTypedContent<BrukerAPI.Sak>("saker/saker/0")
+                sak.id shouldBe sakOpprettet.sakId
+                sak.merkelapp shouldBe "tag"
+                sak.lenke shouldBe sakOpprettet.lenke
+                sak.tittel shouldBe sakOpprettet.tittel
+                sak.virksomhet.virksomhetsnummer shouldBe sakOpprettet.virksomhetsnummer
+                sak.sisteStatus.tekst shouldBe "Mottatt"
+                sak.sisteStatus.tidspunkt shouldBe sakOpprettet.opprettetTidspunkt(fallbackTimeNotUsed)
             }
         }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   kafka:
-    image: docker.io/bitnami/kafka:latest
+    image: docker.io/bitnami/kafka:3.4.1-debian-11-r55
     networks:
       - my-net
     ports:
@@ -11,11 +11,11 @@ services:
       - KAFKA_ENABLE_KRAFT=yes
       - KAFKA_CFG_PROCESS_ROLES=broker,controller
       - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_BROKER_ID=1
+      - KAFKA_BROKER_ID=0
+      - KAFKA_CFG_NODE_ID=0
       - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093
-      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@127.0.0.1:9093
       - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
       - ALLOW_PLAINTEXT_LISTENER=yes
       - BITNAMI_DEBUG=true


### PR DESCRIPTION
Dagens SQL har en veldig treg merge-join. Virker som om postgres ikke forstår at saks-listen kun trenger saks-statuser på de 30 valgte sakene, ikke for alle sakene.