### PR TITLE
legg til index på notifikasjon_id i hendelse_relasjon

### DIFF
--- a/app/src/main/resources/db/migration/kafka_reaper_model/V4__index_notifikasjon_id.sql
+++ b/app/src/main/resources/db/migration/kafka_reaper_model/V4__index_notifikasjon_id.sql
@@ -1,0 +1,1 @@
+create index notifikasjon_hendelse_relasjon_notifikasjon_id_idx on notifikasjon_hendelse_relasjon (notifikasjon_id);


### PR DESCRIPTION
Det er en del tid brukt på replay i reaperen som forårsaker consumer lag.
Dette er på grunn av sprørringen 
`SELECT hendelse_id FROM notifikasjon_hendelse_relasjon WHERE notifikasjon_id = $1`
som bruker 1 sekund i snitt på å kjøre.

Uten denne indeksen:

| QUERY PLAN                                                                         |
|:-----------------------------------------------------------------------------------|
| Seq Scan on notifikasjon\_hendelse\_relasjon  \(cost=0.00..16.50 rows=3 width=16\) |
| Filter: \(notifikasjon\_id = 'xxx'::uuid\)                                         |


Med denne indeksen:

| QUERY PLAN |
| :--- |
| Bitmap Heap Scan on notifikasjon\_hendelse\_relasjon  \(cost=4.17..11.28 rows=3 width=16\) |
|   Recheck Cond: \(notifikasjon\_id = '39ec6122-6862-4f92-b272-3a8005cf7857'::uuid\) |
|   -&gt;  Bitmap Index Scan on notifikasjon\_hendelse\_relasjon\_notifikasjon\_id\_idx  \(cost=0.00..4.17 rows=3 width=0\) |
|         Index Cond: \(notifikasjon\_id = 'xxx'::uuid\) |

![image](https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/assets/189395/0341206c-9406-42fc-856c-47bf9d65b60c)


![image](https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/assets/189395/f8d88874-5dfd-447f-9bd1-bab8e6e1f67e)
