### PR TITLE
Index for raskere oppslag med partition+offset

### DIFF
--- a/app/src/main/resources/db/migration/kafka_backup_model/V2__partition_offset_index.sql
+++ b/app/src/main/resources/db/migration/kafka_backup_model/V2__partition_offset_index.sql
@@ -1,0 +1,1 @@
+create index topic_notifikasjon_partition_offset_dx on topic_notifikasjon(partition, "offset");


### PR DESCRIPTION
Hvis man har partition+offset, tar det veldig lang tid å slå opp på event (~20 sek).