### PR TITLE
Utvid duplikatsjekk til å ta hensyn til payload i varsler

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
@@ -131,6 +131,24 @@ object ProdusentModel {
                                     },
                                 )
                             }
+                        },
+                        påminnelseEksterneVarsler = other.påminnelseEksterneVarsler.mapIndexed { i, otherVarsel ->
+                            val thisVarsel = this.påminnelseEksterneVarsler.getOrNull(i) // simpler with getOrDefault?
+                            if (thisVarsel == null) {
+                                otherVarsel
+                            } else {
+                                otherVarsel.copy(
+                                    varselId = thisVarsel.varselId,
+                                    status = thisVarsel.status,
+                                    feilmelding = thisVarsel.feilmelding,
+                                    kildeHendelse = when (otherVarsel.kildeHendelse) {
+                                        is AltinntjenesteVarselKontaktinfo -> otherVarsel.kildeHendelse.copy(varselId = thisVarsel.kildeHendelse?.varselId ?: otherVarsel.kildeHendelse.varselId)
+                                        is EpostVarselKontaktinfo -> otherVarsel.kildeHendelse.copy(varselId = thisVarsel.kildeHendelse?.varselId ?: otherVarsel.kildeHendelse.varselId)
+                                        is SmsVarselKontaktinfo -> otherVarsel.kildeHendelse.copy(varselId = thisVarsel.kildeHendelse?.varselId ?: otherVarsel.kildeHendelse.varselId)
+                                        null -> null // TODO: remove when no longer nullable
+                                    },
+                                )
+                            }
                         }
                     )
                 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
@@ -61,7 +61,7 @@ object ProdusentModel {
                         opprettetTidspunkt = this.opprettetTidspunkt,
                         id = this.id,
                         eksterneVarsler = other.eksterneVarsler.mapIndexed { i, otherVarsel ->
-                            val thisVarsel = this.eksterneVarsler.getOrNull(i) // simpler with getOrDefault?
+                            val thisVarsel = this.eksterneVarsler.getOrNull(i)
                             if (thisVarsel == null) {
                                 otherVarsel
                             } else {
@@ -115,7 +115,7 @@ object ProdusentModel {
                         opprettetTidspunkt = this.opprettetTidspunkt,
                         id = this.id,
                         eksterneVarsler = other.eksterneVarsler.mapIndexed { i, otherVarsel ->
-                            val thisVarsel = this.eksterneVarsler.getOrNull(i) // simpler with getOrDefault?
+                            val thisVarsel = this.eksterneVarsler.getOrNull(i)
                             if (thisVarsel == null) {
                                 otherVarsel
                             } else {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
@@ -59,10 +59,7 @@ object ProdusentModel {
                     this == other.copy(
                         opprettetTidspunkt = this.opprettetTidspunkt,
                         id = this.id,
-                        eksterneVarsler = other.eksterneVarsler.mapIndexed { i, varsel ->
-                            val varselId = this.eksterneVarsler.getOrNull(i)?.varselId ?: varsel.varselId
-                            varsel.copy(varselId = varselId)
-                        }
+                        eksterneVarsler = if (other.eksterneVarsler.size == this.eksterneVarsler.size) this.eksterneVarsler else other.eksterneVarsler
                     )
                 }
                 else -> false
@@ -99,10 +96,7 @@ object ProdusentModel {
                     this == other.copy(
                         opprettetTidspunkt = this.opprettetTidspunkt,
                         id = this.id,
-                        eksterneVarsler = other.eksterneVarsler.mapIndexed { i, varsel ->
-                            val varselId = this.eksterneVarsler.getOrNull(i)?.varselId ?: varsel.varselId
-                            varsel.copy(varselId = varselId)
-                        }
+                        eksterneVarsler = if (other.eksterneVarsler.size == this.eksterneVarsler.size) this.eksterneVarsler else other.eksterneVarsler
                     )
                 }
                 else -> false

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -508,15 +508,18 @@ class ProdusentRepositoryImpl(
                 insert into eksternt_varsel(
                     varsel_id,
                     notifikasjon_id,
-                    status
+                    status,
+                    kilde_hendelse
                 )
-                values (?, ?, 'NY')
-                on conflict do nothing;
+                values (?, ?, 'NY', ?::jsonb)
+                on conflict(varsel_id) do update
+                set kilde_hendelse = excluded.kilde_hendelse;
                 """,
                 beskjedOpprettet.eksterneVarsler
             ) { eksterntVarsel ->
                 uuid(eksterntVarsel.varselId)
                 uuid(beskjedOpprettet.notifikasjonId)
+                jsonb(eksterntVarsel)
             }
         }
     }
@@ -562,15 +565,18 @@ class ProdusentRepositoryImpl(
                 insert into eksternt_varsel(
                     varsel_id,
                     notifikasjon_id,
-                    status
+                    status,
+                    kilde_hendelse
                 )
-                values (?, ?, 'NY')
-                on conflict do nothing;
+                values (?, ?, 'NY', ?::jsonb)
+                on conflict(varsel_id) do update
+                set kilde_hendelse = excluded.kilde_hendelse;
                 """,
                 oppgaveOpprettet.eksterneVarsler
             ) { eksterntVarsel ->
                 uuid(eksterntVarsel.varselId)
                 uuid(oppgaveOpprettet.notifikasjonId)
+                jsonb(eksterntVarsel)
             }
 
             executeBatch(
@@ -578,15 +584,18 @@ class ProdusentRepositoryImpl(
                 insert into paaminnelse_eksternt_varsel(
                     varsel_id,
                     notifikasjon_id,
-                    status
+                    status,
+                    kilde_hendelse
                 )
-                values (?, ?, 'NY')
-                on conflict do nothing;
+                values (?, ?, 'NY', ?::jsonb)
+                on conflict(varsel_id) do update 
+                set kilde_hendelse = excluded.kilde_hendelse;
                 """,
                 oppgaveOpprettet.påminnelse?.eksterneVarsler.orEmpty()
             ) { eksterntVarsel ->
                 uuid(eksterntVarsel.varselId)
                 uuid(oppgaveOpprettet.notifikasjonId)
+                jsonb(eksterntVarsel)
             }
         }
     }

--- a/app/src/main/resources/db/migration/produsent_model/V19__kilde_hendelse_eksternt_varsel.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V19__kilde_hendelse_eksternt_varsel.sql
@@ -1,0 +1,31 @@
+alter table eksternt_varsel add column kilde_hendelse jsonb;
+alter table paaminnelse_eksternt_varsel add column kilde_hendelse jsonb;
+-- make kilde_hendelse not null after rebuilding model
+
+create or replace view eksterne_varsler_json as
+select
+    notifikasjon_id,
+    json_agg(
+            json_build_object(
+                    'varselId', varsel_id,
+                    'status', status,
+                    'feilmelding', feilmelding,
+                    'kildeHendelse', kilde_hendelse
+            )
+    ) as eksterne_varsler_json
+from eksternt_varsel
+group by notifikasjon_id;
+
+create or replace view paaminnelse_eksterne_varsler_json as
+select
+    notifikasjon_id,
+    json_agg(
+            json_build_object(
+                    'varselId', varsel_id,
+                    'status', status,
+                    'feilmelding', feilmelding,
+                    'kildeHendelse', kilde_hendelse
+            )
+    ) as paaminnelse_eksterne_varsler_json
+from paaminnelse_eksternt_varsel
+group by notifikasjon_id;

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/IdempotensOppførselForProdusentApiTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/IdempotensOppførselForProdusentApiTests.kt
@@ -1,16 +1,19 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import com.fasterxml.jackson.databind.node.NullNode
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLRequest
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
-import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import org.intellij.lang.annotations.Language
 import java.util.*
 
 class IdempotensOppførselForProdusentApiTests : DescribeSpec({
@@ -28,7 +31,7 @@ class IdempotensOppførselForProdusentApiTests : DescribeSpec({
     fun nyBeskjedGql(tekst: String) : String {
         // language=GraphQL
         return """
-            mutation {
+            mutation NyBeskjed(${'$'}eksterneVarsler: [EksterntVarselInput!]! = []) {
                 nyBeskjed(nyBeskjed: {
                     metadata: {
                         eksternId: "$eksternId"
@@ -43,33 +46,7 @@ class IdempotensOppførselForProdusentApiTests : DescribeSpec({
                         serviceCode: "${mottaker.serviceCode}"
                         serviceEdition: "${mottaker.serviceEdition}"
                     }}
-                    eksterneVarsler: [
-                        { sms: {
-                            mottaker: {
-                                kontaktinfo: {
-                                    fnr: ""
-                                    tlf: ""
-                                }
-                            },
-                            smsTekst: "En test SMS",
-                            sendetidspunkt: {
-                                sendevindu: NKS_AAPNINGSTID
-                            }
-                        }},
-                        { epost: {
-                            mottaker: {
-                                kontaktinfo: {
-                                    fnr: "0",
-                                    epostadresse: "0"
-                                }
-                            }
-                            epostTittel: "En tittel til din epost"
-                            epostHtmlBody: "<body><h1>hei</h1></body>"
-                            sendetidspunkt: {
-                                sendevindu: LOEPENDE
-                            }
-                        }}
-                    ]
+                    eksterneVarsler: ${'$'}eksterneVarsler
                 }) {
                     __typename
                     ... on Error { feilmelding }
@@ -82,7 +59,7 @@ class IdempotensOppførselForProdusentApiTests : DescribeSpec({
     fun nyOppgaveGql(tekst: String) : String {
         // language=GraphQL
         return """
-            mutation {
+            mutation NyOppgave(${'$'}eksterneVarsler: [EksterntVarselInput!]! = []) {
                 nyOppgave(nyOppgave: {
                     metadata: {
                         eksternId: "$eksternId"
@@ -97,33 +74,7 @@ class IdempotensOppførselForProdusentApiTests : DescribeSpec({
                         serviceCode: "${mottaker.serviceCode}"
                         serviceEdition: "${mottaker.serviceEdition}"
                     }}
-                    eksterneVarsler: [
-                        { sms: {
-                            mottaker: {
-                                kontaktinfo: {
-                                    fnr: ""
-                                    tlf: ""
-                                }
-                            },
-                            smsTekst: "En test SMS",
-                            sendetidspunkt: {
-                                sendevindu: NKS_AAPNINGSTID
-                            }
-                        }},
-                        { epost: {
-                            mottaker: {
-                                kontaktinfo: {
-                                    fnr: "0",
-                                    epostadresse: "0"
-                                }
-                            }
-                            epostTittel: "En tittel til din epost"
-                            epostHtmlBody: "<body><h1>hei</h1></body>"
-                            sendetidspunkt: {
-                                sendevindu: LOEPENDE
-                            }
-                        }}
-                    ]
+                    eksterneVarsler: ${'$'}eksterneVarsler
                 }) {
                     __typename
                     ... on Error { feilmelding }
@@ -176,8 +127,38 @@ class IdempotensOppførselForProdusentApiTests : DescribeSpec({
             }
         }
 
+        context("Beskjed med varsler") {
+            val nyBeskjedReq = GraphQLRequest(
+                query = nyBeskjedGql("foo"),
+                variables = laxObjectMapper.readValue<Map<String, Any?>>(varlser1),
+            )
+            val idNyBeskjed1 = engine.produsentApi(nyBeskjedReq).getTypedContent<UUID>("/nyBeskjed/id")
+            val idNyBeskjed2 = engine.produsentApi(nyBeskjedReq).getTypedContent<UUID>("/nyBeskjed/id")
+
+            it("er opprettet med samme id") {
+                idNyBeskjed1 shouldBe idNyBeskjed2
+            }
+        }
+
+        context("Oppgave med varsler") {
+            val nyOppgaveReq = GraphQLRequest(
+                query = nyOppgaveGql("foo"),
+                variables = laxObjectMapper.readValue<Map<String, Any?>>(varlser1),
+            )
+            val idNyOppgave1 = engine.produsentApi(nyOppgaveReq).getTypedContent<UUID>("/nyOppgave/id")
+            val idNyOppgave2 = engine.produsentApi(nyOppgaveReq).getTypedContent<UUID>("/nyOppgave/id")
+
+            it("er opprettet med samme id") {
+                idNyOppgave1 shouldBe idNyOppgave2
+            }
+        }
+
         context("ny oppgave er idempotent også når varsler er sendt") {
-            val resultat1 = engine.produsentApi(nyOppgaveGql("foo"))
+            val nyOppgaveReq = GraphQLRequest(
+                query = nyOppgaveGql("foo"),
+                variables = laxObjectMapper.readValue<Map<String, Any?>>(varlser1),
+            )
+            val resultat1 = engine.produsentApi(nyOppgaveReq)
 
             it("første kall er opprettet") {
                 resultat1.getTypedContent<String>("/nyOppgave/__typename") shouldBe MutationNyOppgave.NyOppgaveVellykket::class.simpleName
@@ -201,9 +182,133 @@ class IdempotensOppførselForProdusentApiTests : DescribeSpec({
             }
 
             it("andre kall er idempotent") {
-                val idNyOppgave2 = engine.produsentApi(nyOppgaveGql("foo")).getTypedContent<UUID>("/nyOppgave/id")
+                val idNyOppgave2 = engine.produsentApi(nyOppgaveReq).getTypedContent<UUID>("/nyOppgave/id")
                 idNyOppgave2 shouldBe idNyOppgave1
             }
         }
+
+        context("ny oppgave med endrede varsler får feilmelding") {
+            val resultat1 = engine.produsentApi(
+                GraphQLRequest(
+                    query = nyOppgaveGql("foo"),
+                    variables = laxObjectMapper.readValue<Map<String, Any?>>(varlser1),
+                )
+            )
+            val resultat2 = engine.produsentApi(
+                GraphQLRequest(
+                    query = nyOppgaveGql("foo"),
+                    variables = laxObjectMapper.readValue<Map<String, Any?>>(varlser2),
+                )
+            )
+
+            it("første kall er opprettet") {
+                resultat1.getTypedContent<String>("/nyOppgave/__typename") shouldBe MutationNyOppgave.NyOppgaveVellykket::class.simpleName
+            }
+            it("andre kall er feilmelding") {
+                resultat2.getTypedContent<String>("/nyOppgave/__typename") shouldBe Error.DuplikatEksternIdOgMerkelapp::class.simpleName
+            }
+        }
     }
+
+    // TODO: test påminnelse med ekstern varsel
 })
+
+@Language("json")
+private val varlser1 = """
+{
+  "eksterneVarsler": [
+    {
+      "sms": {
+        "mottaker": {
+          "kontaktinfo": {
+            "fnr": "1234",
+            "tlf": "4321"
+          }
+        },
+        "smsTekst": "En test SMS",
+        "sendetidspunkt": {
+          "sendevindu": "NKS_AAPNINGSTID"
+        }
+      }
+    },
+    {
+      "epost": {
+        "mottaker": {
+          "kontaktinfo": {
+            "fnr": "0",
+            "epostadresse": "foo@bar.baz"
+          }
+        },
+        "epostTittel": "En tittel til din epost",
+        "epostHtmlBody": "<body><h1>hei</h1></body>",
+        "sendetidspunkt": {
+          "tidspunkt": "2021-01-01T12:00:00"
+        }
+      }
+    },
+    {
+      "altinntjeneste": {
+        "mottaker": {
+          "serviceCode": "1337",
+          "serviceEdition": "42"
+        },
+        "tittel": "Følg med, du har nye følgere å følge opp",
+        "innhold": "Gå inn på Nav sine nettsider og følg veiledningen",
+        "sendetidspunkt": {
+          "sendevindu": "LOEPENDE"
+        }
+      }
+    }
+  ]
+}
+"""
+
+@Language("json")
+private val varlser2 = """
+{
+  "eksterneVarsler": [
+    {
+      "sms": {
+        "mottaker": {
+          "kontaktinfo": {
+            "fnr": "1337",
+            "tlf": "470000"
+          }
+        },
+        "smsTekst": "En test SMS",
+        "sendetidspunkt": {
+          "sendevindu": "NKS_AAPNINGSTID"
+        }
+      }
+    },
+    {
+      "epost": {
+        "mottaker": {
+          "kontaktinfo": {
+            "fnr": "0",
+            "epostadresse": "foo@bar.baz"
+          }
+        },
+        "epostTittel": "En tittel til din epost",
+        "epostHtmlBody": "<body><h1>hei</h1></body>",
+        "sendetidspunkt": {
+          "tidspunkt": "2021-01-01T13:00:00"
+        }
+      }
+    },
+    {
+      "altinntjeneste": {
+        "mottaker": {
+          "serviceCode": "1337",
+          "serviceEdition": "42"
+        },
+        "tittel": "Følg med, du har nye følgere å følge opp",
+        "innhold": "Gå inn på Nav sine nettsider og følg veiledningen",
+        "sendetidspunkt": {
+          "sendevindu": "LOEPENDE"
+        }
+      }
+    }
+  ]
+}
+"""


### PR DESCRIPTION
Som en oppfølger til, eller alternativ til #608 

Bakgrunnen for dette er at healsearbeidsgiver retryer noen kall, og så har varslene blitt sendt, og dermed feiler vi. 
Dersom varslene er like burde kallene anses som idempotente, og ikke feile for dem.

Denne PR utvider duplikatsjekk i produsent api til å ta hensyn til innhold i varsler.
Dette gjøres ved å ta vare på kilden til bestilte varsel, slik at dette kan brukes som grunnlag for sammenligning.
Inneholder også en rebuilder, slik at når denne er ajour så vil vi svare riktig på forespørsler.

TODO før merge:
- [x] test og implementer for påminnelser med eksterne varsler (se TODO i testen)

Etter denne er shippet, er det et par TODOs som må fikses:
* [ ] gjør kilde_hendelse not null i databasen
* [ ] endre `ProdusentModel.EksterntVarsel` til not nullable
* [ ] fjern null branch på when i `erDuplikatAv`
* løses her https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/610