### PR TITLE
Tag 2087 valider ny frist i api

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
@@ -60,7 +60,8 @@ internal sealed class Error {
         override val feilmelding: String
     ) :
         Error(),
-        MutationNyStatusSak.NyStatusSakResultat
+        MutationNyStatusSak.NyStatusSakResultat,
+        MutationOppgaveUtsettFrist.OppgaveUtsettFristResultat
 
     @JsonTypeName("DuplikatEksternIdOgMerkelapp")
     data class DuplikatEksternIdOgMerkelapp(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationOppgaveUtsettFrist.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationOppgaveUtsettFrist.kt
@@ -75,6 +75,10 @@ internal class MutationOppgaveUtsettFrist(
 
         tilgangsstyrMerkelapp(produsent, notifikasjon.merkelapp) { error -> return error }
 
+        if (notifikasjon.frist != null && notifikasjon.frist > nyFrist) {
+            return Error.Konflikt("Ny frist kan ikke være tidligere enn den gamle")
+        }
+
         try {
             hendelseDispatcher.send(
                 FristUtsatt(

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -854,6 +854,7 @@ type OppgaveUtfoertVellykket {
 union OppgaveUtsettFristResultat =
     | OppgaveUtsettFristVellykket
     | UgyldigMerkelapp
+    | Konflikt
     | UgyldigPaaminnelseTidspunkt
     | NotifikasjonFinnesIkke
     | UkjentProdusent

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/UtsattFristTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/UtsattFristTests.kt
@@ -221,6 +221,53 @@ class UtsattFristTests : DescribeSpec({
             }
         }
 
+        context("Oppgave med frist som er senere enn ny frist") {
+            OppgaveOpprettet(
+                virksomhetsnummer = "1",
+                merkelapp = merkelapp,
+                eksternId = eksternId,
+                mottakere = listOf(mottaker),
+                hendelseId = uuid,
+                notifikasjonId = uuid,
+                tekst = "test",
+                lenke = "https://nav.no",
+                opprettetTidspunkt = opprettetTidspunkt,
+                kildeAppNavn = "",
+                produsentId = "",
+                grupperingsid = null,
+                eksterneVarsler = listOf(),
+                hardDelete = null,
+                frist = LocalDate.parse("2023-12-24"),
+                påminnelse = null,
+            ).also {
+                produsentModel.oppdaterModellEtterHendelse(it)
+            }
+
+
+            val response = engine.produsentApi(
+                """
+                mutation {
+                    oppgaveUtsettFrist(
+                        id: "$uuid", 
+                        nyFrist: "2023-01-01"
+                    ) {
+                        __typename
+                        ... on OppgaveUtsettFristVellykket {
+                            id
+                        }
+                        ... on Error {
+                            feilmelding
+                        }
+                    }
+                }
+                """
+            )
+
+            it("Får feilmelding") {
+                response.getTypedContent<Error.Konflikt>("oppgaveUtsettFrist")
+            }
+        }
+
     }
 
 
@@ -460,6 +507,51 @@ class UtsattFristTests : DescribeSpec({
 
             it("returnerer feilmelding") {
                 response.getTypedContent<Error.NotifikasjonFinnesIkke>("oppgaveUtsettFristByEksternId")
+            }
+        }
+
+        context("Oppgave med frist som er senere enn ny frist") {
+            OppgaveOpprettet(
+                virksomhetsnummer = "1",
+                merkelapp = merkelapp,
+                eksternId = eksternId,
+                mottakere = listOf(mottaker),
+                hendelseId = uuid,
+                notifikasjonId = uuid,
+                tekst = "test",
+                lenke = "https://nav.no",
+                opprettetTidspunkt = opprettetTidspunkt,
+                kildeAppNavn = "",
+                produsentId = "",
+                grupperingsid = null,
+                eksterneVarsler = listOf(),
+                hardDelete = null,
+                frist = LocalDate.parse("2023-12-24"),
+                påminnelse = null,
+            ).also {
+                produsentModel.oppdaterModellEtterHendelse(it)
+            }
+
+
+            val response = engine.produsentApi(
+                """
+                mutation {
+                    oppgaveUtsettFristByEksternId(
+                        eksternId: "$eksternId", 
+                        merkelapp: "$merkelapp",
+                        nyFrist: "2023-01-05"
+                    ) {
+                        __typename
+                        ... on Error {
+                            feilmelding
+                        }
+                    }
+                }
+                """
+            )
+
+            it("Får feilmelding") {
+                response.getTypedContent<Error.Konflikt>("oppgaveUtsettFristByEksternId")
             }
         }
     }


### PR DESCRIPTION
forslag til å returnere feil dersom ny frist er tidligere enn eksisterende. Gjenbruker Konflikt typen, kan vurdere ny type for denne feilen.