### PR TITLE
produsent api husker hard deletes og blokkerer gjenbruk av sak koordinat

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -55,7 +55,7 @@ object Produsent {
         runBlocking(Dispatchers.Default) {
             val database = openDatabaseAsync(databaseConfig)
             val produsentRepositoryAsync = async {
-                ProdusentRepositoryImpl(database.await())
+                ProdusentRepository(database.await())
             }
 
             launch {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HardDeletedRepository
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
@@ -28,27 +29,18 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.*
 
-interface ProdusentRepository {
-    suspend fun hentNotifikasjon(id: UUID): ProdusentModel.Notifikasjon?
-    suspend fun hentNotifikasjon(eksternId: String, merkelapp: String): ProdusentModel.Notifikasjon?
-    suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse, metadata: HendelseMetadata)
-    suspend fun finnNotifikasjoner(
-        merkelapper: List<String>,
-        grupperingsid: String?,
-        antall: Int,
-        offset: Int,
-    ): List<ProdusentModel.Notifikasjon>
-
-    suspend fun hentSak(grupperingsid: String, merkelapp: String): ProdusentModel.Sak?
-    suspend fun hentSak(id: UUID): ProdusentModel.Sak?
-}
-
-class ProdusentRepositoryImpl(
+class ProdusentRepository(
     private val database: Database,
-) : ProdusentRepository {
+) : HardDeletedRepository(database) {
+    enum class AggregateType {
+        SAK,
+        BESKJED,
+        OPPGAVE,
+    }
+
     val log = logger()
 
-    override suspend fun hentNotifikasjon(id: UUID): ProdusentModel.Notifikasjon? =
+    suspend fun hentNotifikasjon(id: UUID): ProdusentModel.Notifikasjon? =
         hentNotifikasjonerMedVarsler(
             """ 
                 where id = ?
@@ -58,7 +50,7 @@ class ProdusentRepositoryImpl(
         }
             .firstOrNull()
 
-    override suspend fun hentNotifikasjon(eksternId: String, merkelapp: String): ProdusentModel.Notifikasjon? =
+    suspend fun hentNotifikasjon(eksternId: String, merkelapp: String): ProdusentModel.Notifikasjon? =
         hentNotifikasjonerMedVarsler(
             """ 
                 where
@@ -71,7 +63,7 @@ class ProdusentRepositoryImpl(
         }
             .firstOrNull()
 
-    override suspend fun finnNotifikasjoner(
+    suspend fun finnNotifikasjoner(
         merkelapper: List<String>,
         grupperingsid: String?,
         antall: Int,
@@ -92,7 +84,7 @@ class ProdusentRepositoryImpl(
             integer(offset)
         }
 
-    override suspend fun hentSak(grupperingsid: String, merkelapp: String): ProdusentModel.Sak? {
+    suspend fun hentSak(grupperingsid: String, merkelapp: String): ProdusentModel.Sak? {
         return hentSaker(
             where = """
                grupperingsid = ? and merkelapp = ?
@@ -105,7 +97,7 @@ class ProdusentRepositoryImpl(
             .firstOrNull()
     }
 
-    override suspend fun hentSak(id: UUID): ProdusentModel.Sak? {
+    suspend fun hentSak(id: UUID): ProdusentModel.Sak? {
         return hentSaker(
             where = """
                 id = ?
@@ -116,6 +108,17 @@ class ProdusentRepositoryImpl(
         )
             .firstOrNull()
     }
+
+    suspend fun erHardDeleted(type: AggregateType, merkelapp: String, grupperingsid: String) =
+        database.nonTransactionalExecuteQuery("""
+            select * from hard_deleted_aggregates_metadata where aggregate_type = ? and merkelapp = ? and grupperingsid = ?
+            """,
+            {
+                text(type.name)
+                text(merkelapp)
+                text(grupperingsid)
+            }
+        ) {}.isNotEmpty()
 
     private suspend fun hentSaker(
         where: String,
@@ -219,7 +222,12 @@ class ProdusentRepositoryImpl(
             }
         }
 
-    override suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse, metadata: HendelseMetadata) {
+    suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse, metadata: HendelseMetadata) {
+        if (erHardDeleted(hendelse.aggregateId)) {
+            log.info("skipping harddeleted event {}", hendelse)
+            return
+        }
+
         /* when-expressions gives error when not exhaustive, as opposed to when-statement. */
         @Suppress("UNUSED_VARIABLE") val ignored: Unit = when (hendelse) {
             is SakOpprettet -> oppdaterModellEtterSakOpprettet(hendelse)
@@ -308,18 +316,49 @@ class ProdusentRepositoryImpl(
 
     private suspend fun oppdaterModellEtterHardDelete(hardDelete: HardDelete) {
         database.transaction {
+            registrerHardDelete(this, hardDelete)
+            executeQuery("""
+                select aggregate_type from (
+                    select 'SAK' as aggregate_type from sak where id = ?
+                    union
+                    select 'BESKJED' as aggregate_type from notifikasjon where id = ?
+                    union
+                    select 'OPPGAVE' as aggregate_type from notifikasjon where id = ?
+                ) as aggregate_type
+            """, setup = {
+                uuid(hardDelete.aggregateId)
+                uuid(hardDelete.aggregateId)
+                uuid(hardDelete.aggregateId)
+            }, transform = {
+                AggregateType.valueOf(getString("aggregate_type"))
+            }).firstOrNull()?.let {
+                // har ikke grunnlag for å backfille metadata, men for fremtidige events vil vi ha metadata.
+                // derfor er det en null-sjekk rundt dette
+                executeUpdate(
+                    """
+                insert into hard_deleted_aggregates_metadata(aggregate_id, aggregate_type, merkelapp, grupperingsid)
+                values (?, ?, ?, ?);
+                """
+                ) {
+                    uuid(hardDelete.aggregateId)
+                    text(it.name)
+                    nullableText(hardDelete.merkelapp)
+                    nullableText(hardDelete.grupperingsid)
+                }
+            }
+
             executeUpdate(
                 """
-                DELETE FROM notifikasjon
-                WHERE id = ?
+                delete from notifikasjon
+                where id = ?
                 """
             ) {
                 uuid(hardDelete.aggregateId)
             }
             executeUpdate(
                 """
-                DELETE FROM sak
-                WHERE id = ?
+                delete from sak
+                where id = ?
                 """
             ) {
                 uuid(hardDelete.aggregateId)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -96,7 +96,7 @@ internal class MutationNySak(
 
         return when {
             eksisterende == null && erHardDeleted -> {
-                Error.DuplikatGrupperingsid( // TODO: erstatt med spesifikk feiltype
+                Error.DuplikatGrupperingsid(
                     "sak med angitt grupperings-id og merkelapp har vært brukt tidligere"
                 )
             }

--- a/app/src/main/resources/db/migration/produsent_model/V18__hard_deleted_aggregates.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V18__hard_deleted_aggregates.sql
@@ -11,6 +11,4 @@ create table hard_deleted_aggregates_metadata
     merkelapp      text
 );
 
-create index on hard_deleted_aggregates_metadata (aggregate_type);
-create index on hard_deleted_aggregates_metadata (grupperingsid);
-create index on hard_deleted_aggregates_metadata (merkelapp);
+create index on hard_deleted_aggregates_metadata (aggregate_type, grupperingsid, merkelapp);

--- a/app/src/main/resources/db/migration/produsent_model/V18__hard_deleted_aggregates.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V18__hard_deleted_aggregates.sql
@@ -1,0 +1,16 @@
+create table hard_deleted_aggregates
+(
+    aggregate_id  uuid not null primary key
+);
+
+create table hard_deleted_aggregates_metadata
+(
+    aggregate_id   uuid not null references hard_deleted_aggregates (aggregate_id) on delete cascade,
+    aggregate_type text not null,
+    grupperingsid  text,
+    merkelapp      text
+);
+
+create index on hard_deleted_aggregates_metadata (aggregate_type);
+create index on hard_deleted_aggregates_metadata (grupperingsid);
+create index on hard_deleted_aggregates_metadata (merkelapp);

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -751,7 +751,8 @@ type Mutation {
     Formålet er å støtte juridiske krav om sletting i henhold til personvern.
 
     Advarsel: det er ikke mulig å angre på denne operasjonen. All data blir borte for godt.
-    Advarsel: ingen notifikasjoner blir slettet (selv om de har samme grupperingsid).
+    Advarsel: notifikasjoner med samme merkelapp og grupperingsid blir slettet.
+    Advarsel: Det vil ikke være mulig å lage en ny sak med samme merkelapp og grupperingsid.
     """
     hardDeleteSak(id: ID!): HardDeleteSakResultat!
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/EksternVarselApiTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/EksternVarselApiTests.kt
@@ -11,7 +11,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.EksterntVarselVel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLRequest
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.NyNotifikasjonInputType.nyBeskjed
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.NyNotifikasjonInputType.nyOppgave
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
@@ -80,7 +80,7 @@ private val jsonVariabler = laxObjectMapper.readValue<Map<String, Any?>>("""
 
 class EksternVarselApiTests: DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
 
     val engine = ktorProdusentTestServer(
         produsentRepository = produsentModel

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HardDeleteNotifikasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HardDeleteNotifikasjonTests.kt
@@ -25,7 +25,7 @@ import java.util.*
 
 class HardDeleteNotifikasjonTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
     val kafkaProducer = mockk<HendelseProdusent>()
 
     coEvery { kafkaProducer.sendOgHentMetadata(ofType<HardDelete>()) } returns HendelseModel.HendelseMetadata(Instant.parse("1970-01-01T00:00:00Z"))

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HardDeleteSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HardDeleteSakTests.kt
@@ -11,9 +11,9 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HardDelete
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakOpprettet
-import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
-import no.nav.arbeidsgiver.notifikasjon.produsent.*
+import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -25,7 +25,7 @@ import java.util.*
 
 class HardDeleteSakTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
     val kafkaProducer = mockk<HendelseProdusent>()
 
     coEvery {kafkaProducer.sendOgHentMetadata(ofType<HardDelete>()) } returns HendelseModel.HendelseMetadata(Instant.parse("1970-01-01T00:00:00Z"))

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HardDeleteSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HardDeleteSakTests.kt
@@ -196,6 +196,38 @@ class HardDeleteSakTests : DescribeSpec({
                 val sak = produsentModel.hentSak(uuid2)
                 sak shouldNotBe null
             }
+
+            it("opprettelse av ny sak med samme merkelapp og grupperingsid feiler") {
+                engine.produsentApi(
+                    """
+                    mutation {
+                        nySak(
+                            virksomhetsnummer: "1"
+                            merkelapp: "$merkelapp"
+                            grupperingsid: "$grupperingsid"
+                            mottakere: [{
+                                altinn: {
+                                    serviceCode: "5441"
+                                    serviceEdition: "1"
+                                }
+                            }]
+                            initiellStatus: MOTTATT
+                            tidspunkt: "2020-01-01T01:01Z"
+                            tittel: "ny sak"
+                            lenke: "#foo"
+                        ) {
+                            __typename
+                            ... on NySakVellykket {
+                                id
+                            }
+                            ... on Error {
+                                feilmelding
+                            }
+                        }
+                    }
+                    """
+                ).getTypedContent<Error.DuplikatGrupperingsid>("nySak")
+            }
         }
 
         context("Sak mangler") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/IdempotensOppførselForProdusentApiTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/IdempotensOppførselForProdusentApiTests.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -12,7 +12,7 @@ import java.util.*
 
 class IdempotensOppførselForProdusentApiTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val queryModel = ProdusentRepositoryImpl(database)
+    val queryModel = ProdusentRepository(database)
 
     val virksomhetsnummer = "1234"
     val mottaker = AltinnMottaker(serviceCode = "5441", serviceEdition = "1", virksomhetsnummer = virksomhetsnummer)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MineNotifikasjonerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MineNotifikasjonerTests.kt
@@ -7,7 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -18,7 +18,7 @@ import kotlin.time.ExperimentalTime
 @ExperimentalTime
 class MineNotifikasjonerTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
     val engine = ktorProdusentTestServer(produsentRepository = produsentModel)
     val virksomhetsnummer = "123"
     val merkelapp = "tag"

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationExceptionTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationExceptionTests.kt
@@ -8,7 +8,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.getGraphqlErrors
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -18,7 +18,7 @@ import kotlin.time.ExperimentalTime
 @ExperimentalTime
 class MutationExceptionTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
     val kafkaProducer = mockk<HendelseProdusent>()
     val engine = ktorProdusentTestServer(
         kafkaProducer = kafkaProducer,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedFlereMottakereTests.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.shouldNot
 import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.getGraphqlErrors
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
@@ -19,7 +19,7 @@ import java.util.*
 
 class NyBeskjedFlereMottakereTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
 
     val engine = ktorProdusentTestServer(
         produsentRepository = produsentRepository,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedTests.kt
@@ -19,7 +19,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NærmesteLederMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -28,7 +28,7 @@ import kotlin.time.ExperimentalTime
 @ExperimentalTime
 class NyBeskjedTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
     val kafkaProducer = mockk<HendelseProdusent>()
     coEvery { kafkaProducer.sendOgHentMetadata(any()) } returns HendelseModel.HendelseMetadata(Instant.parse("1970-01-01T00:00:00Z"))
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveFlereMottakereTests.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.getGraphqlErrors
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
@@ -15,7 +15,7 @@ import java.util.*
 
 class NyOppgaveFlereMottakereTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
 
     val engine = ktorProdusentTestServer(
         produsentRepository = produsentRepository,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgavePaaminnelseTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgavePaaminnelseTests.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.fakeHendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
@@ -15,7 +15,7 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 class NyOppgavePaaminnelseTests : DescribeSpec({
     val stubbedKafkaProducer = fakeHendelseProdusent()
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
 
     val engine = ktorProdusentTestServer(
         kafkaProducer = stubbedKafkaProducer,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveTests.kt
@@ -19,7 +19,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NærmesteLederMot
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.Instant
 import java.time.LocalDate
@@ -29,7 +29,7 @@ import kotlin.time.ExperimentalTime
 @ExperimentalTime
 class NyOppgaveTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
 
     val kafkaProducer = mockk<HendelseProdusent>()
     coEvery { kafkaProducer.sendOgHentMetadata(any()) } returns HendelseModel.HendelseMetadata(Instant.parse("1970-01-01T00:00:00Z"))

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakDuplisertTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakDuplisertTests.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.types.beInstanceOf
 import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.OffsetDateTime
 import java.util.*
@@ -37,7 +37,7 @@ private val sakOpprettet = HendelseModel.SakOpprettet(
 
 class NySakDuplisertTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
     val hendelseProdusent = FakeHendelseProdusent()
     val engine = ktorProdusentTestServer(
         kafkaProducer = hendelseProdusent,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakTests.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.types.instanceOf
 import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
@@ -18,7 +18,7 @@ import java.util.*
 
 class NySakTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
     val stubbedKafkaProducer = FakeHendelseProdusent()
     val engine = ktorProdusentTestServer(
         kafkaProducer = stubbedKafkaProducer,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
@@ -8,7 +8,7 @@ import io.kotest.matchers.types.beInstanceOf
 import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.LocalDateTime
 import java.util.*
@@ -17,7 +17,7 @@ class NyStatusSakTests : DescribeSpec({
     val stubbedKafkaProducer = FakeHendelseProdusent()
 
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
+    val produsentRepository = ProdusentRepository(database)
 
     val engine = ktorProdusentTestServer(
         kafkaProducer = stubbedKafkaProducer,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/OppgaveUtførtTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/OppgaveUtførtTests.kt
@@ -9,7 +9,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveUtført
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
@@ -20,7 +20,7 @@ import java.util.*
 
 class OppgaveUtførtTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
     val stubbedKafkaProducer = FakeHendelseProdusent()
 
     val engine = ktorProdusentTestServer(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/OppgaveUtgåttTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/OppgaveUtgåttTests.kt
@@ -10,7 +10,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveUtgått
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.OffsetDateTime
 import java.util.*
@@ -18,7 +18,7 @@ import java.util.*
 
 class OppgaveUtgåttTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
     val stubbedKafkaProducer = FakeHendelseProdusent()
 
     val engine = ktorProdusentTestServer(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
@@ -6,14 +6,14 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.arbeidsgiver.notifikasjon.kafka_reaper.typeNavn
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.util.*
 
 class ProdusentModelIdempotensTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
 
     describe("Produsent Model Idempotent oppførsel") {
         withData(EksempelHendelse.Alle) { hendelse ->

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/SoftDeleteNotifikasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/SoftDeleteNotifikasjonTests.kt
@@ -27,7 +27,7 @@ import java.util.*
 class SoftDeleteNotifikasjonTests : DescribeSpec({
 
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
     val kafkaProducer = mockk<HendelseProdusent>()
 
     coEvery { kafkaProducer.sendOgHentMetadata(ofType<SoftDelete>()) } returns HendelseModel.HendelseMetadata(Instant.parse("1970-01-01T00:00:00Z"))

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/SoftDeleteSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/SoftDeleteSakTests.kt
@@ -13,7 +13,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SoftDelete
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
@@ -25,7 +25,7 @@ import java.util.*
 class SoftDeleteSakTests : DescribeSpec({
 
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
     val kafkaProducer = mockk<HendelseProdusent>()
 
     coEvery { kafkaProducer.sendOgHentMetadata(ofType<SoftDelete>()) } returns HendelseModel.HendelseMetadata(Instant.parse("1970-01-01T00:00:00Z"))

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/UtsattFristTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/UtsattFristTests.kt
@@ -9,7 +9,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveUtgått
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
@@ -21,7 +21,7 @@ import java.util.*
 
 class UtsattFristTests : DescribeSpec({
     val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
+    val produsentModel = ProdusentRepository(database)
     val stubbedKafkaProducer = FakeHendelseProdusent()
 
     val engine = ktorProdusentTestServer(


### PR DESCRIPTION
Denne PR inneholder i hovedsak to ting:

1. lagre ned info om hard deletes, og skip over hendelser på hard deleted aggregater, på samme måte som i bruker api mm. Dette gjør at vi ikke får en periode med gjennopprettelse og sletting når partisjoner replayes.
2. Blokker opprettelse av sak på koordinat(merkelapp/grupperingsid) som har vært brukt tidligere. Hvis vi tillater produsenter å gjøre det, blir det en del kompleksitet involvert i å sørge for at det oppstår en ny sak med samme id, uten at det blir slettet på nytt. Det enkle her er å blokkere dette i produsent apiet.

TODO:
- [x] vurder/innfør ny konkret feiltype, ref todo i koden
  - vurdert. beholder som duplikatgrupperingsid med konkret feillmelding i tekst
- [x] oppdater dokumentasjon 
