### PR TITLE
Fjern access policy for narmesteleder

### DIFF
--- a/config/dev-gcp-bruker-api.yaml
+++ b/config/dev-gcp-bruker-api.yaml
@@ -54,8 +54,6 @@ spec:
       rules:
         - application: altinn-rettigheter-proxy
           namespace: arbeidsgiver
-        - application: narmesteleder
-          namespace: teamsykmelding
       external:
         - host: fakedings.intern.dev.nav.no # fakedings login
         - host: api-gw-q1.oera.no # fallback for altinn-rettigheter-proxy-client

--- a/config/prod-gcp-bruker-api.yaml
+++ b/config/prod-gcp-bruker-api.yaml
@@ -63,8 +63,6 @@ spec:
       rules:
         - application: altinn-rettigheter-proxy
           namespace: arbeidsgiver
-        - application: narmesteleder
-          namespace: teamsykmelding
       external:
         - host: api-gw.oera.no # fallback for altinn-rettigheter-proxy-client
         - host: ereg-services.prod-fss-pub.nais.io # ereg brukes i bruker-api


### PR DESCRIPTION
Vi bruker ikke API-et, men kafka-topic for tilgangsstyring av nærmeste leder.