### PR TITLE
legg til index på grupperingid merkelapp

### DIFF
--- a/app/src/main/resources/db/migration/statistikk_model/V14__indeks_merkelapp_grupperingsid.sql
+++ b/app/src/main/resources/db/migration/statistikk_model/V14__indeks_merkelapp_grupperingsid.sql
@@ -1,0 +1,1 @@
+create index aggregate_gruppering_id_merkelapp_idx on notifikasjon (gruppering_id, merkelapp);


### PR DESCRIPTION
statistikk-model-builder bruker ca 200ms per hard delete event i prod. Dette gjør at big leap replay i dag tok mer enn 1 time.
![image](https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/assets/189395/540352ca-5669-4192-a534-d6e161db3f71)

```
UPDATE
  notifikasjon
SET
  hard_deleted_tidspunkt = $1
WHERE
  gruppering_id = $2
  AND merkelapp = $3
```

## BEFORE
| QUERY PLAN |
| :--- |
| Update on notifikasjon  \(cost=0.15..8.17 rows=1 width=258\) |
|   -&gt;  Index Scan using merkelapp\_idx on notifikasjon  \(cost=0.15..8.17 rows=1 width=258\) |
|         Index Cond: \(merkelapp = 'tag'::text\) |
|         Filter: \(gruppering\_id = '42'::text\) |

## AFTER
| QUERY PLAN |
| :--- |
| Update on notifikasjon  \(cost=0.00..1.05 rows=1 width=258\) |
|   -&gt;  Seq Scan on notifikasjon  \(cost=0.00..1.05 rows=1 width=258\) |
|         Filter: \(\(gruppering\_id = '42'::text\) AND \(merkelapp = 'tag'::text\)\) |
