### PR TITLE
Bruk query expression i stede for join

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -134,10 +134,11 @@ class ProdusentRepository(
                 )
             select 
                 valgt_sak.*, 
-                coalesce(statusoppdateringer_json.statusoppdateringer::jsonb, '[]'::jsonb) as statusoppdateringer
+                coalesce(
+                    (select statusoppdateringer::jsonb from statusoppdateringer_json where sak_id = valgt_sak.id),
+                    '[]'::jsonb
+                ) as statusoppdateringer
             from valgt_sak
-            left join statusoppdateringer_json
-                on statusoppdateringer_json.sak_id = valgt_sak.id
             """,
             variables
         ) {


### PR DESCRIPTION
Veldig tregt oppslag i prod (8 sekunder). Virker som om den må bygge opp tabell med alle group-by fra statusoppdateringer_json-viewet.

Basert på explain, så kan det gå raskere her.