### PR TITLE
Tag 2211 ny status tilbake i tid

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerWriter.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerWriter.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.launchHttpServer
@@ -29,6 +30,14 @@ object BrukerWriter {
         )
     }
 
+    private val rebuildQueryModel by lazy {
+        HendelsesstrømKafkaImpl(
+            topic = NOTIFIKASJON_TOPIC,
+            groupId = "bruker-model-builder-2-rebuild-nov-2023",
+            replayPeriodically = false,
+        )
+    }
+
     fun main(
         httpPort: Int = 8080
     ) {
@@ -42,6 +51,16 @@ object BrukerWriter {
                 val brukerRepository = brukerRepositoryAsync.await()
                 hendelsesstrøm.forEach { event, metadata ->
                     brukerRepository.oppdaterModellEtterHendelse(event, metadata)
+                }
+            }
+
+
+            launch {
+                val brukerRepository = brukerRepositoryAsync.await()
+                rebuildQueryModel.forEach { event, metadata ->
+                    if (event is HendelseModel.NyStatusSak) {
+                        brukerRepository.oppdaterModellEtterHendelse(event, metadata)
+                    }
                 }
             }
 

--- a/app/src/main/resources/db/migration/bruker_model/V38__sakstatus_oppgitt_mottatt_tidspunkt.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V38__sakstatus_oppgitt_mottatt_tidspunkt.sql
@@ -1,0 +1,2 @@
+alter table sak_status rename column tidspunkt to mottatt_tidspunkt;
+alter table sak_status add column oppgitt_tidspunkt timestamp with time zone;

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NyLenkeTilSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NyLenkeTilSakTests.kt
@@ -3,7 +3,11 @@ package no.nav.arbeidsgiver.notifikasjon.bruker
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.IdempotenceKey
-import no.nav.arbeidsgiver.notifikasjon.util.*
+import no.nav.arbeidsgiver.notifikasjon.util.AltinnStub
+import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
+import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import java.time.OffsetDateTime
 
 class NyLenkeTilSakTests : DescribeSpec({
     val database = testDatabase(Bruker.databaseConfig)
@@ -21,6 +25,12 @@ class NyLenkeTilSakTests : DescribeSpec({
         offset = 0,
         limit = 1,
     ).getTypedContent<String>("saker/saker/0/lenke")
+
+    fun hentSisteStatus() = engine.querySakerJson(
+        virksomhetsnummer = TEST_VIRKSOMHET_1,
+        offset = 0,
+        limit = 1,
+    ).getTypedContent<BrukerAPI.SakStatus>("saker/saker/0/sisteStatus")
 
 
     describe("endring av lenke i sak") {
@@ -41,10 +51,15 @@ class NyLenkeTilSakTests : DescribeSpec({
             sak = sakOpprettet,
             idempotensKey = IdempotenceKey.userSupplied("20202021"),
             nyLenkeTilSak = "#bar",
+            oppgittTidspunkt = OffsetDateTime.parse("2020-01-01T12:00:00Z"),
         )
 
         it("Får ny lenke ") {
             hentLenke() shouldBe "#bar"
+        }
+
+        it("Får ny status tidspunkt") {
+            hentSisteStatus().tidspunkt shouldBe OffsetDateTime.parse("2020-01-01T12:00:00Z")
         }
 
         brukerRepository.nyStatusSak(


### PR DESCRIPTION
Som beskrevet i JIRA saken så forsøker Team Helse Arbeidsgiver å oppdatere lenke og tidspunkt via en statusoppdatering på sak med oppgittTidspunkt tilbake i tid.
Det fører i praksis til at saken ser ut som den er uendret, da det blir laget en rad i sak_status, men at en sakstatus med nyere tidsstempel vises som siste.
Denne PRen endrer slik at vi sorterer statusene på mottatt_tidspunkt, men viser tidspunkt hvor tidspunkt enten er oppgittTidspunkt, eller mottattTidspunkt avhengig av om oppgittTidspunkt er null.
 