### PR TITLE
tidslinjeelementer: opprettetTidspunkt som på notifikasjon-apiet

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
@@ -168,6 +168,7 @@ object BrukerAPI {
     @JsonTypeName("OppgaveTidslinjeElement")
     data class OppgaveTidslinjeElement(
         val tittel: String,
+        val opprettetTidspunkt: OffsetDateTime,
         val status: Notifikasjon.Oppgave.Tilstand,
         val paaminnelseTidspunkt: OffsetDateTime?,
         val utgaattTidspunkt: OffsetDateTime?,
@@ -178,6 +179,7 @@ object BrukerAPI {
     @JsonTypeName("BeskjedTidslinjeElement")
     data class BeskjedTidslinjeElement(
         val tittel: String,
+        val opprettetTidspunkt: OffsetDateTime,
     ) : TidslinjeElement()
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "__typename")

--- a/app/src/main/resources/bruker.graphql
+++ b/app/src/main/resources/bruker.graphql
@@ -89,6 +89,7 @@ union TidslinjeElement =
 
 type OppgaveTidslinjeElement {
     tittel: String!
+    opprettetTidspunkt: ISO8601DateTime!
     status: OppgaveTilstand!
     paaminnelseTidspunkt: ISO8601DateTime
     utgaattTidspunkt: ISO8601DateTime
@@ -98,7 +99,7 @@ type OppgaveTidslinjeElement {
 
 type BeskjedTidslinjeElement {
     tittel: String!
-    tidspunkt: ISO8601DateTime!
+    opprettetTidspunkt: ISO8601DateTime!
 }
 
 enum SakStatusType {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTests.kt
@@ -487,7 +487,7 @@ private fun TestApplicationEngine.hentSaker(
                     }
                     ...on BeskjedTidslinjeElement {
                         tittel
-                        tidspunkt
+                        opprettetTidspunkt
                     }
                 }
             }


### PR DESCRIPTION
Trenger `opprettetTidspunkt` i frontend. Bruker samme navn på feltet som i `Beskjed` og `Oppgave`.