### PR TITLE
Bruk convert_to for text->bytea konvertering

### DIFF
--- a/app/src/main/resources/db/migration/dataprodukt_model/V13__correct_cast_pseudonymiser.sql
+++ b/app/src/main/resources/db/migration/dataprodukt_model/V13__correct_cast_pseudonymiser.sql
@@ -1,0 +1,8 @@
+create or replace function pseudonymize(val text)
+    returns text
+as
+$$
+select encode(sha256(convert_to(val || (select * from salt), 'UTF8')), 'hex')
+$$
+    language sql
+    immutable;

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktIdempotensTests.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.dataprodukt
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -187,6 +188,15 @@ class DataproduktIdempotensTests : DescribeSpec({
             oppgaveUtenGrupperingsid.aggregateId,
             oppgaveMedGrupperingsidMedAnnenTag.aggregateId
         )
+    }
+
+    describe("Pseudonymisering av tegn som kan tolkes som escape characters ") {
+        val hendelse = EksempelHendelse.SakOpprettet.copy(tittel = """Billakkerer\Hjelpearbeider""")
+        it("Skal ikke feile fordi det blir tolket") {
+            shouldNotThrowAny {
+                repository.oppdaterModellEtterHendelse(hendelse, metadata)
+            }
+        }
     }
 })
 


### PR DESCRIPTION
Bruk av ::bytea for konvertering til bytea førte til feil hvis teksten inneholdte tegn som kan tolkes som escape characters ('\\').

Bruk av convert_to blir riktig. Stringen skal encodes som den er.