### PR TITLE
legg til index på gruppering_id merkelapp

### DIFF
--- a/app/src/main/resources/db/migration/kafka_reaper_model/V5__index_gruppering_id_merkelapp.sql
+++ b/app/src/main/resources/db/migration/kafka_reaper_model/V5__index_gruppering_id_merkelapp.sql
@@ -1,0 +1,1 @@
+create index notifikasjon_hendelse_relasjon_gruppering_id_merkelapp_idx on notifikasjon_hendelse_relasjon (gruppering_id, merkelapp);


### PR DESCRIPTION
Reaper bruker litt lang til på big leap replay. Ser i cloud console at det er en seq scan på spørringen:
```
INSERT INTO
  deleted_notifikasjon (notifikasjon_id,
    deleted_at) (
  SELECT
    hendelse_id AS notifikasjon_id,
    $1 AS deleted_at
  FROM
    notifikasjon_hendelse_relasjon
  WHERE
    gruppering_id = $2
    AND merkelapp = $3)
ON
  conflict DO nothing

```

![image](https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/assets/189395/c292c26a-c102-45dc-949b-afba369a2073)

