### PR TITLE
Flytter avgjørelse rundt retry ut av AltinnVarselKlient

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/AltinnVarselKlientResponse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/AltinnVarselKlientResponse.kt
@@ -1,0 +1,49 @@
+package no.nav.arbeidsgiver.notifikasjon.ekstern_varsling
+
+import com.fasterxml.jackson.databind.JsonNode
+import no.altinn.services.common.fault._2009._10.AltinnFault
+
+sealed interface AltinnVarselKlientResponse {
+    val rå: JsonNode
+    data class Ok(
+        override val rå: JsonNode
+    ) : AltinnVarselKlientResponse, AltinnVarselKlientResponseOrException
+
+    data class Feil(
+        override val rå: JsonNode,
+        val altinnFault: AltinnFault,
+    ) : AltinnVarselKlientResponse, AltinnVarselKlientResponseOrException {
+        fun isRetryable() = retryableErrorIds.contains(altinnFault.errorID)
+
+        val feilkode: String get() = altinnFault.errorID.toString()
+        val feilmelding: String get() = altinnFault.altinnErrorMessage.value
+
+        override fun toString() = with(altinnFault) {
+            """AltinnResponse.Feil(
+                    altinnErrorMessage=${altinnErrorMessage.value}
+                    altinnExtendedErrorMessage=${altinnExtendedErrorMessage.value}
+                    altinnLocalizedErrorMessage=${altinnLocalizedErrorMessage.value}
+                    errorGuid=${errorGuid.value}
+                    errorID=${errorID}
+                    userGuid=${userGuid.value}
+                    userId=${userId.value}
+                )
+            """.trimIndent()
+        }
+    }
+}
+
+sealed interface AltinnVarselKlientResponseOrException
+
+data class UkjentException(
+    val exception: Throwable,
+) : AltinnVarselKlientResponseOrException
+
+/**
+ * TAG-2054
+ * https://altinn.github.io/docs/api/tjenesteeiere/soap/feilkoder/
+ */
+private val retryableErrorIds = listOf(
+    0, // intern generell feil i altinn.
+    44, // intern teknisk feil i altinn. ikke dokumentert
+)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/AltinnVarselKlientImplTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/AltinnVarselKlientImplTest.kt
@@ -81,9 +81,9 @@ class AltinnVarselKlientImplTest : DescribeSpec({
             )
         )
 
-        response.isSuccess shouldBe true
-        response.getOrNull() shouldBe instanceOf<AltinnVarselKlient.AltinnResponse.Ok>()
-        response.getOrNull()!!.rå shouldBe laxObjectMapper.valueToTree(withNotificationResult)
+        response shouldBe instanceOf<AltinnVarselKlientResponse.Ok>()
+        response as AltinnVarselKlientResponse.Ok
+        response.rå shouldBe laxObjectMapper.valueToTree(withNotificationResult)
     }
 
     describe("returnerer ok for kall med AltinnFault") {
@@ -112,9 +112,9 @@ class AltinnVarselKlientImplTest : DescribeSpec({
             )
         )
 
-        response.isSuccess shouldBe true
-        response.getOrNull() shouldBe instanceOf<AltinnVarselKlient.AltinnResponse.Feil>()
-        (response.getOrNull() as AltinnVarselKlient.AltinnResponse.Feil).let {
+        response shouldBe instanceOf<AltinnVarselKlientResponse.Feil>()
+        response as AltinnVarselKlientResponse.Feil
+        response.let {
             it.feilkode shouldBe altinnFault.errorID.toString()
             it.feilmelding shouldBe altinnFault.altinnErrorMessage.value
             it.rå shouldNotBe null
@@ -134,7 +134,7 @@ class AltinnVarselKlientImplTest : DescribeSpec({
             )
         )
 
-        response.isFailure shouldBe true
+        response shouldBe instanceOf<UkjentException>()
     }
 
     /**
@@ -167,6 +167,8 @@ class AltinnVarselKlientImplTest : DescribeSpec({
             )
         )
 
-        response.isFailure shouldBe true
+        response shouldBe instanceOf<AltinnVarselKlientResponse.Feil>()
+        response as AltinnVarselKlientResponse.Feil
+        response.isRetryable() shouldBe true
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepositoryTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepositoryTests.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.instanceOf
 import kotlinx.coroutines.delay
+import no.altinn.services.common.fault._2009._10.AltinnFault
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinntjenesteVarselKontaktinfo
@@ -26,6 +27,8 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.*
+import javax.xml.bind.JAXBElement
+import javax.xml.namespace.QName
 
 class EksternVarslingRepositoryTests: DescribeSpec({
     val database = testDatabase(EksternVarsling.databaseConfig)
@@ -231,7 +234,7 @@ class EksternVarslingRepositoryTests: DescribeSpec({
 
         repository.markerSomSendtAndReleaseJob(
             id1,
-            AltinnVarselKlient.AltinnResponse.Ok(
+            AltinnVarselKlientResponse.Ok(
                 rå = NullNode.instance
             )
         )
@@ -255,7 +258,7 @@ class EksternVarslingRepositoryTests: DescribeSpec({
         it("should be completed") {
             varsel3 shouldBe instanceOf(EksternVarselTilstand.Kvittert::class)
             varsel3 as EksternVarselTilstand.Kvittert
-            varsel3.response shouldBe instanceOf(AltinnVarselKlient.AltinnResponse.Ok::class)
+            varsel3.response shouldBe instanceOf(AltinnResponse.Ok::class)
         }
     }
 
@@ -275,10 +278,11 @@ class EksternVarslingRepositoryTests: DescribeSpec({
 
         repository.markerSomSendtAndReleaseJob(
             id1,
-            AltinnVarselKlient.AltinnResponse.Feil(
+            AltinnVarselKlientResponse.Feil(
                 rå = NullNode.instance,
-                feilmelding = "hallo",
-                feilkode = "1",
+                altinnFault = AltinnFault()
+                    .withErrorID(1)
+                    .withAltinnErrorMessage(JAXBElement(QName(""), String::class.java, "hallo"))
             )
         )
 
@@ -302,8 +306,8 @@ class EksternVarslingRepositoryTests: DescribeSpec({
             varsel3 shouldBe instanceOf(EksternVarselTilstand.Kvittert::class)
             varsel3 as EksternVarselTilstand.Kvittert
             val response = varsel3.response
-            response shouldBe instanceOf(AltinnVarselKlient.AltinnResponse.Feil::class)
-            response as AltinnVarselKlient.AltinnResponse.Feil
+            response shouldBe instanceOf(AltinnResponse.Feil::class)
+            response as AltinnResponse.Feil
             response.feilkode shouldBe "1"
             response.feilmelding shouldBe "hallo"
         }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
@@ -38,9 +38,9 @@ class EksternVarslingServiceTests : DescribeSpec({
         altinnVarselKlient = object: AltinnVarselKlient {
             override suspend fun send(
                 eksternVarsel: EksternVarsel
-            ): Result<AltinnVarselKlient.AltinnResponse> {
+            ): AltinnVarselKlientResponseOrException {
                 meldingSendt.set(true)
-                return Result.success(AltinnVarselKlient.AltinnResponse.Ok(rå = NullNode.instance))
+                return AltinnVarselKlientResponse.Ok(rå = NullNode.instance)
             }
         },
         hendelseProdusent = hendelseProdusent,


### PR DESCRIPTION
altinn-klienten returnerer nå alltid responsen, uavhengig av om den kan retries.

Det gjør responsen tilgjengelig i servicen, så vi kan logge den til en tabell uansett (PR kommer).