### PR TITLE
Rydd i varsler tilknyttet hard deleted notifikasjoner

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelsesstrøm.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelsesstrøm.kt
@@ -2,20 +2,27 @@ package no.nav.arbeidsgiver.notifikasjon.hendelse
 
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HendelseMetadata
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import java.util.concurrent.atomic.AtomicBoolean
 
 interface Hendelsesstrøm {
     suspend fun forEach(
         stop: AtomicBoolean = AtomicBoolean(false),
+        onTombstone: suspend (String) -> Unit = skipTombstones,
         body: suspend (Hendelse, HendelseMetadata) -> Unit
     )
-
     suspend fun forEach(
         stop: AtomicBoolean = AtomicBoolean(false),
+        onTombstone: suspend (String) -> Unit = skipTombstones,
         body: suspend (Hendelse) -> Unit
     ) {
-        forEach(stop) { hendelse: Hendelse, _: HendelseMetadata ->
+        forEach(stop, onTombstone) { hendelse: Hendelse, _: HendelseMetadata ->
             body(hendelse)
         }
+    }
+
+    companion object {
+        private val log = logger()
+        private val skipTombstones: suspend (String) -> Unit = { log.info("skipping tombstoned event key=${it}") }
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelsesstrøm.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelsesstrøm.kt
@@ -3,17 +3,18 @@ package no.nav.arbeidsgiver.notifikasjon.hendelse
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 
 interface Hendelsesstrøm {
     suspend fun forEach(
         stop: AtomicBoolean = AtomicBoolean(false),
-        onTombstone: suspend (String) -> Unit = skipTombstones,
+        onTombstone: suspend (UUID) -> Unit = skipTombstones,
         body: suspend (Hendelse, HendelseMetadata) -> Unit
     )
     suspend fun forEach(
         stop: AtomicBoolean = AtomicBoolean(false),
-        onTombstone: suspend (String) -> Unit = skipTombstones,
+        onTombstone: suspend (UUID) -> Unit = skipTombstones,
         body: suspend (Hendelse) -> Unit
     ) {
         forEach(stop, onTombstone) { hendelse: Hendelse, _: HendelseMetadata ->
@@ -23,6 +24,6 @@ interface Hendelsesstrøm {
 
     companion object {
         private val log = logger()
-        private val skipTombstones: suspend (String) -> Unit = { log.info("skipping tombstoned event key=${it}") }
+        private val skipTombstones: suspend (UUID) -> Unit = { log.info("skipping tombstoned event key=${it}") }
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
@@ -39,13 +39,13 @@ class HendelsesstrømKafkaImpl(
 
     override suspend fun forEach(
         stop: AtomicBoolean,
-        onTombstone: suspend (String) -> Unit,
+        onTombstone: suspend (UUID) -> Unit,
         body: suspend (Hendelse, HendelseMetadata) -> Unit
     ) {
         consumer.forEach(stop) { record ->
             val recordValue = record.value()
             if (recordValue == null) {
-                onTombstone(record.key())
+                onTombstone(UUID.fromString(record.key()))
             } else if (recordValue.hendelseId in brokenHendelseId) {
                 /* do nothing */
             } else {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -77,7 +77,6 @@ object Produsent {
             launch {
                 val produsentRepository = produsentRepositoryAsync.await()
                 rebuildQueryModel.forEach(onTombstone = { key ->
-                    log.info("skipping tombstoned event key=${key}")
                     produsentRepository.deleteVarslerForTombstone(key)
                 }) { event, metadata ->
                     if (event is HendelseModel.OppgaveOpprettet || event is HendelseModel.BeskjedOpprettet) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.HttpAuthProviders
@@ -78,10 +77,8 @@ object Produsent {
                 val produsentRepository = produsentRepositoryAsync.await()
                 rebuildQueryModel.forEach(onTombstone = { key ->
                     produsentRepository.deleteVarslerForTombstone(key)
-                }) { event, metadata ->
-                    if (event is HendelseModel.OppgaveOpprettet || event is HendelseModel.BeskjedOpprettet) {
-                        produsentRepository.oppdaterModellEtterHendelse(event, metadata)
-                    }
+                }) { _, _ ->
+
                 }
             }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -76,7 +76,10 @@ object Produsent {
 
             launch {
                 val produsentRepository = produsentRepositoryAsync.await()
-                rebuildQueryModel.forEach { event, metadata ->
+                rebuildQueryModel.forEach(onTombstone = { key ->
+                    log.info("skipping tombstoned event key=${key}")
+                    produsentRepository.deleteVarslerForTombstone(key)
+                }) { event, metadata ->
                     if (event is HendelseModel.OppgaveOpprettet || event is HendelseModel.BeskjedOpprettet) {
                         produsentRepository.oppdaterModellEtterHendelse(event, metadata)
                     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -33,7 +33,7 @@ object Produsent {
     private val rebuildQueryModel by lazy {
         HendelsesstrømKafkaImpl(
             topic = NOTIFIKASJON_TOPIC,
-            groupId = "produsent-model-builder-rebuild-nov-2023-1",
+            groupId = "produsent-model-builder-rebuild-nov-2023-2",
             replayPeriodically = false,
         )
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -744,16 +744,16 @@ class ProdusentRepositoryImpl(
     /**
      * temporary method to delete all varsler for a given tombstone
      */
-    suspend fun deleteVarslerForTombstone(key: String) {
+    suspend fun deleteVarslerForTombstone(key: UUID) {
         database.nonTransactionalExecuteUpdate("""
             delete from eksternt_varsel where notifikasjon_id ? 
         """) {
-            uuid(UUID.fromString(key))
+            uuid(key)
         }
         database.nonTransactionalExecuteUpdate("""
             delete from paaminnelse_eksternt_varsel where notifikasjon_id ? 
         """) {
-            uuid(UUID.fromString(key))
+            uuid(key)
         }
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -413,6 +413,22 @@ class ProdusentRepositoryImpl(
             ) {
                 uuid(hardDelete.aggregateId)
             }
+            executeUpdate(
+                """
+                delete from eksternt_varsel
+                where notifikasjon_id = ?
+                """
+            ) {
+                uuid(hardDelete.aggregateId)
+            }
+            executeUpdate(
+                """
+                delete from paaminnelse_eksternt_varsel
+                where notifikasjon_id = ?
+                """
+            ) {
+                uuid(hardDelete.aggregateId)
+            }
         }
     }
 
@@ -722,6 +738,22 @@ class ProdusentRepositoryImpl(
             text(mottaker.virksomhetsnummer)
             text(mottaker.serviceCode)
             text(mottaker.serviceEdition)
+        }
+    }
+
+    /**
+     * temporary method to delete all varsler for a given tombstone
+     */
+    suspend fun deleteVarslerForTombstone(key: String) {
+        database.nonTransactionalExecuteUpdate("""
+            delete from eksternt_varsel where notifikasjon_id ? 
+        """) {
+            uuid(UUID.fromString(key))
+        }
+        database.nonTransactionalExecuteUpdate("""
+            delete from paaminnelse_eksternt_varsel where notifikasjon_id ? 
+        """) {
+            uuid(UUID.fromString(key))
         }
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -746,12 +746,12 @@ class ProdusentRepositoryImpl(
      */
     suspend fun deleteVarslerForTombstone(key: UUID) {
         database.nonTransactionalExecuteUpdate("""
-            delete from eksternt_varsel where notifikasjon_id ? 
+            delete from eksternt_varsel where notifikasjon_id = ? 
         """) {
             uuid(key)
         }
         database.nonTransactionalExecuteUpdate("""
-            delete from paaminnelse_eksternt_varsel where notifikasjon_id ? 
+            delete from paaminnelse_eksternt_varsel where notifikasjon_id = ? 
         """) {
             uuid(key)
         }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingStatusEksportServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingStatusEksportServiceTest.kt
@@ -26,7 +26,7 @@ class EksternVarslingStatusEksportServiceTest : DescribeSpec({
         eventSource = object : Hendelsesstrøm {
             override suspend fun forEach(
                 stop: AtomicBoolean,
-                onTombstone: suspend (String) -> Unit,
+                onTombstone: suspend (UUID) -> Unit,
                 body: suspend (HendelseModel.Hendelse, HendelseModel.HendelseMetadata) -> Unit
             ): Unit = TODO("Not yet implemented")
         },

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingStatusEksportServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingStatusEksportServiceTest.kt
@@ -26,6 +26,7 @@ class EksternVarslingStatusEksportServiceTest : DescribeSpec({
         eventSource = object : Hendelsesstrøm {
             override suspend fun forEach(
                 stop: AtomicBoolean,
+                onTombstone: suspend (String) -> Unit,
                 body: suspend (HendelseModel.Hendelse, HendelseModel.HendelseMetadata) -> Unit
             ): Unit = TODO("Not yet implemented")
         },


### PR DESCRIPTION
Som oppdaget i #610 så er det mange eksterne varsler som ikke har fått kilde_hendelse satt etter rebuild. 
- #610

Grunnen til dette er at hard delete ikke fører til rydding i tabellene `eksternt_varsel` og `paaminnelse_eksternt_varsel`. 
Her er det ei heller noen fkey med cascade delete.

Siden disse hendelsene har blitt tombstoned og compacted for lengst, så synes jeg det var en god løsning å åpne opp får å lytte på tombstones. I dette tilfellet, så rydder jeg alle varsler som er tilknyttet en notifikasjon med id = tombstone.key. 

Dette vil kun være sant for de tombstonene hvor hendelsen var opprettelse av aggregatet (BeskjedOpprettet, OppgaveOpprettet),
resten vil føre til 0 rows affected, da key er hendelseId / uuid.

Kort oppsummert: 
Gjør det mulig å lytte på tombstones via onTombstone i forEach på Hendelsesstrøm. (Default oppførsel er å logge "skipped ..." som før)

Benytt tombstones for å slette varsler som er tilknyttet notifikasjoner med tombstone key som id. 
Dette burde fange opp de hendelsene som er slettet og compacted.

Oppdater hard delete håndtering til å slette tilknyttede varsler, slik at rydding via tombstones kan fjernes etter rebuild.