### PR TITLE
legg til index for grupperingsid merkelapp

### DIFF
--- a/app/src/main/resources/db/migration/skedulert_harddelete_model/V5__index_gruppering_id_merkelapp.sql
+++ b/app/src/main/resources/db/migration/skedulert_harddelete_model/V5__index_gruppering_id_merkelapp.sql
@@ -1,0 +1,1 @@
+create index aggregate_gruppering_id_merkelapp_idx on aggregate (grupperingsid, merkelapp);


### PR DESCRIPTION
Seq scan fører til lagg alert ved replay leap

```
DELETE
FROM
  AGGREGATE
WHERE
  merkelapp = $1
  AND grupperingsid = $2
```

![image](https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/assets/189395/5679b5e4-6082-4cc0-8d9f-919206d0ab5f)
