### PR TITLE
fjern fra job_queue når man setter i wait_queue

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
@@ -581,12 +581,23 @@ class EksternVarslingRepository(
     }
 
     suspend fun scheduleJob(varselId: UUID, resumeAt: LocalDateTime) {
-        database.nonTransactionalExecuteUpdate("""
-            insert into wait_queue (varsel_id, resume_job_at) 
-            values (?, ?)
-        """) {
-            uuid(varselId)
-            timestamp_without_timezone(resumeAt)
+        database.transaction {
+            executeUpdate(
+                """
+                insert into wait_queue (varsel_id, resume_job_at) 
+                values (?, ?)
+                """
+            ) {
+                uuid(varselId)
+                timestamp_without_timezone(resumeAt)
+            }
+            executeUpdate(
+                """
+                delete from job_queue where varsel_id = ?
+                """
+            ) {
+                uuid(varselId)
+            }
         }
     }
 


### PR DESCRIPTION
Når en job settes i wait_queue bør den fjernes fra job_queue. 
Uten dette vil wait queue fortsette å vokse med ett innslag for samme varsel for hver iterasjon av processing loopen.

e.g.
<img width="987" alt="image" src="https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/assets/189395/4fa8a635-4449-4e50-920f-9463c8d25446">
