### PR TITLE
endre waitQueueSizeGauge til å ha tag resume_job_at for past og future

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
@@ -615,11 +615,14 @@ class EksternVarslingRepository(
         }.first()
     }
 
-    suspend fun waitQueueCount(): Int {
+    suspend fun waitQueueCount(): Pair<Int, Int> {
         return database.nonTransactionalExecuteQuery("""
-            select count(*) as count from wait_queue 
+            select
+                count(case when resume_job_at <= now() then 1 end) as past,
+                count(case when resume_job_at > now() then 1 end) as future
+            from wait_queue
         """) {
-            this.getInt("count")
+            this.getInt("past") to this.getInt("future")
         }.first()
     }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
@@ -6,6 +6,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
@@ -21,9 +22,8 @@ import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.ExperimentalTime
+import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalTime::class)
 class EksternVarslingServiceTests : DescribeSpec({
     val database = testDatabase(EksternVarsling.databaseConfig)
     val repository = EksternVarslingRepository(database)
@@ -94,13 +94,13 @@ class EksternVarslingServiceTests : DescribeSpec({
             val serviceJob = service.start(this)
 
             it("sends message eventually") {
-                eventually(kotlin.time.Duration.seconds(5)) {
+                eventually(5.seconds) {
                     meldingSendt.get() shouldBe true
                 }
             }
 
             it("message received from kafka") {
-                eventually(kotlin.time.Duration.seconds(5)) {
+                eventually(5.seconds) {
                     val vellykedeVarsler = hendelseProdusent.hendelserOfType<EksterntVarselVellykket>()
                     vellykedeVarsler shouldNot beEmpty()
                 }
@@ -148,7 +148,7 @@ class EksternVarslingServiceTests : DescribeSpec({
             val serviceJob = service.start(this)
 
             it("sends message eventually") {
-                eventually(kotlin.time.Duration.seconds(5)) {
+                eventually(5.seconds) {
                     meldingSendt.get() shouldBe true
                 }
             }
@@ -195,8 +195,8 @@ class EksternVarslingServiceTests : DescribeSpec({
             val serviceJob = service.start(this)
 
             it("reschedules") {
-                eventually(kotlin.time.Duration.seconds(5)) {
-                    repository.waitQueueCount() shouldBe 1
+                eventually(5.seconds) {
+                    repository.waitQueueCount() shouldNotBe (0 to 0)
                 }
             }
 
@@ -242,7 +242,7 @@ class EksternVarslingServiceTests : DescribeSpec({
             val serviceJob = service.start(this)
 
             it("sends message eventually") {
-                eventually(kotlin.time.Duration.seconds(5)) {
+                eventually(5.seconds) {
                     meldingSendt.get() shouldBe true
                 }
             }
@@ -289,8 +289,8 @@ class EksternVarslingServiceTests : DescribeSpec({
             val serviceJob = service.start(this)
 
             it("reskjedduleres") {
-                eventually(kotlin.time.Duration.seconds(5)) {
-                    repository.waitQueueCount() shouldBe 1
+                eventually(5.seconds) {
+                    repository.waitQueueCount() shouldNotBe (0 to 0)
                 }
             }
 
@@ -335,7 +335,7 @@ class EksternVarslingServiceTests : DescribeSpec({
             val serviceJob = service.start(this)
 
             it("sends message eventually") {
-                eventually(kotlin.time.Duration.seconds(5)) {
+                eventually(5.seconds) {
                     meldingSendt.get() shouldBe true
                 }
             }
@@ -381,8 +381,8 @@ class EksternVarslingServiceTests : DescribeSpec({
             val serviceJob = service.start(this)
 
             it("reschedules") {
-                eventually(kotlin.time.Duration.seconds(5)) {
-                    repository.waitQueueCount() shouldBe 1
+                eventually(5.seconds) {
+                    repository.waitQueueCount() shouldNotBe (0 to 0)
                 }
             }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/ResumeScheduledJobsTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/ResumeScheduledJobsTests.kt
@@ -30,7 +30,7 @@ class ResumeScheduledJobsTests: DescribeSpec({
             repository.jobQueueCount() shouldBe 0
 
             database.waitQueue() shouldContainAll (0..4).map { uuid("$it")  }
-            repository.waitQueueCount() shouldBe 5
+            repository.waitQueueCount().first shouldBe 5
         }
 
         repository.rescheduleWaitingJobs(dateTime("02"))
@@ -38,7 +38,7 @@ class ResumeScheduledJobsTests: DescribeSpec({
         it("one job requeued") {
             repository.jobQueueCount() shouldBe 1
             database.jobQueue() shouldContainInOrder listOf(uuid("0"))
-            repository.waitQueueCount() shouldBe 4
+            repository.waitQueueCount().first shouldBe 4
             database.waitQueue() shouldContainAll (1..4).map { uuid("$it")  }
         }
 
@@ -47,7 +47,7 @@ class ResumeScheduledJobsTests: DescribeSpec({
         it("two jobs requeued") {
             repository.jobQueueCount() shouldBe 3
             database.jobQueue() shouldContainInOrder listOf("0", "1", "2").map(::uuid)
-            repository.waitQueueCount() shouldBe 2
+            repository.waitQueueCount().first shouldBe 2
             database.waitQueue() shouldContainAll (3..4).map { uuid("$it")  }
         }
 
@@ -56,7 +56,7 @@ class ResumeScheduledJobsTests: DescribeSpec({
         it("two more jobs requeued") {
             repository.jobQueueCount() shouldBe 5
             database.jobQueue() shouldContainInOrder listOf("0", "1", "2", "3", "4").map(::uuid)
-            repository.waitQueueCount() shouldBe 0
+            repository.waitQueueCount().first shouldBe 0
             database.waitQueue() shouldContainAll emptyList()
         }
     }


### PR DESCRIPTION
Denne endringen gjør at vi beholder metrikken, men kan lage en alert bare dersom wait queue som har elementer hvor tidpunkt har passert over en gitt grenseverdi.

<img width="975" alt="image" src="https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/assets/189395/df2a3c0c-2da2-420b-9495-48f159b8c016">
