### PR TITLE
Renamer OppgaveOpprettet.{oppgave,frist}OpprettetTidspunkt

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
@@ -167,7 +167,7 @@ object HendelseModel {
         val notifikasjonId: UUID,
         val bestillingHendelseId: UUID,
         val opprettetTidpunkt: Instant,
-        val oppgaveOpprettetTidspunkt: Instant,
+        val fristOpprettetTidspunkt: Instant,
         val frist: LocalDate?,
         val tidspunkt: PåminnelseTidspunkt,
         val eksterneVarsler: List<EksterntVarsel>
@@ -186,7 +186,9 @@ object HendelseModel {
                 notifikasjonId: UUID,
                 bestillingHendelseId: UUID?,
                 opprettetTidpunkt: Instant,
-                oppgaveOpprettetTidspunkt: Instant,
+                /** `oppgaveOpprettetTidspunkt` is the old name, replaced by `fristOpprettetTidspunkt`. */
+                oppgaveOpprettetTidspunkt: Instant?,
+                fristOpprettetTidspunkt: Instant?,
                 frist: LocalDate?,
                 tidspunkt: PåminnelseTidspunkt,
                 eksterneVarsler: List<EksterntVarsel>,
@@ -208,7 +210,9 @@ object HendelseModel {
                 bestillingHendelseId = bestillingHendelseId ?: notifikasjonId,
 
                 opprettetTidpunkt = opprettetTidpunkt,
-                oppgaveOpprettetTidspunkt = oppgaveOpprettetTidspunkt,
+                fristOpprettetTidspunkt = checkNotNull(fristOpprettetTidspunkt ?: oppgaveOpprettetTidspunkt) {
+                    "Missing both fristOpprettetTidspunkt and oppgaveOpprettetTidspunkt for PåminnelseOpprettet(notifikasjonId=$notifikasjonId, hendelseId=$hendelseId)"
+                },
                 frist = frist,
                 tidspunkt = tidspunkt,
                 eksterneVarsler = eksterneVarsler,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelseRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelseRepository.kt
@@ -15,7 +15,7 @@ class SkedulertPåminnelseRepository {
 
     data class SkedulertPåminnelse(
         val oppgaveId: UUID,
-        val oppgaveOpprettetTidspunkt: Instant,
+        val fristOpprettetTidspunkt: Instant,
         val frist: LocalDate?,
         val tidspunkt: HendelseModel.PåminnelseTidspunkt,
         val eksterneVarsler: List<HendelseModel.EksterntVarsel>,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelseService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelseService.kt
@@ -28,7 +28,7 @@ class SkedulertPåminnelseService(
                 repository.add(
                     SkedulertPåminnelseRepository.SkedulertPåminnelse(
                         oppgaveId = hendelse.notifikasjonId,
-                        oppgaveOpprettetTidspunkt = hendelse.opprettetTidspunkt.toInstant(),
+                        fristOpprettetTidspunkt = hendelse.opprettetTidspunkt.toInstant(),
                         frist = hendelse.frist,
                         tidspunkt = hendelse.påminnelse.tidspunkt,
                         eksterneVarsler = hendelse.påminnelse.eksterneVarsler,
@@ -66,7 +66,7 @@ class SkedulertPåminnelseService(
                 produsentId = skedulert.produsentId,
                 kildeAppNavn = NaisEnvironment.clientId,
                 opprettetTidpunkt = Instant.now(),
-                oppgaveOpprettetTidspunkt = skedulert.oppgaveOpprettetTidspunkt,
+                fristOpprettetTidspunkt = skedulert.fristOpprettetTidspunkt,
                 frist = skedulert.frist,
                 tidspunkt = skedulert.tidspunkt,
                 eksterneVarsler = skedulert.eksterneVarsler,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/Common.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/Common.kt
@@ -179,7 +179,7 @@ suspend fun BrukerRepository.påminnelseOpprettet(
     kildeAppNavn = oppgave.kildeAppNavn,
     notifikasjonId = oppgave.notifikasjonId,
     opprettetTidpunkt = opprettetTidpunkt,
-    oppgaveOpprettetTidspunkt = oppgave.opprettetTidspunkt.toInstant(),
+    fristOpprettetTidspunkt = oppgave.opprettetTidspunkt.toInstant(),
     frist = frist,
     tidspunkt = tidspunkt,
     eksterneVarsler = eksterneVarsler,
@@ -198,7 +198,7 @@ suspend fun BrukerRepository.påminnelseOpprettet(
     kildeAppNavn = oppgave.kildeAppNavn,
     notifikasjonId = oppgave.notifikasjonId,
     opprettetTidpunkt = Instant.now(),
-    oppgaveOpprettetTidspunkt = oppgave.opprettetTidspunkt.toInstant(),
+    fristOpprettetTidspunkt = oppgave.opprettetTidspunkt.toInstant(),
     frist = oppgave.frist,
     tidspunkt = HendelseModel.PåminnelseTidspunkt.createAndValidateKonkret(
         konkret = konkretPåminnelseTidspunkt,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepositoryTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepositoryTests.kt
@@ -387,7 +387,7 @@ class EksternVarslingRepositoryTests: DescribeSpec({
             produsentId = "fager",
             kildeAppNavn = "local:local:local",
             opprettetTidpunkt = Instant.parse("2020-01-01T01:01:01.00Z"),
-            oppgaveOpprettetTidspunkt = Instant.parse("2020-01-01T01:01:01.00Z"),
+            fristOpprettetTidspunkt = Instant.parse("2020-01-01T01:01:01.00Z"),
             eksterneVarsler = listOf(
                 SmsVarselKontaktinfo(
                     varselId = varselId,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
@@ -580,7 +580,7 @@ object EksempelHendelse {
         kildeAppNavn = "1",
         notifikasjonId = uuid("1"),
         opprettetTidpunkt = Instant.now(),
-        oppgaveOpprettetTidspunkt = OffsetDateTime.parse("2021-01-01T13:37:00Z").toInstant(),
+        fristOpprettetTidspunkt = OffsetDateTime.parse("2021-01-01T13:37:00Z").toInstant(),
         frist = LocalDate.parse("2021-01-14"),
         tidspunkt = HendelseModel.PåminnelseTidspunkt.createAndValidateKonkret(
             konkret = LocalDateTime.parse("2021-01-10T12:00:00"),


### PR DESCRIPTION
Tanker bak feltet er at det gir informasjonen som gjør det mulig å regne ut relative frister. Og da er det når fristen ble opprettet som blir brukt.