### PR TITLE
retry dersom vi får 502 503 eller 504

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/tokenx/TokenXClient.kt
@@ -40,6 +40,11 @@ fun defaultHttpClient() = HttpClient(Apache) {
     }
     install(HttpRequestRetry) {
         maxRetries = 3
+        retryIf { _, res ->
+            res.status == HttpStatusCode.ServiceUnavailable ||
+            res.status == HttpStatusCode.GatewayTimeout ||
+            res.status == HttpStatusCode.BadGateway
+        }
         retryOnExceptionIf { _, cause ->
             cause is ConnectionClosedException ||
             cause is SocketTimeoutException


### PR DESCRIPTION
Det skjer som regel når det er oppgraderinger i clusteret.
Denne endringen skal gjør oss litt mer robust i de tilfellene.