### PR TITLE
håndter sletting av sak med notifikasjoner atomisk i EksternVarslingRepository

### DIFF
--- a/app/src/main/resources/db/migration/ekstern_varsling_model/V9__notifikasjon_koordinat_sak.sql
+++ b/app/src/main/resources/db/migration/ekstern_varsling_model/V9__notifikasjon_koordinat_sak.sql
@@ -1,0 +1,10 @@
+create table merkelapp_grupperingsid_notifikasjon
+(
+    notifikasjon_id uuid primary key not null,
+    merkelapp text not null,
+    grupperingsid text
+);
+
+create index merkelapp_grupperingsid_notifikasjon_merkelapp_idx on merkelapp_grupperingsid_notifikasjon (merkelapp);
+create index merkelapp_grupperingsid_notifikasjon_grupperingsid_idx on merkelapp_grupperingsid_notifikasjon (grupperingsid);
+

--- a/app/src/main/resources/db/migration/ekstern_varsling_model/V9__notifikasjon_koordinat_sak.sql
+++ b/app/src/main/resources/db/migration/ekstern_varsling_model/V9__notifikasjon_koordinat_sak.sql
@@ -5,6 +5,5 @@ create table merkelapp_grupperingsid_notifikasjon
     grupperingsid text
 );
 
-create index merkelapp_grupperingsid_notifikasjon_merkelapp_idx on merkelapp_grupperingsid_notifikasjon (merkelapp);
-create index merkelapp_grupperingsid_notifikasjon_grupperingsid_idx on merkelapp_grupperingsid_notifikasjon (grupperingsid);
+create index merkelapp_grupperingsid_notifikasjon_mrk_grpid_idx on merkelapp_grupperingsid_notifikasjon (merkelapp, grupperingsid);
 


### PR DESCRIPTION
Dette løses ved å ta vare på koblingsinformasjon fra opprettet events, for så å rydde disse bort når en hard delete intreffer.