### PR TITLE
returner id ved duplikatgrupperingsid

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Error.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
+import java.util.*
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "__typename")
 internal sealed class Error {
@@ -25,7 +26,8 @@ internal sealed class Error {
         MutationOppgaveUtfoert.OppgaveUtfoertResultat,
         MutationOppgaveUtgaatt.OppgaveUtgaattResultat,
         MutationOppgaveUtsettFrist.OppgaveUtsettFristResultat,
-        QueryMineNotifikasjoner.MineNotifikasjonerResultat,
+        QueryNotifikasjoner.MineNotifikasjonerResultat,
+        QueryNotifikasjoner.HentNotifikasjonResultat,
         MutationSoftDeleteSak.SoftDeleteSakResultat,
         MutationHardDeleteSak.HardDeleteSakResultat,
         MutationSoftDeleteNotifikasjon.SoftDeleteNotifikasjonResultat,
@@ -40,7 +42,8 @@ internal sealed class Error {
         MutationOppgaveUtfoert.OppgaveUtfoertResultat,
         MutationOppgaveUtgaatt.OppgaveUtgaattResultat,
         MutationOppgaveUtsettFrist.OppgaveUtsettFristResultat,
-        QueryMineNotifikasjoner.MineNotifikasjonerResultat,
+        QueryNotifikasjoner.MineNotifikasjonerResultat,
+        QueryNotifikasjoner.HentNotifikasjonResultat,
         MutationSoftDeleteSak.SoftDeleteSakResultat,
         MutationHardDeleteSak.HardDeleteSakResultat,
         MutationSoftDeleteNotifikasjon.SoftDeleteNotifikasjonResultat,
@@ -65,13 +68,21 @@ internal sealed class Error {
 
     @JsonTypeName("DuplikatEksternIdOgMerkelapp")
     data class DuplikatEksternIdOgMerkelapp(
-        override val feilmelding: String
+        override val feilmelding: String,
+        val idTilEksisterende: UUID
     ) : Error(),
         MutationNyBeskjed.NyBeskjedResultat,
         MutationNyOppgave.NyOppgaveResultat
 
     @JsonTypeName("DuplikatGrupperingsid")
     data class DuplikatGrupperingsid(
+        override val feilmelding: String,
+        val idTilEksisterende: UUID
+    ) : Error(),
+        MutationNySak.NySakResultat
+
+    @JsonTypeName("DuplikatGrupperingsidEtterDelete")
+    data class DuplikatGrupperingsidEtterDelete(
         override val feilmelding: String
     ) : Error(),
         MutationNySak.NySakResultat
@@ -85,7 +96,8 @@ internal sealed class Error {
         MutationOppgaveUtgaatt.OppgaveUtgaattResultat,
         MutationOppgaveUtsettFrist.OppgaveUtsettFristResultat,
         MutationSoftDeleteNotifikasjon.SoftDeleteNotifikasjonResultat,
-        MutationHardDeleteNotifikasjon.HardDeleteNotifikasjonResultat
+        MutationHardDeleteNotifikasjon.HardDeleteNotifikasjonResultat,
+        QueryNotifikasjoner.HentNotifikasjonResultat
 
     @JsonTypeName("UkjentRolle")
     data class UkjentRolle(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
@@ -41,7 +41,7 @@ internal class MutationNyBeskjed(
     data class NyBeskjedInput(
         val mottakere: List<MottakerInput>,
         val mottaker: MottakerInput?,
-        val notifikasjon: QueryMineNotifikasjoner.NotifikasjonData,
+        val notifikasjon: QueryNotifikasjoner.NotifikasjonData,
         val metadata: MetadataInput,
         val eksterneVarsler: List<EksterntVarselInput>
     ) {
@@ -133,7 +133,8 @@ internal class MutationNyBeskjed(
             }
             else -> {
                 Error.DuplikatEksternIdOgMerkelapp(
-                    "notifikasjon med angitt eksternId og merkelapp finnes fra før"
+                    "notifikasjon med angitt eksternId og merkelapp finnes fra før",
+                    eksisterende.id
                 )
             }
         }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
@@ -41,7 +41,7 @@ internal class MutationNyOppgave(
     data class NyOppgaveInput(
         val mottaker: MottakerInput?,
         val mottakere: List<MottakerInput>,
-        val notifikasjon: QueryMineNotifikasjoner.NotifikasjonData,
+        val notifikasjon: QueryNotifikasjoner.NotifikasjonData,
         val frist: LocalDate?,
         val paaminnelse: PaaminnelseInput?,
         val metadata: MetadataInput,
@@ -287,7 +287,8 @@ internal class MutationNyOppgave(
                     domeneNyOppgave.merkelapp
                 )
                 Error.DuplikatEksternIdOgMerkelapp(
-                    "notifikasjon med angitt eksternId og merkelapp finnes fra før"
+                    "notifikasjon med angitt eksternId og merkelapp finnes fra før",
+                    eksisterende.id
                 )
             }
         }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -96,7 +96,7 @@ internal class MutationNySak(
 
         return when {
             eksisterende == null && erHardDeleted -> {
-                Error.DuplikatGrupperingsid(
+                Error.DuplikatGrupperingsidEtterDelete(
                     "sak med angitt grupperings-id og merkelapp har vært brukt tidligere"
                 )
             }
@@ -128,7 +128,8 @@ internal class MutationNySak(
             }
             else -> {
                 Error.DuplikatGrupperingsid(
-                    "sak med angitt grupperings-id og merkelapp finnes fra før"
+                    "sak med angitt grupperings-id og merkelapp finnes fra før",
+                    eksisterende.id
                 )
             }
         }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
@@ -42,7 +42,7 @@ object ProdusentAPI {
                     dataFetcher("whoami", ::queryWhoami)
                 }
 
-                QueryMineNotifikasjoner(produsentRepository).wire(this)
+                QueryNotifikasjoner(produsentRepository).wire(this)
                 MutationHardDeleteSak(hendelseDispatcher, produsentRepository).wire(this)
                 MutationHardDeleteNotifikasjon(hendelseDispatcher, produsentRepository).wire(this)
                 MutationNyBeskjed(hendelseDispatcher, produsentRepository).wire(this)

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -87,12 +87,24 @@ type Query {
 
         grupperingsid: String
     ): MineNotifikasjonerResultat!
+
+    hentNotifikasjon(id: ID!): HentNotifikasjonResultat!
 }
 
 union MineNotifikasjonerResultat =
     | NotifikasjonConnection
     | UgyldigMerkelapp
     | UkjentProdusent
+
+union HentNotifikasjonResultat =
+    | HentetNotifikasjon
+    | UkjentProdusent
+    | UgyldigMerkelapp
+    | NotifikasjonFinnesIkke
+
+type HentetNotifikasjon {
+    notifikasjon: Notifikasjon!
+}
 
 type NotifikasjonConnection {
     edges: [NotifikasjonEdge!]!
@@ -215,6 +227,7 @@ union NySakResultat =
     | UgyldigMerkelapp
     | UgyldigMottaker
     | DuplikatGrupperingsid
+    | DuplikatGrupperingsidEtterDelete
     | UkjentProdusent
     | UkjentRolle
 
@@ -1393,6 +1406,7 @@ Denne feilen returneres dersom du prøver å opprette en notifikasjon med en eks
 """
 type DuplikatEksternIdOgMerkelapp implements Error {
     feilmelding: String!
+    idTilEksisterende: ID!
 }
 
 """
@@ -1400,6 +1414,15 @@ Denne feilen returneres hvis det allerede eksisterer en sak med denne gruppering
 merkelappen.
 """
 type DuplikatGrupperingsid implements Error {
+    feilmelding: String!
+    idTilEksisterende: ID!
+}
+
+"""
+Denne feilen returneres hvis det tidligere eksisterte en sak med denne grupperingsid-en under
+merkelappen, som har blitt slettet.
+"""
+type DuplikatGrupperingsidEtterDelete implements Error {
     feilmelding: String!
 }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/EksternVarselApiTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/EksternVarselApiTests.kt
@@ -163,9 +163,9 @@ class EksternVarselApiTests: DescribeSpec({
 
         // sjekk varsel-status er 'bestillt' via graphql
         val mineNotifikasjonerResult = engine.produsentApi(mineNotifikasjonerQuery)
-        val varsel0 = mineNotifikasjonerResult.getTypedContent<QueryMineNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/0")
-        val varsel1 = mineNotifikasjonerResult.getTypedContent<QueryMineNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/1")
-        val varsel2 = mineNotifikasjonerResult.getTypedContent<QueryMineNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/2")
+        val varsel0 = mineNotifikasjonerResult.getTypedContent<QueryNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/0")
+        val varsel1 = mineNotifikasjonerResult.getTypedContent<QueryNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/1")
+        val varsel2 = mineNotifikasjonerResult.getTypedContent<QueryNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/2")
 
         it("bestilling registrert") {
             varsel0.id shouldBeIn listOf(id0, id1, id2)
@@ -173,9 +173,9 @@ class EksternVarselApiTests: DescribeSpec({
             varsel2.id shouldBeIn listOf(id0, id1, id2)
             setOf(id0, id1, id2) shouldHaveSize 3
 
-            varsel0.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.NY
-            varsel1.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.NY
-            varsel2.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.NY
+            varsel0.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.NY
+            varsel1.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.NY
+            varsel2.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.NY
         }
 
 
@@ -220,7 +220,7 @@ class EksternVarselApiTests: DescribeSpec({
         )
 
         val mineNotifikasjonerResult2 = engine.produsentApi(mineNotifikasjonerQuery)
-        val oppdaterteVarsler = listOf<QueryMineNotifikasjoner.EksterntVarsel>(
+        val oppdaterteVarsler = listOf<QueryNotifikasjoner.EksterntVarsel>(
             mineNotifikasjonerResult2.getTypedContent("mineNotifikasjoner/edges/0/node/eksterneVarsler/0"),
             mineNotifikasjonerResult2.getTypedContent("mineNotifikasjoner/edges/0/node/eksterneVarsler/1"),
             mineNotifikasjonerResult2.getTypedContent("mineNotifikasjoner/edges/0/node/eksterneVarsler/2"),
@@ -230,9 +230,9 @@ class EksternVarselApiTests: DescribeSpec({
         val oppdatertVarsel2 = oppdaterteVarsler.find { it.id == id2 } !!
 
         it("status-oppdatering reflektert i graphql-endepunkt") {
-            oppdatertVarsel0.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.SENDT
-            oppdatertVarsel1.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.FEILET
-            oppdatertVarsel2.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.FEILET
+            oppdatertVarsel0.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.SENDT
+            oppdatertVarsel1.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.FEILET
+            oppdatertVarsel2.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.FEILET
         }
     }
     describe("Oppretter oppgave med eksterne varsler som sendes OK") {
@@ -247,9 +247,9 @@ class EksternVarselApiTests: DescribeSpec({
 
         // sjekk varsel-status er 'bestillt' via graphql
         val mineNotifikasjonerResult = engine.produsentApi(mineNotifikasjonerQuery)
-        val varsel0 = mineNotifikasjonerResult.getTypedContent<QueryMineNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/0")
-        val varsel1 = mineNotifikasjonerResult.getTypedContent<QueryMineNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/1")
-        val varsel2 = mineNotifikasjonerResult.getTypedContent<QueryMineNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/2")
+        val varsel0 = mineNotifikasjonerResult.getTypedContent<QueryNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/0")
+        val varsel1 = mineNotifikasjonerResult.getTypedContent<QueryNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/1")
+        val varsel2 = mineNotifikasjonerResult.getTypedContent<QueryNotifikasjoner.EksterntVarsel>("mineNotifikasjoner/edges/0/node/eksterneVarsler/2")
 
         it("bestilling registrert") {
             varsel0.id shouldBeIn listOf(id0, id1, id2)
@@ -257,9 +257,9 @@ class EksternVarselApiTests: DescribeSpec({
             varsel2.id shouldBeIn listOf(id0, id1, id2)
             setOf(id0, id1, id2) shouldHaveSize 3
 
-            varsel0.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.NY
-            varsel1.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.NY
-            varsel2.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.NY
+            varsel0.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.NY
+            varsel1.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.NY
+            varsel2.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.NY
         }
 
 
@@ -304,7 +304,7 @@ class EksternVarselApiTests: DescribeSpec({
         )
 
         val mineNotifikasjonerResult2 = engine.produsentApi(mineNotifikasjonerQuery)
-        val oppdaterteVarsler = listOf<QueryMineNotifikasjoner.EksterntVarsel>(
+        val oppdaterteVarsler = listOf<QueryNotifikasjoner.EksterntVarsel>(
             mineNotifikasjonerResult2.getTypedContent("mineNotifikasjoner/edges/0/node/eksterneVarsler/0"),
             mineNotifikasjonerResult2.getTypedContent("mineNotifikasjoner/edges/0/node/eksterneVarsler/1"),
             mineNotifikasjonerResult2.getTypedContent("mineNotifikasjoner/edges/0/node/eksterneVarsler/2"),
@@ -314,9 +314,9 @@ class EksternVarselApiTests: DescribeSpec({
         val oppdatertVarsel2 = oppdaterteVarsler.find { it.id == id2 } !!
 
         it("status-oppdatering reflektert i graphql-endepunkt") {
-            oppdatertVarsel0.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.SENDT
-            oppdatertVarsel1.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.FEILET
-            oppdatertVarsel2.status shouldBe QueryMineNotifikasjoner.EksterntVarselStatus.FEILET
+            oppdatertVarsel0.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.SENDT
+            oppdatertVarsel1.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.FEILET
+            oppdatertVarsel2.status shouldBe QueryNotifikasjoner.EksterntVarselStatus.FEILET
         }
     }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HardDeleteSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HardDeleteSakTests.kt
@@ -250,7 +250,7 @@ class HardDeleteSakTests : DescribeSpec({
                         }
                     }
                     """
-                ).getTypedContent<Error.DuplikatGrupperingsid>("nySak")
+                ).getTypedContent<Error.DuplikatGrupperingsidEtterDelete>("nySak")
             }
         }
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HentNotifikasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/HentNotifikasjonTests.kt
@@ -1,0 +1,215 @@
+package no.nav.arbeidsgiver.notifikasjon.produsent.api
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
+import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
+import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
+import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
+import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import java.time.OffsetDateTime
+import java.util.*
+
+class HentNotifikasjonTests : DescribeSpec({
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentModel = ProdusentRepositoryImpl(database)
+    val engine = ktorProdusentTestServer(produsentRepository = produsentModel)
+    val virksomhetsnummer = "123"
+    val merkelapp = "tag"
+    val mottaker = AltinnMottaker(
+        virksomhetsnummer = virksomhetsnummer,
+        serviceCode = "1",
+        serviceEdition = "1"
+    )
+    val grupperingsid = "sak1"
+
+    val uuid = UUID.randomUUID()
+    val uuid2 = UUID.randomUUID()
+    val oppgave = HendelseModel.OppgaveOpprettet(
+        virksomhetsnummer = "1",
+        merkelapp = merkelapp,
+        eksternId = "1",
+        mottakere = listOf(mottaker),
+        hendelseId = uuid,
+        notifikasjonId = uuid,
+        tekst = "test",
+        lenke = "https://nav.no",
+        opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z"),
+        grupperingsid = grupperingsid,
+        kildeAppNavn = "",
+        produsentId = "",
+        eksterneVarsler = listOf(),
+        hardDelete = null,
+        frist = null,
+        påminnelse = null,
+        sakId = null,
+    )
+    val beskjed = HendelseModel.BeskjedOpprettet(
+        virksomhetsnummer = "1",
+        merkelapp = merkelapp,
+        eksternId = "2",
+        mottakere = listOf(mottaker),
+        hendelseId = uuid2,
+        notifikasjonId = uuid2,
+        tekst = "test",
+        lenke = "https://nav.no",
+        opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z"),
+        grupperingsid = grupperingsid,
+        kildeAppNavn = "",
+        produsentId = "",
+        eksterneVarsler = listOf(),
+        hardDelete = null,
+        sakId = null,
+    )
+
+
+    describe("hentNotifikasjon") {
+        context("notifikasjon finnes ikke") {
+            it("respons inneholder forventet data") {
+                engine.produsentApi(
+                    """
+                        query {
+                            hentNotifikasjon(id: "${UUID.randomUUID()}") {
+                                __typename
+                                ... on Error {
+                                    feilmelding
+                                }
+                            }
+                        }
+                    """.trimIndent()
+                ).getTypedContent<Error.NotifikasjonFinnesIkke>("hentNotifikasjon")
+            }
+        }
+
+        context("produsent mangler tilgang til merkelapp") {
+            produsentModel.oppdaterModellEtterHendelse(oppgave.copy(merkelapp = "fubar"))
+
+            it("respons inneholder forventet data") {
+                engine.produsentApi(
+                    """
+                        query {
+                            hentNotifikasjon(id: "${oppgave.notifikasjonId}") {
+                                __typename
+                                ... on Error {
+                                    feilmelding
+                                }
+                            }
+                        }
+                    """.trimIndent()
+                ).getTypedContent<Error.UgyldigMerkelapp>("hentNotifikasjon")
+            }
+        }
+
+        context("henter notifikasjon på id") {
+            produsentModel.oppdaterModellEtterHendelse(oppgave)
+            produsentModel.oppdaterModellEtterHendelse(beskjed)
+
+            withData(listOf(oppgave.notifikasjonId, beskjed.notifikasjonId)) { notifikasjonId ->
+                engine.produsentApi(
+                    """
+                    query {
+                        hentNotifikasjon(id: "$notifikasjonId") {
+                            __typename
+                            ... on HentetNotifikasjon {
+                                notifikasjon {
+                                    __typename
+                                    ... on Beskjed {
+                                        mottakere {
+                                            __typename
+                                            ... on AltinnMottaker {
+                                                serviceCode
+                                                serviceEdition
+                                                virksomhetsnummer
+                                            }
+                                            ... on NaermesteLederMottaker {
+                                                ansattFnr
+                                                naermesteLederFnr
+                                                virksomhetsnummer
+                                            }
+                                        }
+                                        mottaker {
+                                            __typename
+                                            ... on AltinnMottaker {
+                                                serviceCode
+                                                serviceEdition
+                                                virksomhetsnummer
+                                            }
+                                            ... on NaermesteLederMottaker {
+                                                ansattFnr
+                                                naermesteLederFnr
+                                                virksomhetsnummer
+                                            }
+                                        }
+                                        metadata {
+                                            __typename
+                                            id
+                                            eksternId
+                                            grupperingsid
+                                        }
+                                        beskjed {
+                                            __typename
+                                            lenke
+                                            merkelapp
+                                            tekst
+                                        }
+                                        eksterneVarsler {
+                                            id
+                                        }
+                                    }
+                                    ... on Oppgave {
+                                        mottakere {
+                                            __typename
+                                            ... on AltinnMottaker {
+                                                serviceCode
+                                                serviceEdition
+                                                virksomhetsnummer
+                                            }
+                                            ... on NaermesteLederMottaker {
+                                                ansattFnr
+                                                naermesteLederFnr
+                                                virksomhetsnummer
+                                            }
+                                        }
+                                        mottaker {
+                                            __typename
+                                            ... on AltinnMottaker {
+                                                serviceCode
+                                                serviceEdition
+                                                virksomhetsnummer
+                                            }
+                                            ... on NaermesteLederMottaker {
+                                                ansattFnr
+                                                naermesteLederFnr
+                                                virksomhetsnummer
+                                            }
+                                        }
+                                        metadata {
+                                            __typename
+                                            id
+                                            eksternId
+                                            grupperingsid
+                                        }
+                                        oppgave {
+                                            __typename
+                                            lenke
+                                            merkelapp
+                                            tekst
+                                            tilstand
+                                        }
+                                        eksterneVarsler {
+                                            id
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    """.trimIndent()
+                ).getTypedContent<QueryNotifikasjoner.HentetNotifikasjon>("hentNotifikasjon")
+            }
+        }
+    }
+})
+

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MineNotifikasjonerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MineNotifikasjonerTests.kt
@@ -245,7 +245,7 @@ class MineNotifikasjonerTests : DescribeSpec({
             )
 
             it("respons inneholder forventet data") {
-                response.getTypedContent<QueryMineNotifikasjoner.NotifikasjonConnection>("mineNotifikasjoner")
+                response.getTypedContent<QueryNotifikasjoner.NotifikasjonConnection>("mineNotifikasjoner")
             }
         }
 
@@ -364,7 +364,7 @@ class MineNotifikasjonerTests : DescribeSpec({
             )
 
             it("respons inneholder forventet data") {
-                val connection = response.getTypedContent<QueryMineNotifikasjoner.NotifikasjonConnection>("mineNotifikasjoner")
+                val connection = response.getTypedContent<QueryNotifikasjoner.NotifikasjonConnection>("mineNotifikasjoner")
                 connection.edges.size shouldBe 1
                 connection.pageInfo.hasNextPage shouldBe true
             }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedFlereMottakereTests.kt
@@ -63,7 +63,7 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
             val id = response.getTypedContent<UUID>("/nyBeskjed/id")
             val mottakere = engine.hentMottakere(id)
             mottakere.toSet() shouldBe setOf(
-                QueryMineNotifikasjoner.AltinnMottaker(
+                QueryNotifikasjoner.AltinnMottaker(
                     serviceCode = "5441",
                     serviceEdition = "1",
                     virksomhetsnummer = "0"
@@ -98,7 +98,7 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
             val id = response.getTypedContent<UUID>("/nyBeskjed/id")
             val mottakere = engine.hentMottakere(id)
             mottakere.toSet() shouldBe setOf(
-                QueryMineNotifikasjoner.AltinnMottaker(
+                QueryNotifikasjoner.AltinnMottaker(
                     serviceCode = "5441",
                     serviceEdition = "1",
                     virksomhetsnummer = "0"
@@ -138,12 +138,12 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
             val id = response.getTypedContent<UUID>("/nyBeskjed/id")
             val mottakere = engine.hentMottakere(id)
             mottakere.toSet() shouldBe setOf(
-                QueryMineNotifikasjoner.AltinnMottaker(
+                QueryNotifikasjoner.AltinnMottaker(
                     serviceCode = "5441",
                     serviceEdition = "1",
                     virksomhetsnummer = "0"
                 ),
-                QueryMineNotifikasjoner.NærmesteLederMottaker(
+                QueryNotifikasjoner.NærmesteLederMottaker(
                     ansattFnr = "3",
                     naermesteLederFnr = "2",
                     virksomhetsnummer = "0"
@@ -184,12 +184,12 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
             val id = response.getTypedContent<UUID>("/nyBeskjed/id")
             val mottakere = engine.hentMottakere(id)
             mottakere.toSet() shouldBe setOf(
-                QueryMineNotifikasjoner.AltinnMottaker(
+                QueryNotifikasjoner.AltinnMottaker(
                     serviceCode = "5441",
                     serviceEdition = "1",
                     virksomhetsnummer = "0"
                 ),
-                QueryMineNotifikasjoner.NærmesteLederMottaker(
+                QueryNotifikasjoner.NærmesteLederMottaker(
                     ansattFnr = "3",
                     naermesteLederFnr = "2",
                     virksomhetsnummer = "0"
@@ -225,7 +225,7 @@ fun nyBeskjed(fragment: String) = """
             }
         """
 
-internal fun TestApplicationEngine.hentMottakere(id: UUID): List<QueryMineNotifikasjoner.Mottaker> {
+internal fun TestApplicationEngine.hentMottakere(id: UUID): List<QueryNotifikasjoner.Mottaker> {
     return this.produsentApi(
         """
         query {
@@ -280,7 +280,7 @@ internal fun TestApplicationEngine.hentMottakere(id: UUID): List<QueryMineNotifi
         .getTypedContent<List<JsonNode>>("$.mineNotifikasjoner.edges[*].node")
         .flatMap {
             if (it["metadata"]["id"].asText() == id.toString())
-                laxObjectMapper.convertValue<List<QueryMineNotifikasjoner.Mottaker>>(it["mottakere"])
+                laxObjectMapper.convertValue<List<QueryNotifikasjoner.Mottaker>>(it["mottakere"])
             else
                 listOf()
         }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveFlereMottakereTests.kt
@@ -59,7 +59,7 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
             val id = response.getTypedContent<UUID>("/nyOppgave/id")
             val mottakere = engine.hentMottakere(id)
             mottakere.toSet() shouldBe setOf(
-                QueryMineNotifikasjoner.AltinnMottaker(
+                QueryNotifikasjoner.AltinnMottaker(
                     serviceCode = "5441",
                     serviceEdition = "1",
                     virksomhetsnummer = "0"
@@ -94,7 +94,7 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
             val id = response.getTypedContent<UUID>("/nyOppgave/id")
             val mottakere = engine.hentMottakere(id)
             mottakere.toSet() shouldBe setOf(
-                QueryMineNotifikasjoner.AltinnMottaker(
+                QueryNotifikasjoner.AltinnMottaker(
                     serviceCode = "5441",
                     serviceEdition = "1",
                     virksomhetsnummer = "0"
@@ -134,12 +134,12 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
             val id = response.getTypedContent<UUID>("/nyOppgave/id")
             val mottakere = engine.hentMottakere(id)
             mottakere.toSet() shouldBe setOf(
-                QueryMineNotifikasjoner.AltinnMottaker(
+                QueryNotifikasjoner.AltinnMottaker(
                     serviceCode = "5441",
                     serviceEdition = "1",
                     virksomhetsnummer = "0"
                 ),
-                QueryMineNotifikasjoner.NærmesteLederMottaker(
+                QueryNotifikasjoner.NærmesteLederMottaker(
                     ansattFnr = "3",
                     naermesteLederFnr = "2",
                     virksomhetsnummer = "0"
@@ -180,12 +180,12 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
             val id = response.getTypedContent<UUID>("/nyOppgave/id")
             val mottakere = engine.hentMottakere(id)
             mottakere.toSet() shouldBe setOf(
-                QueryMineNotifikasjoner.AltinnMottaker(
+                QueryNotifikasjoner.AltinnMottaker(
                     serviceCode = "5441",
                     serviceEdition = "1",
                     virksomhetsnummer = "0"
                 ),
-                QueryMineNotifikasjoner.NærmesteLederMottaker(
+                QueryNotifikasjoner.NærmesteLederMottaker(
                     ansattFnr = "3",
                     naermesteLederFnr = "2",
                     virksomhetsnummer = "0"

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveTests.kt
@@ -193,6 +193,10 @@ private suspend inline fun <reified T: MutationNyOppgave.NyOppgaveResultat> Desc
                         id
                     }
                 }
+                ... on DuplikatEksternIdOgMerkelapp {
+                    feilmelding
+                    idTilEksisterende
+                }
                 ... on Error {
                     feilmelding
                 }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/SoftDeleteNotifikasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/SoftDeleteNotifikasjonTests.kt
@@ -230,7 +230,7 @@ class SoftDeleteNotifikasjonTests : DescribeSpec({
                     """
                 )
                 val slettetNotifikasjon =
-                    response.getTypedContent<QueryMineNotifikasjoner.NotifikasjonConnection>("mineNotifikasjoner")
+                    response.getTypedContent<QueryNotifikasjoner.NotifikasjonConnection>("mineNotifikasjoner")
                         .edges
                         .map { it.node }
                         .find { it.id == uuid }!!


### PR DESCRIPTION
Utvider Error typene `DuplikatEksternIdOgMerkelapp`  og `DuplikatGrupperingsid` med feltet `idTilEksisterende` som reflekterer hva vi anså som eksisterende duplikat.

Nytt endepunkt for å slå opp en Notifikasjon basert på id: `hentNotifikasjon(id: ID!): HentNotifikasjonResultat!`
