### PR TITLE
optimalisering av bygg og deploy

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,7 +6,7 @@ on:
       - closed
   workflow_dispatch:
 
-env: # it is a push to main if it is not a merge commit. the merge commit check could be smarter than commit message check, like author or committer is not github
+env:
   push_to_main: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'Merge pull request') }}
 
 jobs:
@@ -106,10 +106,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 5
-      - name: fix deploy sha for merge commit
-        # if the current sha is a merge commit we want the sha that was on the PR head before merge (the sha of the second parent)
-        run: |
-          echo "DEPLOY_SHA=$(git show ${{ github.sha }}^2 --pretty=format:'%H' --no-patch || echo ${{ github.sha }})" >> $GITHUB_ENV
+
+      - if: env.push_to_main == 'true' || github.event_name == 'workflow_dispatch'
+        run: echo "DEPLOY_SHA=${{ github.sha }}" >> $GITHUB_ENV
+
+      - if: env.push_to_main != 'true' && github.event_name != 'workflow_dispatch'
+        run: echo "DEPLOY_SHA=$(git show ${{ github.sha }}^2 --pretty=format:'%H' --no-patch || echo ${{ github.sha }})" >> $GITHUB_ENV
+
       - uses: nais/login@v0
         id: login
         with:

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -120,7 +120,6 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           team: fager
 
-      # only deploy if push to main, or if PR is merged, or if workflow_dispatch
       - if: env.push_to_main == 'true' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
         uses: nais/deploy/actions/deploy@v1
         name: "${{ matrix.cluster }}: deploy ${{ matrix.app }}"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2,11 +2,16 @@ name: ci/cd
 on:
   push:
   pull_request:
+    types:
+      - closed
   workflow_dispatch:
-  merge_group:
+
+env: # it is a push to main if it is not a merge commit. the merge commit check could be smarter than commit message check, like author or committer is not github
+  push_to_main: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'Merge pull request') }}
 
 jobs:
   build:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: "read"
       id-token: "write"
@@ -62,7 +67,6 @@ jobs:
         working-directory: app
 
       - uses: nais/docker-build-push@v0
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         id: gar-push
         with:
           team: fager
@@ -73,12 +77,12 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
 
   deploy:
+    if: ${{ always() }}
+    needs: [build]
+    runs-on: ubuntu-20.04
     permissions:
       contents: "read"
       id-token: "write"
-    needs: [build]
-    runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     strategy:
       matrix:
         cluster:
@@ -100,13 +104,22 @@ jobs:
           #- manuelt-vedlikehold
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+      - name: fix deploy sha for merge commit
+        # if the current sha is a merge commit we want the sha that was on the PR head before merge (the sha of the second parent)
+        run: |
+          echo "DEPLOY_SHA=$(git show ${{ github.sha }}^2 --pretty=format:'%H' --no-patch || git rev-parse ${{ github.sha }})" >> $GITHUB_ENV
       - uses: nais/login@v0
         id: login
         with:
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           team: fager
-      - uses: nais/deploy/actions/deploy@v1
+
+      # only deploy if push to main, or if PR is merged, or if workflow_dispatch
+      - if: env.push_to_main == 'true' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+        uses: nais/deploy/actions/deploy@v1
         name: "${{ matrix.cluster }}: deploy ${{ matrix.app }}"
         env:
           IMAGE: ${{ steps.login.outputs.registry }}/arbeidsgiver-notifikasjon-produsent-api:${{ github.sha }}

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: fix deploy sha for merge commit
         # if the current sha is a merge commit we want the sha that was on the PR head before merge (the sha of the second parent)
         run: |
-          echo "DEPLOY_SHA=$(git show ${{ github.sha }}^2 --pretty=format:'%H' --no-patch || git rev-parse ${{ github.sha }})" >> $GITHUB_ENV
+          echo "DEPLOY_SHA=$(git show ${{ github.sha }}^2 --pretty=format:'%H' --no-patch || echo ${{ github.sha }})" >> $GITHUB_ENV
       - uses: nais/login@v0
         id: login
         with:


### PR DESCRIPTION
Tanken her er at vi alltid bygger på push og dispatch, mens deploy skjer bare hvis det er en av følgende:
* direkte push på main
* manuell trigg av workflow
* PR blir lukket og merget

Deploy steget passer på å alltid deploye riktig parent på en merge commit, eller github.sha dersom det ikke er en merge commit