### PR TITLE
fjern deserialization config fra test

### DIFF
--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QueryKommendeKalenderavtalerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QueryKommendeKalenderavtalerTests.kt
@@ -3,7 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon.bruker
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.Notifikasjon.Kalenderavtale
-import no.nav.arbeidsgiver.notifikasjon.tid.atOsloAsOffsetDateTime
+import no.nav.arbeidsgiver.notifikasjon.tid.atOslo
 import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.LocalDateTime
 
@@ -83,11 +83,11 @@ class QueryKommendeKalenderavtalerTests: DescribeSpec({
             val kalenderavtaler = response.getTypedContent<List<Kalenderavtale>>("kommendeKalenderavtaler/avtaler")
             kalenderavtaler.size shouldBe 3
             kalenderavtaler[0].tekst shouldBe "1. plass"
-            kalenderavtaler[0].startTidspunkt shouldBe now.plusHours(1).atOsloAsOffsetDateTime()
+            kalenderavtaler[0].startTidspunkt.toInstant() shouldBe now.plusHours(1).atOslo().toInstant()
             kalenderavtaler[1].tekst shouldBe "2. plass"
-            kalenderavtaler[1].startTidspunkt shouldBe now.plusDays(1).atOsloAsOffsetDateTime()
+            kalenderavtaler[1].startTidspunkt.toInstant() shouldBe now.plusDays(1).atOslo().toInstant()
             kalenderavtaler[2].tekst shouldBe "fra DNF til 3. plass"
-            kalenderavtaler[2].startTidspunkt shouldBe now.plusDays(2).atOsloAsOffsetDateTime()
+            kalenderavtaler[2].startTidspunkt.toInstant() shouldBe now.plusDays(2).atOslo().toInstant()
         }
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTidslinjeTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTidslinjeTest.kt
@@ -14,7 +14,7 @@ import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.Notifikasjon.Oppgave.Ti
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.OppgaveTidslinjeElement
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.TidslinjeElement
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
-import no.nav.arbeidsgiver.notifikasjon.tid.atOsloAsOffsetDateTime
+import no.nav.arbeidsgiver.notifikasjon.tid.atOslo
 import no.nav.arbeidsgiver.notifikasjon.util.AltinnStub
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
@@ -159,8 +159,8 @@ class QuerySakerTidslinjeTest: DescribeSpec({
             instanceOf<BrukerAPI.KalenderavtaleTidslinjeElement, TidslinjeElement>(tidslinje1[0]) {
                 it.tekst shouldBe kalenderavtale.tekst
                 it.avtaletilstand shouldBe BrukerAPI.Notifikasjon.Kalenderavtale.Tilstand.VENTER_SVAR_FRA_ARBEIDSGIVER
-                it.startTidspunkt shouldBe kalenderavtale.startTidspunkt.atOsloAsOffsetDateTime()
-                it.sluttTidspunkt shouldBe kalenderavtale.sluttTidspunkt?.atOsloAsOffsetDateTime()
+                it.startTidspunkt.toInstant() shouldBe kalenderavtale.startTidspunkt.atOslo().toInstant()
+                it.sluttTidspunkt?.toInstant() shouldBe kalenderavtale.sluttTidspunkt?.atOslo()?.toInstant()
                 it.lokasjon shouldNot beNull()
                 it.lokasjon!!.adresse shouldBe kalenderavtale.lokasjon!!.adresse
                 it.lokasjon!!.poststed shouldBe kalenderavtale.lokasjon!!.poststed

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
@@ -1,6 +1,5 @@
 package no.nav.arbeidsgiver.notifikasjon.util
 
-import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.jayway.jsonpath.JsonPath
@@ -23,33 +22,23 @@ fun TestApplicationResponse.validateStatusOK() {
     }
 }
 
-/**
- * fikse slik at deserialiserte datoer beholder tidssone
- * se: https://github.com/FasterXML/jackson-modules-java8/issues/53
- *
- * Vi bør vurdere om dette skal settes i prod koden også, mao direkte på laxObjectMapper
- */
-val laxObjectMapperForTest = laxObjectMapper.apply {
-    configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
-}
-
 inline fun <reified T> TestApplicationResponse.getTypedContent(name: String): T {
     validateStatusOK()
     val errors = getGraphqlErrors()
     if (errors.isEmpty()) {
-        val tree = laxObjectMapperForTest.readTree(this.content!!)
+        val tree = laxObjectMapper.readTree(this.content!!)
         logger().error("content: $tree")
         val dataNode = tree.get("data")
 
         return if (name.startsWith("$")) {
-            val rawJson = laxObjectMapperForTest.writeValueAsString(JsonPath.read(dataNode.toString(), name))
+            val rawJson = laxObjectMapper.writeValueAsString(JsonPath.read(dataNode.toString(), name))
             laxObjectMapper.readValue(rawJson)
         } else {
             val node = dataNode.at(name.ensurePrefix("/"))
             if (node.isNull || node.isMissingNode) {
                 throw Exception("content.data does not contain element '$name' content: $tree")
             }
-            laxObjectMapperForTest.convertValue(node)
+            laxObjectMapper.convertValue(node)
         }
     } else {
         throw Exception("Got errors $errors")
@@ -61,8 +50,8 @@ fun TestApplicationResponse.getGraphqlErrors(): List<GraphQLError> {
     if (this.content == null) {
         throw NullPointerException("content is null. status:${status()}")
     }
-    val tree = laxObjectMapperForTest.readTree(this.content!!)
+    val tree = laxObjectMapper.readTree(this.content!!)
     logger().info("content: $tree")
     val errors = tree.get("errors")
-    return if (errors == null) emptyList() else laxObjectMapperForTest.convertValue(errors)
+    return if (errors == null) emptyList() else laxObjectMapper.convertValue(errors)
 }


### PR DESCRIPTION
Dette hadde påvirkning på tester på sak.
Må se nærmere på en proper fix, men endrer tilbake deserialization feature først

Fikk ikke testfeil på branch før etter merge, som er veldig rart 🤔 
Tester på main feiler nå, så jeg rullet tilbake endring av laxObjectMapper i test og heller gjorde en temp workaround på de testene som var litt wonky.

Tenker å se på å få til en tilsvarende fix som tidligere, hvor dato blir serdes med offset hvis angitt. Så slipper vi masse workarounds i tester fordi man går fra +1 til Z gjennom jackson