### PR TITLE
ReplayValidator sjekker etter opprettelser etter hard delete sak

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
@@ -11,6 +11,7 @@ import no.nav.arbeidsgiver.notifikasjon.kafka_backup.KafkaBackup
 import no.nav.arbeidsgiver.notifikasjon.kafka_reaper.KafkaReaper
 import no.nav.arbeidsgiver.notifikasjon.manuelt_vedlikehold.ManueltVedlikehold
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
+import no.nav.arbeidsgiver.notifikasjon.replay_validator.ReplayValidator
 import no.nav.arbeidsgiver.notifikasjon.skedulert_påminnelse.SkedulertPåminnelse
 import no.nav.arbeidsgiver.notifikasjon.skedulert_utgått.SkedulertUtgått
 import no.nav.arbeidsgiver.notifikasjon.statistikk.Statistikk

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
@@ -493,7 +493,10 @@ object HendelseModel {
         val deletedAt: OffsetDateTime,
         val grupperingsid: String?,
         val merkelapp: String?,
-    ) : Hendelse()
+    ) : Hendelse() {
+        @JsonIgnore
+        val erSak = grupperingsid != null
+    }
 
     @JsonTypeName("BrukerKlikket")
     data class BrukerKlikket(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/manuelt_vedlikehold/ManueltVedlikeholdService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/manuelt_vedlikehold/ManueltVedlikeholdService.kt
@@ -4,6 +4,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HardDelete
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionProcessor
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import java.time.OffsetDateTime
@@ -36,7 +37,7 @@ class ManueltVedlikeholdService(
         ) },
     ).map { UUID.fromString(it)!!}
 
-    override suspend fun processHendelse(hendelse: HendelseModel.Hendelse) {
+    override suspend fun processHendelse(hendelse: HendelseModel.Hendelse, metadata: PartitionHendelseMetadata) {
         when (hendelse) {
             is HardDelete ->
                 aggregatesDeleted[hendelse.aggregateId] = Unit

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidatorService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidatorService.kt
@@ -1,0 +1,218 @@
+package no.nav.arbeidsgiver.notifikasjon.replay_validator
+
+import io.micrometer.core.instrument.MultiGauge
+import io.micrometer.core.instrument.Tags
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionProcessor
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.local_database.EphemeralDatabase
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.local_database.executeQuery
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.local_database.executeUpdate
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import java.sql.ResultSet
+
+
+class ReplayValidatorService : PartitionProcessor {
+    private val log = logger()
+    private val antallOpprettelserEtterHardDelete = MultiGauge.builder("antall_notifikasjoner_opprettet_etter_delete")
+        .description("Antall notifikasjoner opprettet etter hard delete av sak")
+        .register(Metrics.meterRegistry)
+
+    internal val repository = ReplayValidatorRepository()
+
+    override fun close() = repository.close()
+
+    override suspend fun processHendelse(hendelse: HendelseModel.Hendelse, metadata: PartitionHendelseMetadata) {
+        when (hendelse) {
+            is HendelseModel.OppgaveOpprettet,
+            is HendelseModel.BeskjedOpprettet,
+            -> {
+                repository.insertNotifikasjonCreate(
+                    id = hendelse.aggregateId.toString(),
+                    produsentId = hendelse.produsentId ?: "ukjent produsent",
+                    merkelapp = when (hendelse) {
+                        is HendelseModel.OppgaveOpprettet -> hendelse.merkelapp
+                        is HendelseModel.BeskjedOpprettet -> hendelse.merkelapp
+                        else -> throw IllegalStateException("Uventet hendelse $hendelse")
+                    },
+                    grupperingsid = when (hendelse) {
+                        is HendelseModel.OppgaveOpprettet -> hendelse.grupperingsid
+                        is HendelseModel.BeskjedOpprettet -> hendelse.grupperingsid
+                        else -> throw IllegalStateException("Uventet hendelse $hendelse")
+                    },
+                    createdOffset = metadata.offset.toString(),
+                    createdPartition = metadata.partition.toString(),
+                )
+            }
+
+            is HendelseModel.HardDelete -> {
+                if (hendelse.erSak) {
+                    repository.insertSakHardDelete(
+                        id = hendelse.aggregateId.toString(),
+                        produsentId = hendelse.produsentId,
+                        merkelapp = hendelse.merkelapp!!,
+                        grupperingsid = hendelse.grupperingsid!!,
+                        deletedOffset = metadata.offset.toString(),
+                        deletedPartition = metadata.partition.toString(),
+                    )
+                }
+            }
+
+            is HendelseModel.SakOpprettet,
+            is HendelseModel.OppgaveUtført,
+            is HendelseModel.OppgaveUtgått,
+            is HendelseModel.PåminnelseOpprettet,
+            is HendelseModel.BrukerKlikket,
+            is HendelseModel.FristUtsatt,
+            is HendelseModel.EksterntVarselFeilet,
+            is HendelseModel.EksterntVarselVellykket,
+            is HendelseModel.SoftDelete,
+            is HendelseModel.NyStatusSak -> Unit
+        }
+
+    }
+
+    override suspend fun processingLoopStep() {
+        repository.findNotifikasjonCreatesAfterHardDeleteSak().forEach {
+            log.warn("NotifikasjonCreateAfterHardDeleteSak: partition={} offset={}", it.createdPartition, it.createdOffset)
+        }
+
+        antallOpprettelserEtterHardDelete.register(
+            repository.findNotifikasjonCreatesAfterHardDeleteSak()
+                .groupBy { it.produsentId }
+                .map { (key, value) ->
+                    MultiGauge.Row.of(
+                        Tags.of("produsent_id", key),
+                        value.size.toDouble()
+                    )
+                },
+            true
+        )
+    }
+}
+
+class ReplayValidatorRepository : AutoCloseable {
+    private val database = EphemeralDatabase(
+        "replay_validator",
+        """
+        create table notifikasjon_creates (
+            id text not null primary key,
+            produsent_id text not null,
+            merkelapp text not null,
+            grupperingsid text,
+            created_offset bigint,
+            created_partition int
+        );
+        
+        create table sak_hard_deletes (
+            id text not null primary key,
+            produsent_id text not null,
+            merkelapp text not null,
+            grupperingsid text not null,
+            deleted_offset bigint,
+            deleted_partition int
+        );
+        """.trimIndent()
+    )
+
+    override fun close() = database.close()
+
+    fun insertNotifikasjonCreate(
+        id: String,
+        produsentId: String,
+        merkelapp: String,
+        grupperingsid: String?,
+        createdOffset: String,
+        createdPartition: String,
+    ) {
+        database.useTransaction {
+            executeUpdate(
+                """
+                insert into notifikasjon_creates (id, produsent_id, merkelapp, grupperingsid, created_offset, created_partition)
+                values (?, ?, ?, ?, ?, ?)
+                on conflict (id) do nothing
+                """.trimIndent(),
+                setup = {
+                    setText(id)
+                    setText(produsentId)
+                    setText(merkelapp)
+                    setTextOrNull(grupperingsid)
+                    setText(createdOffset)
+                    setText(createdPartition)
+                }
+            )
+        }
+    }
+
+    fun insertSakHardDelete(
+        id: String,
+        produsentId: String,
+        merkelapp: String,
+        grupperingsid: String,
+        deletedOffset: String,
+        deletedPartition: String,
+    ) {
+        database.useTransaction {
+            executeUpdate(
+                """
+                insert into sak_hard_deletes (id, produsent_id, merkelapp, grupperingsid, deleted_offset, deleted_partition)
+                values (?, ?, ?, ?, ?, ?)
+                on conflict (id) do nothing
+                """.trimIndent(),
+                setup = {
+                    setText(id)
+                    setText(produsentId)
+                    setText(merkelapp)
+                    setText(grupperingsid)
+                    setText(deletedOffset)
+                    setText(deletedPartition)
+                }
+            )
+        }
+    }
+
+    fun findNotifikasjonCreatesAfterHardDeleteSak(): List<NotifikasjonCreateAfterHardDeleteSak> {
+        return database.useTransaction {
+            executeQuery(
+                """
+                select * from notifikasjon_creates n 
+                where exists (
+                    select s.id from sak_hard_deletes s 
+                    where s.merkelapp = n.merkelapp
+                        and s.grupperingsid = n.grupperingsid
+                        and s.deleted_offset is not null
+                        and s.deleted_offset < n.created_offset
+                )
+                """.trimIndent(),
+                setup = {},
+                result = {
+                    val results = mutableListOf<NotifikasjonCreateAfterHardDeleteSak>()
+                    while (next()) {
+                        results.add(asNotifikasjonCreateAfterHardDeleteSak())
+                    }
+                    results
+                }
+            )
+        }
+    }
+}
+
+data class NotifikasjonCreateAfterHardDeleteSak(
+    val id: String,
+    val produsentId: String,
+    val merkelapp: String,
+    val grupperingsid: String,
+    val createdOffset: String,
+    val createdPartition: String,
+)
+
+private fun ResultSet.asNotifikasjonCreateAfterHardDeleteSak() =
+    NotifikasjonCreateAfterHardDeleteSak(
+        id = getString("id"),
+        produsentId = getString("produsent_id"),
+        merkelapp = getString("merkelapp"),
+        grupperingsid = getString("grupperingsid"),
+        createdOffset = getString("created_offset"),
+        createdPartition = getString("created_partition"),
+    )

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelseService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelseService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.time.delay
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.NaisEnvironment
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionProcessor
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTid
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTidImpl
@@ -19,7 +20,7 @@ class SkedulertPåminnelseService(
 ) : PartitionProcessor {
     private val repository = SkedulertPåminnelseRepository()
 
-    override suspend fun processHendelse(hendelse: HendelseModel.Hendelse) {
+    override suspend fun processHendelse(hendelse: HendelseModel.Hendelse, metadata: PartitionHendelseMetadata) {
         repository.processHendelse(hendelse)
     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttService.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.time.delay
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.NaisEnvironment
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionProcessor
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTid
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTidImpl
@@ -24,7 +25,7 @@ class SkedulertUtgåttService(
 
     override fun close() = repository.close()
 
-    override suspend fun processHendelse(hendelse: HendelseModel.Hendelse) {
+    override suspend fun processHendelse(hendelse: HendelseModel.Hendelse, metadata: PartitionHendelseMetadata) {
         @Suppress("UNUSED_VARIABLE")
         val ignored = when (hendelse) {
             is HendelseModel.OppgaveOpprettet -> {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/replay_validator/LocalMainReplayValidator.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/executable/replay_validator/LocalMainReplayValidator.kt
@@ -1,6 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.executable.replay_validator
 
-import no.nav.arbeidsgiver.notifikasjon.ReplayValidator
+import no.nav.arbeidsgiver.notifikasjon.replay_validator.ReplayValidator
 import no.nav.arbeidsgiver.notifikasjon.executable.Port
 
 /* Bruker API */

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidatorServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidatorServiceTest.kt
@@ -1,0 +1,75 @@
+package no.nav.arbeidsgiver.notifikasjon.replay_validator
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
+import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
+
+class ReplayValidatorServiceTest : DescribeSpec({
+
+    describe("ReplayValidatorService opprett notifikasjon etter hard delete av sak") {
+        val service = ReplayValidatorService()
+
+        val hendelser = listOf(
+            EksempelHendelse.SakOpprettet.copy(
+                merkelapp = "merkelapp",
+                grupperingsid = "grupperingsid",
+            ),
+            EksempelHendelse.HardDelete.copy(
+                merkelapp = "merkelapp",
+                grupperingsid = "grupperingsid",
+            ),
+            EksempelHendelse.BeskjedOpprettet.copy(
+                merkelapp = "merkelapp",
+                grupperingsid = "grupperingsid",
+            ),
+        )
+
+        hendelser.forEachIndexed { i, hendelse ->
+            service.processHendelse(hendelse, PartitionHendelseMetadata(1, (i + 1).toLong()))
+        }
+
+        it("NotifikasjonCreateAfterHardDeleteSak skal finnes i repo") {
+            val notifikasjonCreateAfterHardDeleteSak = service.repository.findNotifikasjonCreatesAfterHardDeleteSak()
+            notifikasjonCreateAfterHardDeleteSak shouldContainExactly listOf(
+                NotifikasjonCreateAfterHardDeleteSak(
+                    id = hendelser.last().aggregateId.toString(),
+                    produsentId = hendelser.last().produsentId!!,
+                    merkelapp = "merkelapp",
+                    grupperingsid = "grupperingsid",
+                    createdOffset = "3",
+                    createdPartition = "1",
+                )
+            )
+        }
+    }
+
+    describe("ReplayValidatorService opprett notifikasjon før hard delete av sak") {
+        val service = ReplayValidatorService()
+
+        val hendelser = listOf(
+            EksempelHendelse.SakOpprettet.copy(
+                merkelapp = "merkelapp",
+                grupperingsid = "grupperingsid",
+            ),
+            EksempelHendelse.BeskjedOpprettet.copy(
+                merkelapp = "merkelapp",
+                grupperingsid = "grupperingsid",
+            ),
+            EksempelHendelse.HardDelete.copy(
+                merkelapp = "merkelapp",
+                grupperingsid = "grupperingsid",
+            ),
+        )
+
+        hendelser.forEachIndexed { i, hendelse ->
+            service.processHendelse(hendelse, PartitionHendelseMetadata(1, (i + 1).toLong()))
+        }
+
+        it("NotifikasjonCreateAfterHardDeleteSak skal finnes i repo") {
+            val notifikasjonCreateAfterHardDeleteSak = service.repository.findNotifikasjonCreatesAfterHardDeleteSak()
+            notifikasjonCreateAfterHardDeleteSak shouldBe emptyList()
+        }
+    }
+})

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/HardDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/HardDeleteTests.kt
@@ -5,25 +5,30 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.util.*
 
+
 class HardDeleteTests: DescribeSpec({
+    val metadata = PartitionHendelseMetadata(0, 0)
 
     describe("Hvis oppgave blir hard deleted") {
         val hendelseProdusent = FakeHendelseProdusent()
         val service = SkedulertPåminnelseService(hendelseProdusent)
 
         val oppgave = oppgaveMedPåminnelse()
-        service.processHendelse(oppgave)
-        service.processHendelse(hardDelete(
-            aggregateId = oppgave.aggregateId,
-            grupperingsId = null,
-            merkelapp = null,
-        ))
+        service.processHendelse(oppgave, metadata)
+        service.processHendelse(
+            hardDelete(
+                aggregateId = oppgave.aggregateId,
+                grupperingsId = null,
+                merkelapp = null,
+            ), metadata
+        )
 
         it("Sendes ingen påminnelse") {
             service.sendAktuellePåminnelser()
@@ -38,31 +43,33 @@ class HardDeleteTests: DescribeSpec({
         oppgaveMedPåminnelse(
             merkelapp = "m1",
             grupperingsId = "g1",
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenGruppe = oppgaveMedPåminnelse(
             merkelapp = "m1",
             grupperingsId = "g2"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenMerkelapp = oppgaveMedPåminnelse(
             merkelapp = "m2",
             grupperingsId = "g1"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenGruppeOgMerkelapp = oppgaveMedPåminnelse(
             merkelapp = "m2",
             grupperingsId = "g2"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val sak1 = opprettSak(merkelapp = "m1", grupperingsId = "g1")
-            .also { service.processHendelse(it) }
+            .also { service.processHendelse(it, metadata) }
 
-        service.processHendelse(hardDelete(
-            aggregateId = sak1.aggregateId,
-            merkelapp = "m1",
-            grupperingsId = "g1"
-        ))
+        service.processHendelse(
+            hardDelete(
+                aggregateId = sak1.aggregateId,
+                merkelapp = "m1",
+                grupperingsId = "g1"
+            ), metadata
+        )
 
         it("sendes ikke påminnelse hvis både merkelapp og grupperingsid matcher") {
             service.sendAktuellePåminnelser()
@@ -85,33 +92,35 @@ class HardDeleteTests: DescribeSpec({
         val service = SkedulertPåminnelseService(hendelseProdusent)
 
         val sak1 = opprettSak(merkelapp = "m1", grupperingsId = "g1")
-            .also { service.processHendelse(it) }
+            .also { service.processHendelse(it, metadata) }
 
         oppgaveMedPåminnelse(
             merkelapp = "m1",
             grupperingsId = "g1",
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenGruppe = oppgaveMedPåminnelse(
             merkelapp = "m1",
             grupperingsId = "g2"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenMerkelapp = oppgaveMedPåminnelse(
             merkelapp = "m2",
             grupperingsId = "g1"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenGruppeOgMerkelapp = oppgaveMedPåminnelse(
             merkelapp = "m2",
             grupperingsId = "g2"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
-        service.processHendelse(hardDelete(
-            aggregateId = sak1.aggregateId,
-            merkelapp = "m1",
-            grupperingsId = "g1"
-        ))
+        service.processHendelse(
+            hardDelete(
+                aggregateId = sak1.aggregateId,
+                merkelapp = "m1",
+                grupperingsId = "g1"
+            ), metadata
+        )
 
         it("sendes ikke påminnelse hvis både merkelapp og grupperingsid matcher") {
             service.sendAktuellePåminnelser()
@@ -134,33 +143,35 @@ class HardDeleteTests: DescribeSpec({
         val service = SkedulertPåminnelseService(hendelseProdusent)
 
         val sak1 = opprettSak(merkelapp = "m1", grupperingsId = "g1")
-            .also { service.processHendelse(it) }
+            .also { service.processHendelse(it, metadata) }
 
-        service.processHendelse(hardDelete(
-            aggregateId = sak1.aggregateId,
-            merkelapp = "m1",
-            grupperingsId = "g1"
-        ))
+        service.processHendelse(
+            hardDelete(
+                aggregateId = sak1.aggregateId,
+                merkelapp = "m1",
+                grupperingsId = "g1"
+            ), metadata
+        )
 
         oppgaveMedPåminnelse(
             merkelapp = "m1",
             grupperingsId = "g1",
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenGruppe = oppgaveMedPåminnelse(
             merkelapp = "m1",
             grupperingsId = "g2"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenMerkelapp = oppgaveMedPåminnelse(
             merkelapp = "m2",
             grupperingsId = "g1"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         val annenGruppeOgMerkelapp = oppgaveMedPåminnelse(
             merkelapp = "m2",
             grupperingsId = "g2"
-        ).also { service.processHendelse(it) }
+        ).also { service.processHendelse(it, metadata) }
 
         it("sendes ikke påminnelse hvis både merkelapp og grupperingsid matcher") {
             service.sendAktuellePåminnelser()

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelseIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelseIdempotensTests.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.skedulert_påminnelse
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.NoopHendelseProdusent
 
@@ -10,8 +11,8 @@ class SkedulertPåminnelseIdempotensTests : DescribeSpec({
 
     describe("SkedulertPåminnelse Idempotent oppførsel") {
         withData(EksempelHendelse.Alle) { hendelse ->
-            service.processHendelse(hendelse)
-            service.processHendelse(hendelse)
+            service.processHendelse(hendelse, PartitionHendelseMetadata(0, 0))
+            service.processHendelse(hendelse, PartitionHendelseMetadata(0, 0))
         }
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttIdempotensTests.kt
@@ -2,6 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.skedulert_utgått
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.NoopHendelseProdusent
 
@@ -10,8 +11,8 @@ class SkedulertUtgåttIdempotensTests : DescribeSpec({
 
     describe("SkedulertUtgått Idempotent oppførsel") {
         withData(EksempelHendelse.Alle) { hendelse ->
-            service.processHendelse(hendelse)
-            service.processHendelse(hendelse)
+            service.processHendelse(hendelse, PartitionHendelseMetadata(0, 0))
+            service.processHendelse(hendelse, PartitionHendelseMetadata(0, 0))
         }
     }
 })


### PR DESCRIPTION
dersom det oppdager noen opprettede notifikasjoner på grupperingsid og merkelapp som er slettet så blir det logget en warning og lagt til info i metrikken antall_notifikasjoner_opprettet_etter_delete


TODO: 
* [x] deploy til dev og sjekk at replayvalidator fungerer som den skal
  * får nok ikke fremprovosert tilstanden, da det kun kan skje ved en race condition