### PR TITLE
Split ut to forskjellige prosesserings-løkker for ekstern varsel

### DIFF
--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
@@ -102,7 +102,7 @@ class EksternVarslingServiceTests : DescribeSpec({
             }
 
             it("message received from kafka") {
-                eventually(5.seconds) {
+                eventually(10.seconds) {
                     val vellykedeVarsler = hendelseProdusent.hendelserOfType<EksterntVarselVellykket>()
                     vellykedeVarsler shouldNot beEmpty()
                 }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
@@ -102,7 +102,7 @@ class EksternVarslingServiceTests : DescribeSpec({
             }
 
             it("message received from kafka") {
-                eventually(10.seconds) {
+                eventually(20.seconds) {
                     val vellykedeVarsler = hendelseProdusent.hendelserOfType<EksterntVarselVellykket>()
                     vellykedeVarsler shouldNot beEmpty()
                 }


### PR DESCRIPTION
En for førstegangs-prosessering av en varsel. En annen for å forsøke feilede varsler på nytt.

Midlertidig implementasjon, så vi ikke må sparke databasen selv.
