### PR TITLE
Saktilgang overstyrer notifikasjontilgang

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.idl.TypeRuntimeWiring
 import kotlinx.coroutines.CoroutineScope
+import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.Notifikasjon.Oppgave.Tilstand.Companion.tilBrukerAPI
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BrukerKlikket
-import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.Notifikasjon.Oppgave.Tilstand.Companion.tilBrukerAPI
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.NaisEnvironment
@@ -301,9 +301,7 @@ object BrukerAPI {
 
             val notifikasjonerDb = brukerRepository.hentNotifikasjoner(context.fnr, tilganger)
             val sakstitler = brukerRepository.hentSakerForNotifikasjoner(
-                notifikasjonerDb.mapNotNull { it.grupperingsid },
-                context.fnr,
-                tilganger
+                notifikasjonerDb.mapNotNull { it.gruppering },
             )
             val notifikasjoner = notifikasjonerDb
                 .map { notifikasjon ->
@@ -386,7 +384,7 @@ object BrukerAPI {
                 limit = env.getArgumentOrDefault("limit", 3) ?: 3,
                 oppgaveTilstand = env.getTypedArgumentOrNull("oppgaveTilstand"),
             )
-            val berikelser = brukerRepository.berikSaker(sakerResultat.saker, context.fnr, tilganger)
+            val berikelser = brukerRepository.berikSaker(sakerResultat.saker)
             val saker = sakerResultat.saker.map {
                 val berikelse = berikelser[it.sakId]
                 val oppgaver = berikelse?.tidslinje.orEmpty()

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
@@ -19,11 +19,20 @@ object BrukerModel {
         val id: UUID
         val virksomhetsnummer: String
         val sorteringTidspunkt: OffsetDateTime
+        val merkelapp: String
         val grupperingsid: String?
+
+        val gruppering: Gruppering?
+            get() = grupperingsid?.let {
+                Gruppering(
+                    grupperingsid = it,
+                    merkelapp = merkelapp,
+                )
+            }
     }
 
     data class Beskjed(
-        val merkelapp: String,
+        override val merkelapp: String,
         val tekst: String,
         override val grupperingsid: String? = null,
         val lenke: String,
@@ -38,7 +47,7 @@ object BrukerModel {
     }
 
     data class Oppgave(
-        val merkelapp: String,
+        override val merkelapp: String,
         val tekst: String,
         override val grupperingsid: String? = null,
         val lenke: String,
@@ -70,7 +79,18 @@ object BrukerModel {
         val lenke: String,
         val merkelapp: String,
         val opprettetTidspunkt: Instant,
-        val grupperingsid: String?,
+        val grupperingsid: String,
+    ) {
+        val gruppering: Gruppering
+            get() = Gruppering(
+                grupperingsid = grupperingsid,
+                merkelapp = merkelapp,
+            )
+    }
+
+    data class Gruppering(
+        val grupperingsid: String,
+        val merkelapp: String,
     )
 
     data class Sakberikelse(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
@@ -63,19 +63,12 @@ object BrukerModel {
             get() = paaminnelseTidspunkt ?: opprettetTidspunkt
     }
 
-    data class OppgaveMetadata(
-        val tilstand: Oppgave.Tilstand,
-        val frist: LocalDate?,
-        val paaminnelseTidspunkt: OffsetDateTime?,
-    )
-
     data class Sak(
         val sakId: UUID,
         val virksomhetsnummer: String,
         val tittel: String,
         val lenke: String,
         val merkelapp: String,
-        val oppgaver: List<OppgaveMetadata>,
         val opprettetTidspunkt: Instant,
         val grupperingsid: String?,
     )

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -356,16 +356,7 @@ class BrukerRepositoryImpl(
                                 sist_endret_tidspunkt,
                                 opprettet_tidspunkt,
                                 count(*) filter (where oppgave_tilstand = 'NY') as nye_oppgaver,
-                                min(oppgave_frist) filter (where oppgave_tilstand = 'NY') as tidligste_frist,
-                                case
-                                    when count(*) filter (where oppgave_tilstand is not null) = 0 then '[]'::jsonb
-                                    else jsonb_agg(
-                                        jsonb_build_object(
-                                            'tilstand', oppgave_tilstand,
-                                            'frist', oppgave_frist,
-                                            'paaminnelseTidspunkt', oppgave_paaminnelse_tidspunkt
-                                    ) order by oppgave_frist nulls last    
-                                ) end as oppgaver
+                                min(oppgave_frist) filter (where oppgave_tilstand = 'NY') as tidligste_frist
                             from mine_saker_filtrert
                             group by id, virksomhetsnummer, tittel, lenke, merkelapp, grupperingsid, sist_endret_tidspunkt, opprettet_tidspunkt
                         ),
@@ -376,7 +367,6 @@ class BrukerRepositoryImpl(
                                 sak.tittel,
                                 sak.lenke,
                                 sak.merkelapp,
-                                sak.oppgaver,
                                 sak.opprettet_tidspunkt,
                                 sak.grupperingsid
                             from mine_saker_aggregerte_oppgaver_uten_statuser sak
@@ -413,7 +403,6 @@ class BrukerRepositoryImpl(
                                 'tittel', tittel,
                                 'lenke', lenke,
                                 'merkelapp', merkelapp,
-                                'oppgaver', oppgaver,
                                 'opprettetTidspunkt', opprettet_tidspunkt,
                                 'grupperingsid', grupperingsid
                             )), '[]'::jsonb) 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -21,15 +21,8 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveUtgått
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.PåminnelseOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SoftDelete
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Transaction
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.coRecord
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.getUuid
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.ifNotBlank
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import no.nav.arbeidsgiver.notifikasjon.nærmeste_leder.NarmesteLederLeesah
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import java.time.LocalDate
@@ -78,8 +71,6 @@ interface BrukerRepository {
      */
     suspend fun berikSaker(
         saker: List<BrukerModel.Sak>,
-        fnr: String,
-        tilganger: Tilganger,
     ): Map<UUID, BrukerModel.Sakberikelse>
 
     suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse, metadata: HendelseMetadata)
@@ -87,9 +78,7 @@ interface BrukerRepository {
     suspend fun oppdaterModellEtterNærmesteLederLeesah(nærmesteLederLeesah: NarmesteLederLeesah)
     suspend fun hentSakstyper(fnr: String, tilganger: Tilganger): List<String>
     suspend fun hentSakerForNotifikasjoner(
-        grupperingsid: List<String>,
-        fnr: String,
-        tilganger: Tilganger
+        grupperinger: List<BrukerModel.Gruppering>
     ): Map<String, String>
 }
 
@@ -249,22 +238,10 @@ class BrukerRepositoryImpl(
                             join mine_altinntilganger using (virksomhet, service_code, service_edition)
                             where er.sak_id is not null
                         ),
-                        mine_altinn_notifikasjoner as (
-                            select er.notifikasjon_id
-                            from mottaker_altinn_enkeltrettighet er
-                            join mine_altinntilganger using (virksomhet, service_code, service_edition) 
-                            where 
-                                er.notifikasjon_id is not null
-                        ),
                         mine_digisyfo_saker as (
                             select sak_id
                             from mottaker_digisyfo_for_fnr
                             where fnr_leder = ? and virksomhet = any(?) and sak_id is not null
-                        ),
-                        mine_digisyfo_notifikasjoner as (
-                            select notifikasjon_id 
-                            from mottaker_digisyfo_for_fnr
-                            where fnr_leder = ? and notifikasjon_id is not null
                         ),
                         mine_sak_ider as (
                             (select * from mine_digisyfo_saker)
@@ -273,24 +250,10 @@ class BrukerRepositoryImpl(
                         ),
                         mine_saker as (
                             select s.*
-                                from mine_sak_ider as ms
-                                join sak as s on s.id = ms.sak_id
-                        ),
-                        mine_oppgaver as (
-                            select
-                                id,
-                                tilstand, 
-                                frist, 
-                                paaminnelse_tidspunkt,
-                                grupperingsid
-                            from notifikasjon
-                            where 
-                                type = 'OPPGAVE' and
-                                id in (
-                                        select * from mine_digisyfo_notifikasjoner
-                                            union
-                                        select * from mine_altinn_notifikasjoner
-                                )
+                            from mine_sak_ider as ms
+                            join sak_search as search on ms.sak_id = search.id
+                            join sak as s on s.id = ms.sak_id
+                            $tekstsoekSql
                         ),
                         mine_saker_med_oppgaver as (
                             select 
@@ -300,20 +263,17 @@ class BrukerRepositoryImpl(
                             o.frist as oppgave_frist, 
                             o.paaminnelse_tidspunkt as oppgave_paaminnelse_tidspunkt
                             from mine_saker s
-                            left join mine_oppgaver as o
-                                on o.grupperingsid = s.grupperingsid
-                        ),
-                        mine_saker_med_tekstsøk as (
-                            select s.*
-                            from mine_saker_med_oppgaver as s
-                            join sak_search as search on s.id = search.id
-                            $tekstsoekSql
+                            left join notifikasjon as o
+                                on 
+                                    o.merkelapp = s.merkelapp 
+                                    and o.grupperingsid = s.grupperingsid
+                                    and o.type = 'OPPGAVE'
                         ),
                         
                         -- Beregn antall saker pr. merkelap
                         mine_saker_oppgave_tilstandfiltrert as (
                             select * 
-                            from mine_saker_med_tekstsøk
+                            from mine_saker_med_oppgaver
                             where coalesce(coalesce(oppgave_tilstand, 'IngenTilstand') = any(?), true)
                         ),
                         mine_merkelapper as (
@@ -327,7 +287,7 @@ class BrukerRepositoryImpl(
                         -- Beregn antall saker pr. oppgave-tilstand
                         mine_saker_sakstypefiltrert as (
                             select * 
-                            from mine_saker_med_tekstsøk
+                            from mine_saker_med_oppgaver
                             where coalesce(merkelapp = any(?), true)
                         ),
                         mine_oppgavetilstander as (
@@ -341,7 +301,7 @@ class BrukerRepositoryImpl(
                         
                         mine_saker_filtrert as (
                             select * 
-                            from mine_saker_med_tekstsøk
+                            from mine_saker_med_oppgaver
                             where coalesce(merkelapp = any(?), true)
                             and coalesce(coalesce(oppgave_tilstand, 'IngenTilstand') = any(?), true)
                         ),
@@ -414,7 +374,6 @@ class BrukerRepositoryImpl(
                     jsonb(tilgangerAltinnMottaker)
                     text(fnr)
                     textArray(virksomhetsnummer)
-                    text(fnr)
                     tekstsoekElementer.forEach { text(it) }
                     nullableEnumAsTextList(oppgaveTilstand)
                     nullableTextArray(sakstyper)
@@ -437,57 +396,24 @@ class BrukerRepositoryImpl(
 
     override suspend fun berikSaker(
         saker: List<BrukerModel.Sak>,
-        fnr: String,
-        tilganger: Tilganger,
     ): Map<UUID, BrukerModel.Sakberikelse> {
         if (saker.isEmpty()) {
             return mapOf()
         }
 
-        val tilgangerAltinnMottaker = tilganger.tjenestetilganger.map {
-            AltinnMottaker(
-                serviceCode = it.servicecode,
-                serviceEdition = it.serviceedition,
-                virksomhetsnummer = it.virksomhet
-            )
-        }
         val tidslinjer = database.nonTransactionalExecuteQuery(
             /*  quotes are necessary for fields from json, otherwise they are lower-cased */
             """
-            with 
-                mine_altinntilganger as (
-                    select * from json_to_recordset(?::json) 
-                    as (virksomhetsnummer text, "serviceCode" text, "serviceEdition" text)
-                ),
-                mine_altinn_notifikasjoner as (
-                    select er.notifikasjon_id
-                    from mottaker_altinn_enkeltrettighet er
-                    join mine_altinntilganger at on 
-                        er.virksomhet = at.virksomhetsnummer and
-                        er.service_code = at."serviceCode" and
-                        er.service_edition = at."serviceEdition"
-                    where
-                        er.notifikasjon_id is not null
-                ),
-                mine_digisyfo_notifikasjoner as (
-                    select notifikasjon_id 
-                    from mottaker_digisyfo_for_fnr
-                    where fnr_leder = ? and notifikasjon_id is not null
-                )
-            select * 
-            from notifikasjon
-            where
-                grupperingsid = any(?)
-                and id in (
-                    (select * from mine_digisyfo_notifikasjoner)
-                    union 
-                    (select * from mine_altinn_notifikasjoner)
-                )
+            with saker as (
+                select grupperingsid, merkelapp
+                from json_to_recordset(?::json) as (grupperingsid text, merkelapp text)
+            )
+            select n.* 
+            from notifikasjon n
+            join saker s on s.grupperingsid = n.grupperingsid and s.merkelapp = n.merkelapp
             """,
             {
-                jsonb(tilgangerAltinnMottaker)
-                text(fnr)
-                textArray(saker.mapNotNull { it.grupperingsid})
+                jsonb(saker.map { it.gruppering })
             }
         ) {
             when (val type = getString("type")) {
@@ -592,55 +518,21 @@ class BrukerRepositoryImpl(
     }
 
     override suspend fun hentSakerForNotifikasjoner(
-        grupperingsid: List<String>,
-        fnr: String,
-        tilganger: Tilganger
+        grupperinger: List<BrukerModel.Gruppering>,
     ): Map<String, String> = timer.coRecord {
-        val tilgangerAltinnMottaker = tilganger.tjenestetilganger.map {
-            AltinnMottaker(
-                serviceCode = it.servicecode,
-                serviceEdition = it.serviceedition,
-                virksomhetsnummer = it.virksomhet
-            )
-        }
-
         val rows = database.nonTransactionalExecuteQuery(
             /*  quotes are necessary for fields from json, otherwise they are lower-cased */
             """
-                with 
-                    mine_altinntilganger as (
-                        select
-                            virksomhetsnummer as virksomhet,
-                            "serviceCode" as service_code,
-                            "serviceEdition" as service_edition from json_to_recordset(?::json) 
-                        as (virksomhetsnummer text, "serviceCode" text, "serviceEdition" text)
-                    ),
-                    mine_altinn_saker as (
-                        select er.sak_id
-                        from mottaker_altinn_enkeltrettighet er
-                        join mine_altinntilganger using (virksomhet, service_code, service_edition)
-                        where er.sak_id is not null
-                    ),
-                    mine_digisyfo_saker as (
-                        select sak_id
-                        from mottaker_digisyfo_for_fnr
-                        where fnr_leder = ? and sak_id is not null
-                    ),
-                    mine_sak_ider as (
-                        (select * from mine_digisyfo_saker)
-                        union 
-                        (select * from mine_altinn_saker)
-                    )
-                    
+                with gruppering as (
+                    select grupperingsid, merkelapp
+                    from json_to_recordset(?::json) as (grupperingsid text, merkelapp text)
+                )
                 select s.*
-                    from mine_sak_ider as ms
-                    join sak as s on s.id = ms.sak_id
-                    where s.grupperingsid = any(?)
+                    from sak s
+                    join gruppering g on g.grupperingsid = s.grupperingsid and g.merkelapp = s.merkelapp
                 """,
             {
-                jsonb(tilgangerAltinnMottaker)
-                text(fnr)
-                textArray(grupperingsid)
+                jsonb(grupperinger)
             }
         ) {
             getString("grupperingsid") to getString("tittel")

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerApiTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerApiTests.kt
@@ -56,7 +56,7 @@ class BrukerApiTests : DescribeSpec({
             } returns listOf(beskjed, oppgave)
 
             coEvery {
-                brukerRepository.hentSakerForNotifikasjoner(any(), any(), any())
+                brukerRepository.hentSakerForNotifikasjoner(any())
             } returns emptyMap()
 
             val response = engine.queryNotifikasjonerJson()

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/FeilhåndteringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/FeilhåndteringTests.kt
@@ -33,7 +33,7 @@ class FeilhåndteringTests : DescribeSpec({
                 brukerRepository.hentNotifikasjoner(any(), any())
             } returns listOf()
             coEvery {
-                brukerRepository.hentSakerForNotifikasjoner(any(), any(), any())
+                brukerRepository.hentSakerForNotifikasjoner(any())
             } returns emptyMap()
 
             val response = engine.queryNotifikasjonerJson()

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTidslinjeTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTidslinjeTest.kt
@@ -53,6 +53,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
         // Legg til oppgave på en sak
         val oppgave0 = brukerRepository.oppgaveOpprettet(
             grupperingsid = sak0.grupperingsid,
+            merkelapp = sak0.merkelapp,
             opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01:01+00"),
         )
         it("første oppgave vises på riktig sak") {
@@ -70,6 +71,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
 
         val beskjed1 = brukerRepository.beskjedOpprettet(
             grupperingsid = sak0.grupperingsid,
+            merkelapp = sak0.merkelapp,
             opprettetTidspunkt = oppgave0.opprettetTidspunkt.plusHours(1),
         )
         it("andre beskjed på samme sak kommer i riktig rekkefølge") {
@@ -89,30 +91,10 @@ class QuerySakerTidslinjeTest: DescribeSpec({
 
         val beskjed2 = brukerRepository.beskjedOpprettet(
             grupperingsid = sak1.grupperingsid,
+            merkelapp = sak1.merkelapp,
+            opprettetTidspunkt = oppgave0.opprettetTidspunkt.plusHours(2),
         )
         it("ny beskjed på andre saken, vises kun der") {
-            val tidslinje0 = fetchTidslinje(sak0)
-            tidslinje0 should haveSize(2)
-            instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje0[0]) {
-                it.tekst shouldBe beskjed1.tekst
-            }
-            instanceOf<OppgaveTidslinjeElement, TidslinjeElement>(tidslinje0[1]) {
-                it.tekst shouldBe oppgave0.tekst
-                it.tilstand shouldBe NY
-            }
-
-            val tidslinje1 = fetchTidslinje(sak1)
-            tidslinje1 should haveSize(1)
-            instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje1[0]) {
-                it.tekst shouldBe beskjed2.tekst
-            }
-        }
-
-        brukerRepository.beskjedOpprettet(
-            grupperingsid = sak1.grupperingsid,
-            mottakere = listOf(TEST_MOTTAKER_2),
-        )
-        it("ny beskjed uten tilgang vises ikke til bruker") {
             val tidslinje0 = fetchTidslinje(sak0)
             tidslinje0 should haveSize(2)
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje0[0]) {
@@ -133,13 +115,9 @@ class QuerySakerTidslinjeTest: DescribeSpec({
 
         brukerRepository.oppgaveUtført(
             oppgave = oppgave0,
-            utfoertTidspunkt = oppgave0.opprettetTidspunkt.plusHours(2),
+            utfoertTidspunkt = oppgave0.opprettetTidspunkt.plusHours(4),
         )
         it("endret oppgave-status reflekteres i tidslinja, men posisjonen er uendret") {
-            brukerRepository.beskjedOpprettet(
-                grupperingsid = sak1.grupperingsid,
-                mottakere = listOf(TEST_MOTTAKER_2),
-            )
             val tidslinje0 = fetchTidslinje(sak0)
             tidslinje0 should haveSize(2)
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje0[0]) {
@@ -159,7 +137,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
     }
 })
 
-inline suspend fun <reified SubClass: Class, Class: Any>TestScope.instanceOf(
+suspend inline fun <reified SubClass: Class, Class: Any>TestScope.instanceOf(
     subject: Class,
     crossinline test: suspend TestScope.(it: SubClass) -> Unit
 )  {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakNotifikasjonKoblingTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakNotifikasjonKoblingTests.kt
@@ -1,0 +1,58 @@
+package no.nav.arbeidsgiver.notifikasjon.bruker
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.haveSize
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import no.nav.arbeidsgiver.notifikasjon.util.AltinnStub
+import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
+import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+
+class SakNotifikasjonKoblingTests : DescribeSpec({
+    val database = testDatabase(Bruker.databaseConfig)
+    val brukerRepository = BrukerRepositoryImpl(database)
+    val engine = ktorBrukerTestServer(
+        brukerRepository = brukerRepository,
+        altinn = AltinnStub { _, _ ->
+            BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+        }
+    )
+
+    describe("sak og oppgave med samme grupperingsid, men forskjellig merkelapp ") {
+        brukerRepository.oppgaveOpprettet(
+            grupperingsid = "gruppe1",
+            merkelapp = "X",
+
+        )
+        brukerRepository.sakOpprettet(
+            grupperingsid = "gruppe1",
+            merkelapp = "Z",
+        ).also {
+            brukerRepository.nyStatusSak(sak = it, idempotensKey = "")
+        }
+
+        it ("sak og oppgave eksisterer hver for seg") {
+            val saker = engine.querySakerJson()
+                .getTypedContent<List<Any>>("$.saker.saker")
+            saker should haveSize(1)
+
+            val notifikasjoner = engine.queryNotifikasjonerJson()
+                .getTypedContent<List<Any>>("$.notifikasjoner.notifikasjoner")
+            notifikasjoner should haveSize(1)
+        }
+
+        it("oppgave dukker ikke opp i tidslinje") {
+            val tidslinje = engine.querySakerJson()
+                .getTypedContent<List<Any>>("$.saker.saker[0].tidslinje")
+            tidslinje should beEmpty()
+        }
+
+        it("sak dukker ikke opp på oppgave") {
+            val oppgave = engine.queryNotifikasjonerJson()
+                .getTypedContent<BrukerAPI.Notifikasjon.Oppgave>("$.notifikasjoner.notifikasjoner[0]")
+            oppgave.sak should beNull()
+        }
+    }
+})

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SorteringAvSakerPåFristTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SorteringAvSakerPåFristTest.kt
@@ -4,7 +4,10 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.SakSortering.FRIST
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.IdempotenceKey
-import no.nav.arbeidsgiver.notifikasjon.util.*
+import no.nav.arbeidsgiver.notifikasjon.util.AltinnStub
+import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
+import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.*
@@ -37,6 +40,7 @@ class SorteringAvSakerPåFristTest : DescribeSpec({
         for (frist in frister) {
             brukerRepository.oppgaveOpprettet(
                 grupperingsid = sak.grupperingsid,
+                merkelapp = sak.merkelapp,
                 frist = frist?.let { LocalDate.parse(it) },
                 opprettetTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
             )


### PR DESCRIPTION
Tror de tre committene med fordel kan leses hver for seg.

1. Handeleren for GraphQL-queryen `saker` kan bruke info fra tidslinjene for å fylle ut feltene `frister` og `oppgaver`, så den informasjonen kan fjernes fra hoved-spørringen for saker.
2. Fjerner/oppdaterer unittester som sjekker at saker og notifikasjoner tilgangsstyres hver for seg
3. Legger til unitttest som sjekker at grupperingsid-er på tvers av merkelapper ikke blandes sammen. Implementerer dette og fjerner separat tilgangsstyring for saker og notifikasjoner. 