### PR TITLE
raskere tester med template db og eksplisit oppsett

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -25,6 +25,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
+          POSTGRESQL_FSYNC: "off"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -21,7 +21,7 @@ import java.util.*
  * are running a single command or a transaction.
  */
 class Database private constructor(
-    private val config: Config,
+    val config: Config,
     private val dataSource: NonBlockingDataSource<*>,
 ): Closeable {
     data class Config(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -21,7 +21,7 @@ import java.util.*
  * are running a single command or a transaction.
  */
 class Database private constructor(
-    val config: Config,
+    private val config: Config,
     private val dataSource: NonBlockingDataSource<*>,
 ): Closeable {
     data class Config(

--- a/app/src/main/resources/kotest.properties
+++ b/app/src/main/resources/kotest.properties
@@ -1,3 +1,9 @@
 # uten disse tar testene en evighet å starte. se: https://github.com/kotest/kotest/issues/3126
+kotest.framework.discovery.jar.scan.disable=true
 kotest.framework.classpath.scanning.config.disable=true
 kotest.framework.classpath.scanning.autoscan.disable=true
+
+# default=1
+kotest.framework.parallelism=1
+# one of InstancePerTest, InstancePerLeaf, SingleInstance(default)
+kotest.framework.isolation.mode=SingleInstance

--- a/app/src/main/resources/kotest.properties
+++ b/app/src/main/resources/kotest.properties
@@ -4,6 +4,6 @@ kotest.framework.classpath.scanning.config.disable=true
 kotest.framework.classpath.scanning.autoscan.disable=true
 
 # default=1
-kotest.framework.parallelism=1
+kotest.framework.parallelism=3
 # one of InstancePerTest, InstancePerLeaf, SingleInstance(default)
 kotest.framework.isolation.mode=SingleInstance

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/AltinnTilgangsstyringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/AltinnTilgangsstyringTests.kt
@@ -10,10 +10,10 @@ import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.OffsetDateTime
 
 class AltinnTilgangsstyringTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
     describe("Tilgangsstyring med altinn-tjenester") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+
         for ((id, serviceCode) in listOf(
             "0" to  "HarTilgang0",
             "1" to  "HarTilgang1",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerApiTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerApiTests.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.bruker
 
+import io.kotest.core.annotation.Isolate
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.shouldBe
@@ -12,6 +13,7 @@ import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 
+@Isolate // see todo below
 class BrukerApiTests : DescribeSpec({
 
     val fnr = "00000000000"
@@ -45,6 +47,7 @@ class BrukerApiTests : DescribeSpec({
             )
         )
 
+        val before = meterRegistry.get("notifikasjoner_hentet").counter().count()
         val response = engine.queryNotifikasjonerJson()
 
         it("response inneholder riktig data") {
@@ -63,8 +66,9 @@ class BrukerApiTests : DescribeSpec({
         }
 
         it("notifikasjoner hentet counter økt") {
+            // TODO: this is flaky in parallell.
             val vellykket = meterRegistry.get("notifikasjoner_hentet").counter().count()
-            vellykket shouldBe 2
+            vellykket - before shouldBe 2
         }
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerApiTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerApiTests.kt
@@ -13,19 +13,19 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 
 class BrukerApiTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
 
     val fnr = "00000000000"
     val ansattFnr = "12344321"
     val virksomhetsnummer = "1234"
     val mottaker = HendelseModel.NærmesteLederMottaker(fnr, ansattFnr, virksomhetsnummer)
 
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-    )
 
     describe("graphql bruker-api Query.notifikasjoner") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+        )
         val beskjed = brukerRepository.beskjedOpprettet(
             virksomhetsnummer = virksomhetsnummer,
             mottakere = listOf(mottaker),

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerKlikkGraphQL_QueryModell_IntegrasjonTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerKlikkGraphQL_QueryModell_IntegrasjonTests.kt
@@ -9,19 +9,19 @@ import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 
 class BrukerKlikkGraphQL_QueryModell_IntegrasjonTests: DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
 
     val fnr = "00000000000"
     val ansattFnr = "12344321"
     val virksomhetsnummer = "1234"
     val mottaker = NærmesteLederMottaker(fnr, ansattFnr, virksomhetsnummer)
 
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-    )
 
     describe("Brukerklikk-oppførsel") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+        )
 
         val beskjedOpprettet = brukerRepository.beskjedOpprettet(
             virksomhetsnummer = virksomhetsnummer,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelTests.kt
@@ -15,8 +15,7 @@ import java.time.temporal.ChronoUnit.MILLIS
 import java.util.*
 
 class BrukerModelTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
+
     val uuid = UUID.fromString("da89eafe-b31b-11eb-8529-0242ac130003")
     val mottaker = NærmesteLederMottaker(
         naermesteLederFnr = "314",
@@ -44,6 +43,8 @@ class BrukerModelTests : DescribeSpec({
 
     describe("Beskjed opprettet i BrukerModel") {
         context("happy path") {
+            val database = testDatabase(Bruker.databaseConfig)
+            val brukerRepository = BrukerRepositoryImpl(database)
             brukerRepository.oppdaterModellEtterNærmesteLederLeesah(
                 NarmesteLederLeesah(
                     narmesteLederId = uuid("4321"),
@@ -76,6 +77,8 @@ class BrukerModelTests : DescribeSpec({
         }
 
         context("notifikasjon mottas flere ganger (fra kafka f.eks.)") {
+            val database = testDatabase(Bruker.databaseConfig)
+            val brukerRepository = BrukerRepositoryImpl(database)
             brukerRepository.oppdaterModellEtterNærmesteLederLeesah(
                 NarmesteLederLeesah(
                     narmesteLederId = uuid("4321"),

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepositoryNærmesteLederTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepositoryNærmesteLederTests.kt
@@ -9,11 +9,12 @@ import java.time.LocalDate
 import java.util.*
 
 class BrukerRepositoryNærmesteLederTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
+
 
     describe("BrukerRepository NærmesteLeder") {
         context("når mottar slett hendelse uten at det er noe å slette") {
+            val database = testDatabase(Bruker.databaseConfig)
+            val brukerRepository = BrukerRepositoryImpl(database)
             val narmesteLederFnr = "42"
             brukerRepository.oppdaterModellEtterNærmesteLederLeesah(
                 NarmesteLederLeesah(
@@ -31,6 +32,8 @@ class BrukerRepositoryNærmesteLederTests : DescribeSpec({
         }
 
         context("når mottar to forskjellige koblinger") {
+            val database = testDatabase(Bruker.databaseConfig)
+            val brukerRepository = BrukerRepositoryImpl(database)
             val narmesteLederId = UUID.fromString("da89eafe-b31b-11eb-8529-0242ac130003")
             brukerRepository.oppdaterModellEtterNærmesteLederLeesah(
                 NarmesteLederLeesah(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepositorySearchTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepositorySearchTest.kt
@@ -10,10 +10,10 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class BrukerRepositorySearchTest : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
 
     describe("BrukerRepositoryImpl#hentSaker") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
         brukerRepository.insertSak("1", "Refusjon graviditet - Gerd - 112233")
         brukerRepository.insertSak("2", "Refusjon kronisk syk - Gerd - 112233")
         brukerRepository.insertSak("3", "Refusjon kronisk syk - Gerd - 223344")

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/HardDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/HardDeleteTests.kt
@@ -16,10 +16,9 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class HardDeleteTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
     describe("HardDelete av notifikasjon") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
         val uuid1 = UUID.fromString("da89eafe-b31b-11eb-8529-0242ac130003")
         val uuid2 = UUID.fromString("da89eafe-b31b-11eb-8529-0242ac130004")
 
@@ -84,6 +83,8 @@ class HardDeleteTests : DescribeSpec({
     }
 
     describe("HardDelete av sak") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
         val uuid1 = UUID.fromString("da89eafe-b31b-11eb-8529-0242ac130003")
         val uuid2 = UUID.fromString("da89eafe-b31b-11eb-8529-0242ac130004")
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NyLenkeOppgaveTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NyLenkeOppgaveTests.kt
@@ -6,10 +6,10 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 
 
 class NyLenkeOppgaveTests: DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
 
     describe("Oppgave med uendret lenke") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
         val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(lenke = "https://opprettelse-lenke")
         it("Starter med lenken fra hendelse") {
             brukerRepository.hentLenke() shouldBe "https://opprettelse-lenke"
@@ -22,6 +22,8 @@ class NyLenkeOppgaveTests: DescribeSpec({
     }
 
     describe("Oppgave med endret lenke") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
         val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(lenke = "https://opprettelse-lenke")
         it("Starter med lenken fra hendelse") {
             brukerRepository.hentLenke() shouldBe "https://opprettelse-lenke"

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NærmesteLederTilgangsstyringTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NærmesteLederTilgangsstyringTests.kt
@@ -15,15 +15,16 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 
 class NærmesteLederTilgangsstyringTests: DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
 
-    suspend fun beskjedOpprettet(mottaker: Mottaker) = brukerRepository.beskjedOpprettet(
+    suspend fun BrukerRepository.beskjedOpprettet(mottaker: Mottaker) = beskjedOpprettet(
         virksomhetsnummer = mottaker.virksomhetsnummer,
         mottakere = listOf(mottaker),
     )
 
     describe("Tilgangsstyring av nærmeste leder") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+
         val virksomhet1 = "1".repeat(9)
         val virksomhet2 = "2".repeat(9)
         val nærmesteLeder = "1".repeat(11)
@@ -48,9 +49,9 @@ class NærmesteLederTilgangsstyringTests: DescribeSpec({
             virksomhetsnummer = virksomhet2,
         )
 
-        val beskjed1 = beskjedOpprettet(mottaker = mottaker1)
-        beskjedOpprettet(mottaker = mottaker2)
-        val beskjed3 = beskjedOpprettet(mottaker = mottaker3)
+        val beskjed1 = brukerRepository.beskjedOpprettet(mottaker = mottaker1)
+        brukerRepository.beskjedOpprettet(mottaker = mottaker2)
+        val beskjed3 = brukerRepository.beskjedOpprettet(mottaker = mottaker3)
 
         it("ingen ansatte gir ingen notifikasjoner") {
             val notifikasjoner = brukerRepository.hentNotifikasjoner(nærmesteLeder, Tilganger.EMPTY)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/OppgaveMedFristTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/OppgaveMedFristTests.kt
@@ -12,17 +12,16 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class OppgaveMedFristTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
-        }
-    )
 
     describe("oppgave med frist") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(
             frist = LocalDate.parse("2007-12-03"),
         )
@@ -36,6 +35,14 @@ class OppgaveMedFristTests : DescribeSpec({
     }
 
     describe("ny oppgave med utsatt frist får ny frist") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(
             frist = LocalDate.parse("2007-12-03"),
         )
@@ -54,6 +61,14 @@ class OppgaveMedFristTests : DescribeSpec({
     }
 
     describe("utført oppgave med utsatt frist har samme frist") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(
             frist = LocalDate.parse("2007-12-03"),
         )
@@ -73,6 +88,14 @@ class OppgaveMedFristTests : DescribeSpec({
     }
 
     describe("utgått oppgave med utsatt frist har ny frist") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(
             frist = LocalDate.parse("2007-12-03"),
         )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/OppgaveMedPåminnelseTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/OppgaveMedPåminnelseTests.kt
@@ -3,22 +3,24 @@ package no.nav.arbeidsgiver.notifikasjon.bruker
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import no.nav.arbeidsgiver.notifikasjon.tid.inOsloLocalDateTime
-import no.nav.arbeidsgiver.notifikasjon.util.*
+import no.nav.arbeidsgiver.notifikasjon.util.AltinnStub
+import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
+import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.time.OffsetDateTime
 import java.util.*
 
 class OppgaveMedPåminnelseTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
-        }
-    )
 
     describe("oppgave med påminnelse blir bumpet og klikk state clearet") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val tidspunkt = OffsetDateTime.parse("2020-12-03T10:15:30+01:00")
         val oppgave0 = brukerRepository.oppgaveOpprettet(
             opprettetTidspunkt = tidspunkt,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/OppgaveUførtTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/OppgaveUførtTests.kt
@@ -7,17 +7,16 @@ import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.OffsetDateTime
 
 class OppgaveUførtTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
-        }
-    )
 
     describe("oppgave utført") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(
             notifikasjonId = uuid("0"),
             opprettetTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/OppgaveUtgåttTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/OppgaveUtgåttTests.kt
@@ -7,17 +7,15 @@ import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.OffsetDateTime
 
 class OppgaveUtgåttTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
-        }
-    )
-
     describe("oppgave utgått") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(
             notifikasjonId = uuid("1"),
             opprettetTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QueryKommendeKalenderavtalerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QueryKommendeKalenderavtalerTests.kt
@@ -8,18 +8,17 @@ import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.LocalDateTime
 
 class QueryKommendeKalenderavtalerTests: DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
-        }
-    )
     val now = LocalDateTime.now()
 
     describe("kommendeKalenderavtaler") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val grupperingsid = "42"
         val merkelapp = "tag"
         brukerRepository.sakOpprettet(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QueryNotifikasjonerMedSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QueryNotifikasjonerMedSakTests.kt
@@ -14,17 +14,16 @@ import java.time.LocalDate
 import java.time.OffsetDateTime
 
 class QueryNotifikasjonerMedSakTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
-        }
-    )
 
     context("Query.notifikasjoner med sak") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val opprettetTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00")
 
         val oppgaveUtenSakOpprettet = brukerRepository.oppgaveOpprettet(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakTests.kt
@@ -13,22 +13,10 @@ import java.util.*
 class QuerySakTests : DescribeSpec({
     val fallbackTimeNotUsed = OffsetDateTime.parse("2020-01-01T01:01:01Z")
 
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
 
-    val engine = ktorBrukerTestServer(
-        altinn = AltinnStub(
-            "0".repeat(11) to BrukerModel.Tilganger(
-                tjenestetilganger = listOf(
-                    BrukerModel.Tilgang.Altinn("42", "5441", "1"),
-                    BrukerModel.Tilgang.Altinn("43", "5441", "1")
-                ),
-            )
-        ),
-        brukerRepository = brukerRepository,
-    )
 
     describe("Query.sakById") {
+        val (brukerRepository, engine) = setupRepoOgEngine()
         val sak1 = brukerRepository.sakOpprettet(
             virksomhetsnummer = "42",
             merkelapp = "tag",
@@ -78,6 +66,7 @@ class QuerySakTests : DescribeSpec({
     }
 
     describe("Query.sakByGrupperingsid") {
+        val (brukerRepository, engine) = setupRepoOgEngine()
         val sak1 = brukerRepository.sakOpprettet(
             virksomhetsnummer = "42",
             merkelapp = "tag",
@@ -126,6 +115,23 @@ class QuerySakTests : DescribeSpec({
         }
     }
 })
+
+private fun DescribeSpec.setupRepoOgEngine(): Pair<BrukerRepositoryImpl, TestApplicationEngine> {
+    val database = testDatabase(Bruker.databaseConfig)
+    val brukerRepository = BrukerRepositoryImpl(database)
+    val engine = ktorBrukerTestServer(
+        altinn = AltinnStub(
+            "0".repeat(11) to BrukerModel.Tilganger(
+                tjenestetilganger = listOf(
+                    BrukerModel.Tilgang.Altinn("42", "5441", "1"),
+                    BrukerModel.Tilgang.Altinn("43", "5441", "1")
+                ),
+            )
+        ),
+        brukerRepository = brukerRepository,
+    )
+    return Pair(brukerRepository, engine)
+}
 
 private fun TestApplicationEngine.sakById(sakId: UUID) = brukerApi(
     GraphQLRequest(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerAntallMerkelapperTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerAntallMerkelapperTests.kt
@@ -19,25 +19,23 @@ private val tilgang1 = AltinnMottaker(virksomhetsnummer = "43", serviceCode = "5
 private val tilgang2 = AltinnMottaker(virksomhetsnummer = "44", serviceCode = "5441", serviceEdition = "1")
 
 class QuerySakerAntallMerkelapperTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        altinn = AltinnStub(
-            "0".repeat(11) to BrukerModel.Tilganger(
-                tjenestetilganger = listOf(tilgang1, tilgang2).map {
-                    BrukerModel.Tilgang.Altinn(
-                        virksomhet = it.virksomhetsnummer,
-                        servicecode = it.serviceCode,
-                        serviceedition = it.serviceEdition
-                    )
-                },
-            )
-        ),
-        brukerRepository = brukerRepository,
-    )
-
     describe("antall i sakstype (Query.saker)") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            altinn = AltinnStub(
+                "0".repeat(11) to BrukerModel.Tilganger(
+                    tjenestetilganger = listOf(tilgang1, tilgang2).map {
+                        BrukerModel.Tilgang.Altinn(
+                            virksomhet = it.virksomhetsnummer,
+                            servicecode = it.serviceCode,
+                            serviceedition = it.serviceEdition
+                        )
+                    },
+                )
+            ),
+            brukerRepository = brukerRepository,
+        )
         for (merkelapp in listOf("merkelapp1", "merkelapp2")) {
             for (tittel in listOf("sykmelding", "refusjon")) {
                 brukerRepository.opprettSak(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTidslinjeTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTidslinjeTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.instanceOf
+import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.Notifikasjon.Oppgave.Tilstand.NY
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.Notifikasjon.Oppgave.Tilstand.UTFOERT
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.OppgaveTidslinjeElement
@@ -22,32 +23,23 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.time.OffsetDateTime
 
 class QuerySakerTidslinjeTest: DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
-        }
-    )
-
-    fun fetchTidslinje(sak: HendelseModel.SakOpprettet)
-            = engine.querySakerJson()
-                .getTypedContent<BrukerAPI.SakerResultat>("$.saker")
-                .saker
-                .first { it.id == sak.sakId }
-                .tidslinje
-
     describe("tidslinje") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(listOf(TEST_TILGANG_1))
+            }
+        )
         val sak0 = brukerRepository.sakOpprettet()
         val sak1 = brukerRepository.sakOpprettet(lenke = null)
 
         it("tidslinje er tom til å starte med") {
-            val tidslinje0 = fetchTidslinje(sak0)
+            val tidslinje0 = engine.fetchTidslinje(sak0)
             tidslinje0 should beEmpty()
 
-            val tidslinje1 = fetchTidslinje(sak1)
+            val tidslinje1 = engine.fetchTidslinje(sak1)
             tidslinje1 should beEmpty()
         }
 
@@ -58,7 +50,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
             opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01:01+00"),
         )
         it("første oppgave vises på riktig sak") {
-            val tidslinje0 = fetchTidslinje(sak0)
+            val tidslinje0 = engine.fetchTidslinje(sak0)
             tidslinje0 should haveSize(1)
             instanceOf<OppgaveTidslinjeElement, TidslinjeElement>(tidslinje0[0]) {
                 it.tekst shouldBe oppgave0.tekst
@@ -66,7 +58,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
                 it.id shouldNot beNull()
             }
 
-            val tidslinje1 = fetchTidslinje(sak1)
+            val tidslinje1 = engine.fetchTidslinje(sak1)
             tidslinje1 should beEmpty()
         }
 
@@ -76,7 +68,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
             opprettetTidspunkt = oppgave0.opprettetTidspunkt.plusHours(1),
         )
         it("andre beskjed på samme sak kommer i riktig rekkefølge") {
-            val tidslinje0 = fetchTidslinje(sak0)
+            val tidslinje0 = engine.fetchTidslinje(sak0)
             tidslinje0 should haveSize(2)
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje0[0]) {
                 it.tekst shouldBe beskjed1.tekst
@@ -86,7 +78,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
                 it.tilstand shouldBe NY
             }
 
-            val tidslinje1 = fetchTidslinje(sak1)
+            val tidslinje1 = engine.fetchTidslinje(sak1)
             tidslinje1 should beEmpty()
         }
 
@@ -96,7 +88,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
             opprettetTidspunkt = oppgave0.opprettetTidspunkt.plusHours(2),
         )
         it("ny beskjed på andre saken, vises kun der") {
-            val tidslinje0 = fetchTidslinje(sak0)
+            val tidslinje0 = engine.fetchTidslinje(sak0)
             tidslinje0 should haveSize(2)
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje0[0]) {
                 it.tekst shouldBe beskjed1.tekst
@@ -106,7 +98,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
                 it.tilstand shouldBe NY
             }
 
-            val tidslinje1 = fetchTidslinje(sak1)
+            val tidslinje1 = engine.fetchTidslinje(sak1)
             tidslinje1 should haveSize(1)
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje1[0]) {
                 it.tekst shouldBe beskjed2.tekst
@@ -119,7 +111,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
             utfoertTidspunkt = oppgave0.opprettetTidspunkt.plusHours(4),
         )
         it("endret oppgave-status reflekteres i tidslinja, men posisjonen er uendret") {
-            val tidslinje0 = fetchTidslinje(sak0)
+            val tidslinje0 = engine.fetchTidslinje(sak0)
             tidslinje0 should haveSize(2)
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje0[0]) {
                 it.tekst shouldBe beskjed1.tekst
@@ -129,7 +121,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
                 it.tilstand shouldBe UTFOERT
             }
 
-            val tidslinje1 = fetchTidslinje(sak1)
+            val tidslinje1 = engine.fetchTidslinje(sak1)
             tidslinje1 should haveSize(1)
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje1[0]) {
                 it.tekst shouldBe beskjed2.tekst
@@ -145,7 +137,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
             sakId = sak1.sakId,
         )
         it("kalenderavtale på andre saken, vises kun der") {
-            val tidslinje0 = fetchTidslinje(sak0)
+            val tidslinje0 = engine.fetchTidslinje(sak0)
             tidslinje0 should haveSize(2)
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje0[0]) {
                 it.tekst shouldBe beskjed1.tekst
@@ -154,7 +146,7 @@ class QuerySakerTidslinjeTest: DescribeSpec({
                 it.tekst shouldBe oppgave0.tekst
             }
 
-            val tidslinje1 = fetchTidslinje(sak1)
+            val tidslinje1 = engine.fetchTidslinje(sak1)
             tidslinje1 should haveSize(2)
             instanceOf<BrukerAPI.KalenderavtaleTidslinjeElement, TidslinjeElement>(tidslinje1[0]) {
                 it.tekst shouldBe kalenderavtale.tekst
@@ -173,6 +165,13 @@ class QuerySakerTidslinjeTest: DescribeSpec({
         }
     }
 })
+
+private fun TestApplicationEngine.fetchTidslinje(sak: HendelseModel.SakOpprettet)
+        = querySakerJson()
+    .getTypedContent<BrukerAPI.SakerResultat>("$.saker")
+    .saker
+    .first { it.id == sak.sakId }
+    .tidslinje
 
 suspend inline fun <reified SubClass: Class, Class: Any>TestScope.instanceOf(
     subject: Class,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakMedOppgaverMedFristMedPaaminnelseTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakMedOppgaverMedFristMedPaaminnelseTests.kt
@@ -15,110 +15,26 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class SakMedOppgaverMedFristMedPaaminnelseTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(
-                listOf(
-                    BrukerModel.Tilgang.Altinn(
-                        virksomhet = "1",
-                        servicecode = "1",
-                        serviceedition = "1",
+    describe("Sak med oppgave med frist og påminnelse") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(
+                    listOf(
+                        BrukerModel.Tilgang.Altinn(
+                            virksomhet = "1",
+                            servicecode = "1",
+                            serviceedition = "1",
+                        )
                     )
                 )
-            )
-        }
-    )
-
-    suspend fun opprettOppgave(
-        grupperingsid: String,
-        frist: LocalDate?,
-        paaminnelse: HendelseModel.Påminnelse,
-    ) {
-        val oppgaveId = UUID.randomUUID()
-
-        val oppgaveOpprettet = brukerRepository.oppgaveOpprettet(
-            notifikasjonId = oppgaveId,
-            virksomhetsnummer = "1",
-            produsentId = "1",
-            kildeAppNavn = "1",
-            grupperingsid = grupperingsid,
-            eksternId = "1",
-            eksterneVarsler = listOf(),
-            opprettetTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
-            merkelapp = "tag",
-            tekst = "tjohei",
-            mottakere = listOf(
-                HendelseModel.AltinnMottaker(
-                    virksomhetsnummer = "1",
-                    serviceCode = "1",
-                    serviceEdition = "1"
-                )
-            ),
-            lenke = "#foo",
-            hardDelete = null,
-            frist = frist,
-            påminnelse = paaminnelse,
+            }
         )
-
-        brukerRepository.påminnelseOpprettet(
-            oppgave = oppgaveOpprettet,
-            opprettetTidpunkt = Instant.now(),
-            frist = frist,
-            tidspunkt = paaminnelse.tidspunkt,
-        )
-    }
-
-    suspend fun opprettSak(
-        id: String,
-    ): String {
-        val uuid = uuid(id)
-        val sakOpprettet = brukerRepository.sakOpprettet(
-            virksomhetsnummer = "1",
-            produsentId = "1",
-            kildeAppNavn = "1",
-            sakId = uuid,
-            grupperingsid = uuid.toString(),
-            merkelapp = "tag",
-            mottakere = listOf(
-                HendelseModel.AltinnMottaker(
-                    virksomhetsnummer = "1",
-                    serviceCode = "1",
-                    serviceEdition = "1"
-                )
-            ),
-            tittel = "tjohei",
-            lenke = "#foo",
-            oppgittTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
-            mottattTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
-            hardDelete = null,
-        )
-
-        brukerRepository.nyStatusSak(
-            sakOpprettet,
-            hendelseId = UUID.randomUUID(),
-            virksomhetsnummer = "1",
-            produsentId = "1",
-            kildeAppNavn = "1",
-            status = HendelseModel.SakStatus.MOTTATT,
-            overstyrStatustekstMed = null,
-            oppgittTidspunkt = null,
-            mottattTidspunkt = OffsetDateTime.now(),
-            idempotensKey = IdempotenceKey.initial(),
-            hardDelete = null,
-            nyLenkeTilSak = null,
-        )
-
-        return uuid.toString()
-    }
-
-    describe("Sak med oppgave med frist og påminnelse") {
         val påminnelsestidspunktLocalDateTime = LocalDateTime.parse("2023-01-02T12:15:00")
-        val sak1 = opprettSak("1")
-        opprettOppgave(
+        val sak1 = brukerRepository.opprettSak("1")
+        brukerRepository.opprettOppgave(
             sak1,
             LocalDate.parse("2023-01-15"),
             HendelseModel.Påminnelse(
@@ -136,6 +52,82 @@ class SakMedOppgaverMedFristMedPaaminnelseTests : DescribeSpec({
 
         res.first().inOsloLocalDateTime() shouldBe påminnelsestidspunktLocalDateTime
     }
+})
+
+private suspend fun BrukerRepository.opprettSak(
+    id: String,
+) = uuid(id).also { uuid ->
+    sakOpprettet(
+        virksomhetsnummer = "1",
+        produsentId = "1",
+        kildeAppNavn = "1",
+        sakId = uuid,
+        grupperingsid = uuid.toString(),
+        merkelapp = "tag",
+        mottakere = listOf(
+            HendelseModel.AltinnMottaker(
+                virksomhetsnummer = "1",
+                serviceCode = "1",
+                serviceEdition = "1"
+            )
+        ),
+        tittel = "tjohei",
+        lenke = "#foo",
+        oppgittTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
+        mottattTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
+        hardDelete = null,
+    ).let { sakOpprettet ->
+        nyStatusSak(
+            sakOpprettet,
+            hendelseId = UUID.randomUUID(),
+            virksomhetsnummer = "1",
+            produsentId = "1",
+            kildeAppNavn = "1",
+            status = HendelseModel.SakStatus.MOTTATT,
+            overstyrStatustekstMed = null,
+            oppgittTidspunkt = null,
+            mottattTidspunkt = OffsetDateTime.now(),
+            idempotensKey = IdempotenceKey.initial(),
+            hardDelete = null,
+            nyLenkeTilSak = null,
+        )
+    }
+}.toString()
+
+private suspend fun BrukerRepository.opprettOppgave(
+    grupperingsid: String,
+    frist: LocalDate?,
+    paaminnelse: HendelseModel.Påminnelse,
+) {
+    oppgaveOpprettet(
+        notifikasjonId = UUID.randomUUID(),
+        virksomhetsnummer = "1",
+        produsentId = "1",
+        kildeAppNavn = "1",
+        grupperingsid = grupperingsid,
+        eksternId = "1",
+        eksterneVarsler = listOf(),
+        opprettetTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
+        merkelapp = "tag",
+        tekst = "tjohei",
+        mottakere = listOf(
+            HendelseModel.AltinnMottaker(
+                virksomhetsnummer = "1",
+                serviceCode = "1",
+                serviceEdition = "1"
+            )
+        ),
+        lenke = "#foo",
+        hardDelete = null,
+        frist = frist,
+        påminnelse = paaminnelse,
+    ).let { oppgaveOpprettet ->
+        påminnelseOpprettet(
+            oppgave = oppgaveOpprettet,
+            opprettetTidpunkt = Instant.now(),
+            frist = frist,
+            tidspunkt = paaminnelse.tidspunkt,
+        )
+    }
 }
-)
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakerMedOppgaveTilstandTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakerMedOppgaveTilstandTests.kt
@@ -3,6 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon.bruker
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.Notifikasjon.Oppgave.Tilstand.NY
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI.SakSortering.FRIST
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
@@ -13,125 +14,21 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class SakerMedOppgaveTilstandTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(
-                listOf(
-                    BrukerModel.Tilgang.Altinn(
-                        virksomhet = "1",
-                        servicecode = "1",
-                        serviceedition = "1",
-                    )
-                )
-            )
-        }
-    )
-
-    suspend fun opprettOppgave(
-        sak: HendelseModel.SakOpprettet,
-        frist: LocalDate?,
-    ) = brukerRepository.oppgaveOpprettet(
-        virksomhetsnummer = "1",
-        produsentId = "1",
-        kildeAppNavn = "1",
-        grupperingsid = sak.grupperingsid,
-        eksternId = "1",
-        eksterneVarsler = listOf(),
-        opprettetTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
-        merkelapp = "tag",
-        tekst = "tjohei",
-        mottakere = listOf(
-            HendelseModel.AltinnMottaker(
-                virksomhetsnummer = "1",
-                serviceCode = "1",
-                serviceEdition = "1"
-            )
-        ),
-        lenke = "#foo",
-        hardDelete = null,
-        frist = frist,
-        påminnelse = null,
-    )
-
-    suspend fun opprettStatus(sak: HendelseModel.SakOpprettet) = brukerRepository.nyStatusSak(
-        sak = sak,
-        hendelseId = UUID.randomUUID(),
-        virksomhetsnummer = "1",
-        produsentId = "1",
-        kildeAppNavn = "1",
-        status = HendelseModel.SakStatus.MOTTATT,
-        overstyrStatustekstMed = null,
-        oppgittTidspunkt = null,
-        mottattTidspunkt = OffsetDateTime.now(),
-        idempotensKey = IdempotenceKey.initial(),
-        hardDelete = null,
-        nyLenkeTilSak = null,
-    )
-
-    suspend fun opprettSak(
-        id: String,
-    ): HendelseModel.SakOpprettet {
-        val uuid = uuid(id)
-        val sakOpprettet = brukerRepository.sakOpprettet(
-            virksomhetsnummer = "1",
-            produsentId = "1",
-            kildeAppNavn = "1",
-            sakId = uuid,
-            grupperingsid = uuid.toString(),
-            merkelapp = "tag",
-            mottakere = listOf(
-                HendelseModel.AltinnMottaker(
-                    virksomhetsnummer = "1",
-                    serviceCode = "1",
-                    serviceEdition = "1"
-                )
-            ),
-            tittel = "tjohei",
-            lenke = "#foo",
-            oppgittTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
-            mottattTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
-            hardDelete = null,
-        )
-        opprettStatus(sakOpprettet)
-
-        return sakOpprettet
-    }
-
-    suspend fun oppgaveTilstandUtført(oppgaveOpprettet: HendelseModel.OppgaveOpprettet) {
-        brukerRepository.oppgaveUtført(
-            oppgaveOpprettet,
-            hardDelete = null,
-            nyLenke = null,
-            utfoertTidspunkt = OffsetDateTime.parse("2023-01-05T00:00:00+01")
-        )
-    }
-
-    suspend fun oppgaveTilstandUtgått(oppgaveOpprettet: HendelseModel.OppgaveOpprettet) {
-        brukerRepository.oppgaveUtgått(
-            oppgave = oppgaveOpprettet,
-            hardDelete = null,
-            utgaattTidspunkt = OffsetDateTime.now(),
-            nyLenke = null,
-        )
-    }
 
     describe("Sak med oppgave med frist og påminnelse") {
-        val sak = opprettSak("1")
-        opprettOppgave(sak, LocalDate.parse("2023-01-15")).also { oppgaveTilstandUtført(it) }
-        opprettOppgave(sak, LocalDate.parse("2023-05-15"))
-        opprettOppgave(sak, LocalDate.parse("2023-05-15"))
-        opprettOppgave(sak, LocalDate.parse("2023-01-15")).also { oppgaveTilstandUtgått(it) }
+        val (repo, engine) = setupRepoOgEngine()
+        val sak = repo.opprettSak("1")
+        repo.opprettOppgave(sak, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtført(it) }
+        repo.opprettOppgave(sak, LocalDate.parse("2023-05-15"))
+        repo.opprettOppgave(sak, LocalDate.parse("2023-05-15"))
+        repo.opprettOppgave(sak, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtgått(it) }
 
-        val sak2 = opprettSak("2")
-        opprettOppgave(sak2, LocalDate.parse("2023-01-15")).also { oppgaveTilstandUtført(it) }
-        opprettOppgave(sak2, LocalDate.parse("2023-05-15"))
+        val sak2 = repo.opprettSak("2")
+        repo.opprettOppgave(sak2, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtført(it) }
+        repo.opprettOppgave(sak2, LocalDate.parse("2023-05-15"))
 
-        val sak3 = opprettSak("3")
-        opprettOppgave(sak3, LocalDate.parse("2023-01-15")).also { oppgaveTilstandUtført(it) }
+        val sak3 = repo.opprettSak("3")
+        repo.opprettOppgave(sak3, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtført(it) }
 
         val res = engine.querySakerJson(
             virksomhetsnummer = "1",
@@ -162,18 +59,19 @@ class SakerMedOppgaveTilstandTests : DescribeSpec({
     }
 
     describe("Sak med oppgave med frist med filter") {
-        val sak1 = opprettSak("1")
-        opprettOppgave(sak1, LocalDate.parse("2023-01-15")).also { oppgaveTilstandUtført(it) }
-        opprettOppgave(sak1, LocalDate.parse("2023-05-15"))
-        opprettOppgave(sak1, LocalDate.parse("2023-05-15"))
-        opprettOppgave(sak1, LocalDate.parse("2023-01-15")).also { oppgaveTilstandUtgått(it) }
+        val (repo, engine) = setupRepoOgEngine()
+        val sak1 = repo.opprettSak("1")
+        repo.opprettOppgave(sak1, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtført(it) }
+        repo.opprettOppgave(sak1, LocalDate.parse("2023-05-15"))
+        repo.opprettOppgave(sak1, LocalDate.parse("2023-05-15"))
+        repo.opprettOppgave(sak1, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtgått(it) }
 
-        val sak2 = opprettSak("2")
-        opprettOppgave(sak2, LocalDate.parse("2023-01-15")).also { oppgaveTilstandUtført(it) }
-        opprettOppgave(sak2, LocalDate.parse("2023-05-15")).also { oppgaveTilstandUtført(it) }
-        opprettOppgave(sak2, LocalDate.parse("2023-05-15")).also { oppgaveTilstandUtgått(it) }
+        val sak2 = repo.opprettSak("2")
+        repo.opprettOppgave(sak2, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtført(it) }
+        repo.opprettOppgave(sak2, LocalDate.parse("2023-05-15")).also { repo.oppgaveTilstandUtført(it) }
+        repo.opprettOppgave(sak2, LocalDate.parse("2023-05-15")).also { repo.oppgaveTilstandUtgått(it) }
 
-        opprettSak("3")
+        repo.opprettSak("3")
 
         val res =
             engine.querySakerJson(
@@ -188,9 +86,10 @@ class SakerMedOppgaveTilstandTests : DescribeSpec({
     }
 
     describe("Saker med og uten oppgaver") {
-        val sak1 = opprettSak("1")
-        val sak2 = opprettSak("2")
-        opprettOppgave(sak2, LocalDate.parse("2023-01-15")).also { oppgaveTilstandUtført(it) }
+        val (repo, engine) = setupRepoOgEngine()
+        val sak1 = repo.opprettSak("1")
+        val sak2 = repo.opprettSak("2")
+        repo.opprettOppgave(sak2, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtført(it) }
 
         val res = engine.querySakerJson(
             virksomhetsnummer = "1",
@@ -203,5 +102,111 @@ class SakerMedOppgaveTilstandTests : DescribeSpec({
         }
     }
 })
+
+private suspend fun BrukerRepository.opprettOppgave(
+    sak: HendelseModel.SakOpprettet,
+    frist: LocalDate?,
+) = oppgaveOpprettet(
+    virksomhetsnummer = "1",
+    produsentId = "1",
+    kildeAppNavn = "1",
+    grupperingsid = sak.grupperingsid,
+    eksternId = "1",
+    eksterneVarsler = listOf(),
+    opprettetTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
+    merkelapp = "tag",
+    tekst = "tjohei",
+    mottakere = listOf(
+        HendelseModel.AltinnMottaker(
+            virksomhetsnummer = "1",
+            serviceCode = "1",
+            serviceEdition = "1"
+        )
+    ),
+    lenke = "#foo",
+    hardDelete = null,
+    frist = frist,
+    påminnelse = null,
+)
+
+private suspend fun BrukerRepository.opprettStatus(sak: HendelseModel.SakOpprettet) = nyStatusSak(
+    sak = sak,
+    hendelseId = UUID.randomUUID(),
+    virksomhetsnummer = "1",
+    produsentId = "1",
+    kildeAppNavn = "1",
+    status = HendelseModel.SakStatus.MOTTATT,
+    overstyrStatustekstMed = null,
+    oppgittTidspunkt = null,
+    mottattTidspunkt = OffsetDateTime.now(),
+    idempotensKey = IdempotenceKey.initial(),
+    hardDelete = null,
+    nyLenkeTilSak = null,
+)
+
+private suspend fun BrukerRepository.opprettSak(
+    id: String,
+): HendelseModel.SakOpprettet {
+    val uuid = uuid(id)
+    val sakOpprettet = sakOpprettet(
+        virksomhetsnummer = "1",
+        produsentId = "1",
+        kildeAppNavn = "1",
+        sakId = uuid,
+        grupperingsid = uuid.toString(),
+        merkelapp = "tag",
+        mottakere = listOf(
+            HendelseModel.AltinnMottaker(
+                virksomhetsnummer = "1",
+                serviceCode = "1",
+                serviceEdition = "1"
+            )
+        ),
+        tittel = "tjohei",
+        lenke = "#foo",
+        oppgittTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
+        mottattTidspunkt = OffsetDateTime.parse("2017-12-03T10:15:30+01:00"),
+        hardDelete = null,
+    )
+    opprettStatus(sakOpprettet)
+
+    return sakOpprettet
+}
+
+private suspend fun BrukerRepository.oppgaveTilstandUtført(oppgaveOpprettet: HendelseModel.OppgaveOpprettet) =
+    oppgaveUtført(
+        oppgaveOpprettet,
+        hardDelete = null,
+        nyLenke = null,
+        utfoertTidspunkt = OffsetDateTime.parse("2023-01-05T00:00:00+01")
+    )
+
+private suspend fun BrukerRepository.oppgaveTilstandUtgått(oppgaveOpprettet: HendelseModel.OppgaveOpprettet) =
+    oppgaveUtgått(
+        oppgave = oppgaveOpprettet,
+        hardDelete = null,
+        utgaattTidspunkt = OffsetDateTime.now(),
+        nyLenke = null,
+    )
+
+private fun DescribeSpec.setupRepoOgEngine(): Pair<BrukerRepositoryImpl, TestApplicationEngine> {
+    val database = testDatabase(Bruker.databaseConfig)
+    val brukerRepository = BrukerRepositoryImpl(database)
+    val engine = ktorBrukerTestServer(
+        brukerRepository = brukerRepository,
+        altinn = AltinnStub { _, _ ->
+            BrukerModel.Tilganger(
+                listOf(
+                    BrukerModel.Tilgang.Altinn(
+                        virksomhet = "1",
+                        servicecode = "1",
+                        serviceedition = "1",
+                    )
+                )
+            )
+        }
+    )
+    return Pair(brukerRepository, engine)
+}
 
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakstyperQueryTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakstyperQueryTests.kt
@@ -11,8 +11,6 @@ import no.nav.arbeidsgiver.notifikasjon.util.AltinnStub
 import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
 import no.nav.arbeidsgiver.notifikasjon.util.ktorBrukerTestServer
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
-import java.time.OffsetDateTime
-import java.util.*
 
 private val tilgang1 = HendelseModel.AltinnMottaker(
     virksomhetsnummer = "11111",
@@ -37,23 +35,21 @@ private val ikkeTilgang4 = HendelseModel.AltinnMottaker(
 
 
 class SakstyperQueryTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
-
-    val engine = ktorBrukerTestServer(
-        brukerRepository = brukerRepository,
-        altinn = AltinnStub { _, _ ->
-            BrukerModel.Tilganger(tjenestetilganger = listOf(tilgang1, tilgang2).map {
-                BrukerModel.Tilgang.Altinn(
-                    virksomhet = it.virksomhetsnummer,
-                    servicecode = it.serviceCode,
-                    serviceedition = it.serviceEdition,
-                )
-            })
-        }
-    )
-
     describe("bruker har diverse tilganger") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val engine = ktorBrukerTestServer(
+            brukerRepository = brukerRepository,
+            altinn = AltinnStub { _, _ ->
+                BrukerModel.Tilganger(tjenestetilganger = listOf(tilgang1, tilgang2).map {
+                    BrukerModel.Tilgang.Altinn(
+                        virksomhet = it.virksomhetsnummer,
+                        servicecode = it.serviceCode,
+                        serviceedition = it.serviceEdition,
+                    )
+                })
+            }
+        )
         val skalSe = mutableSetOf<String>()
         val skalIkkeSe = mutableSetOf<String>()
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SoftDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SoftDeleteTests.kt
@@ -12,10 +12,10 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class SoftDeleteTests : DescribeSpec({
-    val database = testDatabase(Bruker.databaseConfig)
-    val brukerRepository = BrukerRepositoryImpl(database)
 
     describe("SoftDelete av notifikasjon") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
 
         val mottaker = NærmesteLederMottaker(
             naermesteLederFnr = "314",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktEksterVarselVellykketTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktEksterVarselVellykketTests.kt
@@ -12,11 +12,7 @@ import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.Instant
 
 class DataproduktEksterVarselVellykketTests : DescribeSpec({
-    val database = testDatabase(Dataprodukt.databaseConfig)
-    val subject = DataproduktModel(database)
-
     val meta = HendelseMetadata(Instant.now())
-
     val altinntjenesteVarselKontaktinfo = HendelseModel.AltinntjenesteVarselKontaktinfo(
         varselId = uuid("1"),
         virksomhetsnummer = "1",
@@ -27,7 +23,10 @@ class DataproduktEksterVarselVellykketTests : DescribeSpec({
         sendevindu = HendelseModel.EksterntVarselSendingsvindu.LØPENDE,
         sendeTidspunkt = null
     )
+
     describe("Dataprodukt ekstern varsel vellykket med flere mottakere i respons") {
+        val database = testDatabase(Dataprodukt.databaseConfig)
+        val subject = DataproduktModel(database)
         subject.oppdaterModellEtterHendelse(
             EksempelHendelse.BeskjedOpprettet.copy(
                 eksterneVarsler = listOf(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktIdempotensTests.kt
@@ -15,9 +15,6 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class DataproduktIdempotensTests : DescribeSpec({
-    val database = testDatabase(Dataprodukt.databaseConfig)
-    val repository = DataproduktModel(database)
-
     val metadata = HendelseMetadata(Instant.now())
 
     val mottakere = listOf(
@@ -106,6 +103,9 @@ class DataproduktIdempotensTests : DescribeSpec({
     )
 
     describe("Dataprodukt Idempotent oppførsel") {
+        val database = testDatabase(Dataprodukt.databaseConfig)
+        val repository = DataproduktModel(database)
+
         withData(EksempelHendelse.Alle) { hendelse ->
             repository.oppdaterModellEtterHendelse(hendelse, metadata)
             repository.oppdaterModellEtterHendelse(hendelse, metadata)
@@ -115,6 +115,9 @@ class DataproduktIdempotensTests : DescribeSpec({
     describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
         EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
             context("$i - ${hendelse.typeNavn}") {
+                val database = testDatabase(Dataprodukt.databaseConfig)
+                val repository = DataproduktModel(database)
+
                 repository.oppdaterModellEtterHendelse(
                     EksempelHendelse.HardDelete.copy(
                         virksomhetsnummer = hendelse.virksomhetsnummer,
@@ -127,6 +130,9 @@ class DataproduktIdempotensTests : DescribeSpec({
     }
 
     describe("Atomisk hard delete av Sak sletter kun tilhørende notifikasjoner") {
+        val database = testDatabase(Dataprodukt.databaseConfig)
+        val repository = DataproduktModel(database)
+
         repository.oppdaterModellEtterHendelse(sak, metadata)
         repository.oppdaterModellEtterHendelse(oppgaveKnyttetTilSak, metadata)
         repository.oppdaterModellEtterHendelse(oppgaveUtenGrupperingsid, metadata)
@@ -146,7 +152,7 @@ class DataproduktIdempotensTests : DescribeSpec({
 
         val notifikasjoner = database.nonTransactionalExecuteQuery(
             """
-                select notifikasjon_id from "dataprodukt-model".public.notifikasjon
+                select notifikasjon_id from notifikasjon
             """.trimIndent(),
             transform = { getObject("notifikasjon_id", UUID::class.java) }
         )
@@ -159,6 +165,9 @@ class DataproduktIdempotensTests : DescribeSpec({
 
 
     describe("Atomisk soft delete av Sak sletter kun tilhørende notifikasjoner") {
+        val database = testDatabase(Dataprodukt.databaseConfig)
+        val repository = DataproduktModel(database)
+
         repository.oppdaterModellEtterHendelse(sak, metadata)
         repository.oppdaterModellEtterHendelse(oppgaveKnyttetTilSak, metadata)
         repository.oppdaterModellEtterHendelse(oppgaveUtenGrupperingsid, metadata)
@@ -178,7 +187,7 @@ class DataproduktIdempotensTests : DescribeSpec({
 
         val notifikasjoner = database.nonTransactionalExecuteQuery(
             """
-                select notifikasjon_id from "dataprodukt-model".public.notifikasjon
+                select notifikasjon_id from notifikasjon
                 where soft_deleted_tidspunkt is null
             """.trimIndent(),
             transform = { getObject("notifikasjon_id", UUID::class.java) }
@@ -191,6 +200,9 @@ class DataproduktIdempotensTests : DescribeSpec({
     }
 
     describe("Pseudonymisering av tegn som kan tolkes som escape characters ") {
+        val database = testDatabase(Dataprodukt.databaseConfig)
+        val repository = DataproduktModel(database)
+
         val hendelse = EksempelHendelse.SakOpprettet.copy(tittel = """Billakkerer\Hjelpearbeider""")
         it("Skal ikke feile fordi det blir tolket") {
             shouldNotThrowAny {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingIdempotensTests.kt
@@ -7,10 +7,11 @@ import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 
 class EksternVarslingIdempotensTests : DescribeSpec({
-    val database = testDatabase(EksternVarsling.databaseConfig)
-    val repository = EksternVarslingRepository(database)
 
     describe("Ekstern Varlsing Idempotent oppførsel") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         withData(EksempelHendelse.Alle) { hendelse ->
             repository.oppdaterModellEtterHendelse(hendelse)
             repository.oppdaterModellEtterHendelse(hendelse)
@@ -20,6 +21,9 @@ class EksternVarslingIdempotensTests : DescribeSpec({
     describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
         EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
             context("$i - ${hendelse.typeNavn}") {
+                val database = testDatabase(EksternVarsling.databaseConfig)
+                val repository = EksternVarslingRepository(database)
+
                 repository.oppdaterModellEtterHendelse(EksempelHendelse.HardDelete.copy(
                     virksomhetsnummer = hendelse.virksomhetsnummer,
                     aggregateId = hendelse.aggregateId,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepositoryTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepositoryTests.kt
@@ -35,8 +35,6 @@ import javax.xml.bind.JAXBElement
 import javax.xml.namespace.QName
 
 class EksternVarslingRepositoryTests: DescribeSpec({
-    val database = testDatabase(EksternVarsling.databaseConfig)
-    val repository = EksternVarslingRepository(database)
 
     val oppgaveOpprettet = OppgaveOpprettet(
         virksomhetsnummer = "1",
@@ -91,6 +89,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     )
 
     describe("Getting and deleting jobs") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         repository.oppdaterModellEtterHendelse(oppgaveOpprettet)
 
         val id1 = repository.findJob(lockTimeout = Duration.ofMinutes(1))
@@ -127,6 +128,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("Can't pick a job while locked") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         repository.oppdaterModellEtterHendelse(
             oppgaveOpprettet.copy(
                 eksterneVarsler = oppgaveOpprettet.eksterneVarsler.subList(0, 1)
@@ -146,6 +150,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("auto-release locks") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         it("release time-out") {
             repository.oppdaterModellEtterHendelse(
                 oppgaveOpprettet.copy(
@@ -167,6 +174,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
 
 
     describe("release and reacquire lock") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         repository.oppdaterModellEtterHendelse(
             oppgaveOpprettet.copy(
                 eksterneVarsler = oppgaveOpprettet.eksterneVarsler.subList(0, 1)
@@ -190,6 +200,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("read and write of notification") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         repository.oppdaterModellEtterHendelse(oppgaveOpprettet)
 
         val id1 = repository.findJob(lockTimeout = Duration.ofMinutes(1))
@@ -224,6 +237,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("Kan gå gjennom tilstandene ok") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         repository.oppdaterModellEtterHendelse(
             oppgaveOpprettet.copy(
                 eksterneVarsler = oppgaveOpprettet.eksterneVarsler.subList(0, 1)
@@ -268,6 +284,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("Kan gå gjennom tilstandene altinn-feil") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         repository.oppdaterModellEtterHendelse(
             oppgaveOpprettet.copy(
                 eksterneVarsler = oppgaveOpprettet.eksterneVarsler.subList(0, 1)
@@ -319,6 +338,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("Hard delete event for sak") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         repository.oppdaterModellEtterHendelse(oppgaveOpprettet)
         val sakId = uuid("442")
         val hardDelete =
@@ -364,6 +386,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("Oppgave med påminnelse fører ikke til varsel nå") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         val varselId = UUID.randomUUID()
         OppgaveOpprettet(
             virksomhetsnummer = "1",
@@ -410,7 +435,11 @@ class EksternVarslingRepositoryTests: DescribeSpec({
             repository.findVarsel(varselId) shouldBe null
         }
     }
+
     describe("varsler i påminnelse blir registrert") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         val varselId = UUID.randomUUID()
         val notifikasjonId = UUID.randomUUID()
         HendelseModel.PåminnelseOpprettet(
@@ -460,6 +489,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("Hard delete event for oppgave") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         val eksterntVarselVellykket = HendelseModel.EksterntVarselVellykket(
             virksomhetsnummer = "42",
             notifikasjonId = oppgaveOpprettet.aggregateId,
@@ -493,6 +525,9 @@ class EksternVarslingRepositoryTests: DescribeSpec({
     }
 
     describe("sendetidspunkt med localdatetime.min") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         OppgaveOpprettet(
             virksomhetsnummer = "1",
             notifikasjonId = uuid("1"),

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EmergencyBreakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EmergencyBreakTests.kt
@@ -11,8 +11,6 @@ import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import java.time.OffsetDateTime
 
 class EmergencyBreakTests : DescribeSpec({
-    val database = testDatabase(EksternVarsling.databaseConfig)
-    val repository = EksternVarslingRepository(database)
 
     val oppgaveOpprettet = OppgaveOpprettet(
         virksomhetsnummer = "1",
@@ -49,6 +47,9 @@ class EmergencyBreakTests : DescribeSpec({
 
 
     describe("EmergencyBreak") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
+
         val emergencyBreak = repository.emergencyBreakOn()
 
         it("should be enabled on start up") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/IdempotentOppgaveOpprettetTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/IdempotentOppgaveOpprettetTests.kt
@@ -14,8 +14,6 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class IdempotentOppgaveOpprettetTests: DescribeSpec({
-    val database = testDatabase(EksternVarsling.databaseConfig)
-    val repository = EksternVarslingRepository(database)
 
     val smsVarsel = SmsVarselKontaktinfo(
         varselId = uuid("1"),
@@ -47,6 +45,8 @@ class IdempotentOppgaveOpprettetTests: DescribeSpec({
     )
 
     describe("mutual exclusive access to ekstern_varsel") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
         repository.oppdaterModellEtterHendelse(oppgaveOpprettet)
         repository.oppdaterModellEtterHendelse(oppgaveOpprettet)
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/ResumeScheduledJobsTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/ResumeScheduledJobsTests.kt
@@ -11,14 +11,14 @@ import java.time.LocalDateTime
 import java.util.*
 
 class ResumeScheduledJobsTests: DescribeSpec({
-    val database = testDatabase(EksternVarsling.databaseConfig)
-    val repository = EksternVarslingRepository(database)
 
     fun dateTime(hour: String) =
         LocalDateTime.parse("2020-01-01T$hour:00")
 
 
     describe("resuming scheduled tasks") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
         repository.scheduleJob(uuid("0"), dateTime("02"))
         repository.scheduleJob(uuid("1"), dateTime("03"))
         repository.scheduleJob(uuid("2"), dateTime("03"))
@@ -62,6 +62,8 @@ class ResumeScheduledJobsTests: DescribeSpec({
     }
 
     describe("id eksisterer både i job_queue og wait_queue") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
         // Jobben er fortsatt i job-queuen. Er ikke viktig om den
         // blir "de-duplisert": kan godt forekomme to ganger, men ikke
         // et krav.
@@ -81,6 +83,8 @@ class ResumeScheduledJobsTests: DescribeSpec({
     }
 
     describe("putter varsel_id flere ganger inn i vente-kø") {
+        val database = testDatabase(EksternVarsling.databaseConfig)
+        val repository = EksternVarslingRepository(database)
         repository.scheduleJob(uuid("0"), dateTime("00"))
         repository.scheduleJob(uuid("0"), dateTime("01"))
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/KafkaHendelsesstrømTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/KafkaHendelsesstrømTests.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
+import io.kotest.core.annotation.Isolate
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -10,6 +11,7 @@ import no.nav.arbeidsgiver.notifikasjon.util.localKafka
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 
+@Isolate
 class KafkaHendelsesstrømTests: DescribeSpec({
     val localKafka = localKafka()
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/BackupHendelserTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/BackupHendelserTests.kt
@@ -1,5 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.kafka_backup
 
+import io.kotest.core.annotation.Isolate
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
@@ -7,7 +8,7 @@ import no.nav.arbeidsgiver.notifikasjon.util.localKafka
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.util.concurrent.atomic.AtomicBoolean
 
-
+@Isolate
 class BackupHendelserTests: DescribeSpec({
 
     describe("write to and read from database") {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/BackupHendelserTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/BackupHendelserTests.kt
@@ -7,12 +7,13 @@ import no.nav.arbeidsgiver.notifikasjon.util.localKafka
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.util.concurrent.atomic.AtomicBoolean
 
+
 class BackupHendelserTests: DescribeSpec({
-    val database = testDatabase(KafkaBackup.databaseConfig)
-    val backupRepository = BackupRepository(database)
-    val kafka = localKafka()
 
     describe("write to and read from database") {
+        val database = testDatabase(KafkaBackup.databaseConfig)
+        val backupRepository = BackupRepository(database)
+        val kafka = localKafka()
         val producer = kafka.newProducer()
         var eventsSent = 0
         var eventsRead = 0

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/BackupRepositoryTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/BackupRepositoryTests.kt
@@ -11,8 +11,6 @@ import org.apache.kafka.common.record.TimestampType
 
 
 class BackupRepositoryTests : DescribeSpec({
-    val database = testDatabase(KafkaBackup.databaseConfig)
-    val backupRepository = BackupRepository(database)
 
     val record1 = record(
         partition = 0,
@@ -57,6 +55,8 @@ class BackupRepositoryTests : DescribeSpec({
     )
 
     describe("Reading from database") {
+        val database = testDatabase(KafkaBackup.databaseConfig)
+        val backupRepository = BackupRepository(database)
         listOf(record1, record2, record3, record4, record5).forEach {
             backupRepository.process(it)
         }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModelIdempotensTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModelIdempotensTest.kt
@@ -14,8 +14,6 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class KafkaReaperModelIdempotensTest : DescribeSpec({
-    val database = testDatabase(KafkaReaper.databaseConfig)
-    val model = KafkaReaperModelImpl(database)
 
     val mottakere = listOf(
         HendelseModel.AltinnMottaker(
@@ -103,6 +101,8 @@ class KafkaReaperModelIdempotensTest : DescribeSpec({
     )
 
     describe("Kafka Reaper Idempotent oppførsel") {
+        val database = testDatabase(KafkaReaper.databaseConfig)
+        val model = KafkaReaperModelImpl(database)
         withData(EksempelHendelse.Alle) { hendelse ->
             model.oppdaterModellEtterHendelse(hendelse)
             model.oppdaterModellEtterHendelse(hendelse)
@@ -112,6 +112,9 @@ class KafkaReaperModelIdempotensTest : DescribeSpec({
     describe("Håndterer partial replay hvor midt i hendelsesforløp etter harddelete") {
         EksempelHendelse.Alle.forEachIndexed { i, hendelse ->
             context("$i - ${hendelse.typeNavn}") {
+                val database = testDatabase(KafkaReaper.databaseConfig)
+                val model = KafkaReaperModelImpl(database)
+
                 model.oppdaterModellEtterHendelse(EksempelHendelse.HardDelete.copy(
                     virksomhetsnummer = hendelse.virksomhetsnummer,
                     aggregateId = hendelse.aggregateId,
@@ -122,6 +125,8 @@ class KafkaReaperModelIdempotensTest : DescribeSpec({
     }
 
     describe("Atomisk hard delete av Sak sletter kun tilhørende notifikasjoner") {
+        val database = testDatabase(KafkaReaper.databaseConfig)
+        val model = KafkaReaperModelImpl(database)
         model.oppdaterModellEtterHendelse(sak)
         model.oppdaterModellEtterHendelse(oppgaveKnyttetTilSak)
         model.oppdaterModellEtterHendelse(oppgaveUtenGrupperingsid)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/KalenderavtaleTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/KalenderavtaleTests.kt
@@ -20,20 +20,13 @@ import java.time.OffsetDateTime
 import java.util.*
 
 class KalenderavtaleTests : DescribeSpec({
-    val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
-    val kafkaProducer = FakeHendelseProdusent()
-
-    val engine = ktorProdusentTestServer(
-        kafkaProducer = kafkaProducer,
-        produsentRepository = produsentRepository,
-    )
 
     val grupperingsid = "g42"
     val eksternId = "heuheu"
     val merkelapp = "tag"
 
     describe("Kalenderavtale mutations") {
+        val (produsentRepository, kafkaProducer, engine) = setupEngine()
         val sakOpprettet = HendelseModel.SakOpprettet(
             virksomhetsnummer = "1",
             merkelapp = "tag",
@@ -302,6 +295,17 @@ class KalenderavtaleTests : DescribeSpec({
         }
     }
 })
+
+private fun DescribeSpec.setupEngine(): Triple<ProdusentRepositoryImpl, FakeHendelseProdusent, TestApplicationEngine> {
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+    val kafkaProducer = FakeHendelseProdusent()
+    val engine = ktorProdusentTestServer(
+        kafkaProducer = kafkaProducer,
+        produsentRepository = produsentRepository,
+    )
+    return Triple(produsentRepository, kafkaProducer, engine)
+}
 
 
 private fun TestApplicationEngine.nyKalenderavtale(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedFlereMottakereTests.kt
@@ -18,14 +18,9 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.util.*
 
 class NyBeskjedFlereMottakereTests : DescribeSpec({
-    val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
-
-    val engine = ktorProdusentTestServer(
-        produsentRepository = produsentRepository,
-    )
 
     describe("sender ingen mottakere") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyBeskjed(
                 """
@@ -39,6 +34,7 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
     }
 
     describe("sender 1 mottaker i 'mottaker'") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyBeskjed(
                 """
@@ -73,6 +69,7 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
     }
 
     describe("sender 1 mottaker i 'mottakere'") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyBeskjed(
                 """
@@ -107,6 +104,7 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
         }
     }
     describe("sender 2 mottakere i 'mottakere'") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyBeskjed(
                 """
@@ -153,6 +151,7 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
     }
 
     describe("sender 2 mottaker, en i 'mottaker' og en i 'mottakere'") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyBeskjed(
                 """
@@ -198,6 +197,15 @@ class NyBeskjedFlereMottakereTests : DescribeSpec({
         }
     }
 })
+
+private fun DescribeSpec.setupEngine(): TestApplicationEngine {
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+    val engine = ktorProdusentTestServer(
+        produsentRepository = produsentRepository,
+    )
+    return engine
+}
 
 fun nyBeskjed(fragment: String) = """
             mutation {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveFlereMottakereTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgaveFlereMottakereTests.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.getGraphqlErrors
@@ -14,14 +15,9 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.util.*
 
 class NyOppgaveFlereMottakereTests : DescribeSpec({
-    val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
-
-    val engine = ktorProdusentTestServer(
-        produsentRepository = produsentRepository,
-    )
 
     describe("sender ingen mottakere") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 """
@@ -35,6 +31,7 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
     }
 
     describe("sender 1 mottaker i 'mottaker'") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 """
@@ -69,6 +66,7 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
     }
 
     describe("sender 1 mottaker i 'mottakere'") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 """
@@ -103,6 +101,7 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
         }
     }
     describe("sender 2 mottakere i 'mottakere'") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 """
@@ -149,6 +148,7 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
     }
 
     describe("sender 2 mottaker, en i 'mottaker' og en i 'mottakere'") {
+        val engine = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 """
@@ -194,6 +194,15 @@ class NyOppgaveFlereMottakereTests : DescribeSpec({
         }
     }
 })
+
+private fun DescribeSpec.setupEngine(): TestApplicationEngine {
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+    val engine = ktorProdusentTestServer(
+        produsentRepository = produsentRepository,
+    )
+    return engine
+}
 
 private fun nyOppgave(fragment: String) = """
             mutation {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgavePaaminnelseTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyOppgavePaaminnelseTests.kt
@@ -4,25 +4,16 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
-import no.nav.arbeidsgiver.notifikasjon.util.fakeHendelseProdusent
-import no.nav.arbeidsgiver.notifikasjon.util.getTypedContent
-import no.nav.arbeidsgiver.notifikasjon.util.ktorProdusentTestServer
-import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import no.nav.arbeidsgiver.notifikasjon.util.*
 
 class NyOppgavePaaminnelseTests : DescribeSpec({
-    val stubbedKafkaProducer = fakeHendelseProdusent()
-    val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
-
-    val engine = ktorProdusentTestServer(
-        kafkaProducer = stubbedKafkaProducer,
-        produsentRepository = produsentRepository,
-    )
 
     describe("oppgave med frist konkret tidspunkt for påminnelse") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2019-11-01T00:00:00Z",
@@ -43,6 +34,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("oppgave uten frist konkret tidspunkt for påminnelse") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2019-11-01T00:00:00Z",
@@ -61,6 +53,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
         }
     }
     describe("oppgave med frist konkret tidspunkt for påminnelse etter frist") {
+        val (_, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2019-11-01T00:00:00Z",
@@ -79,6 +72,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
         }
     }
     describe("oppgave uten frist konkret tidspunkt for påminnelse før opprettelse") {
+        val (_, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-02T00:00:00Z",
@@ -99,6 +93,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
 
 
     describe("oppgave uten frist, tidspunkt for påminnelse relativ til opprettelse") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -118,6 +113,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("oppgave uten frist, tidspunkt for påminnelse relativ til frist") {
+        val (_, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -136,6 +132,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("oppgave med frist, tidspunkt for påminnelse relativ til frist") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -156,6 +153,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("oppgave med frist, tidspunkt for påminnelse relativ til frist blir før opprettelse") {
+        val (_, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -175,6 +173,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("ekstern varlser med tom liste") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -197,6 +196,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("ekstern varlser med 1 sms") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -240,6 +240,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("ekstern varlser med 1 epost") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -285,6 +286,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("ekstern varlser med epost og sms") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -353,6 +355,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("ekstern varlser med 1 tjeneste") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -398,6 +401,7 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
     }
 
     describe("ekstern varlser med epost og sms og tjeneste") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response = engine.produsentApi(
             nyOppgave(
                 "2020-01-01T00:00:00Z",
@@ -486,6 +490,17 @@ class NyOppgavePaaminnelseTests : DescribeSpec({
         }
     }
 })
+
+private fun DescribeSpec.setupEngine(): Pair<FakeHendelseProdusent, TestApplicationEngine> {
+    val stubbedKafkaProducer = fakeHendelseProdusent()
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+    val engine = ktorProdusentTestServer(
+        kafkaProducer = stubbedKafkaProducer,
+        produsentRepository = produsentRepository,
+    )
+    return Pair(stubbedKafkaProducer, engine)
+}
 
 private fun nyOppgave(opprettetTidspunkt: String, fragment: String) = """
             mutation {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NySakTests.kt
@@ -18,15 +18,9 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 
 class NySakTests : DescribeSpec({
-    val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
-    val stubbedKafkaProducer = FakeHendelseProdusent()
-    val engine = ktorProdusentTestServer(
-        kafkaProducer = stubbedKafkaProducer,
-        produsentRepository = produsentRepository,
-    )
 
     describe("opprett nySak") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val response1 = engine.nySak()
         it("should be successfull") {
             response1.getTypedContent<String>("$.nySak.__typename") shouldBe "NySakVellykket"
@@ -149,6 +143,17 @@ class NySakTests : DescribeSpec({
         }
     }
 })
+
+private fun DescribeSpec.setupEngine(): Pair<FakeHendelseProdusent, TestApplicationEngine> {
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+    val stubbedKafkaProducer = FakeHendelseProdusent()
+    val engine = ktorProdusentTestServer(
+        kafkaProducer = stubbedKafkaProducer,
+        produsentRepository = produsentRepository,
+    )
+    return Pair(stubbedKafkaProducer, engine)
+}
 
 private fun TestApplicationEngine.nySak(
     grupperingsid: String = "1",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
@@ -15,17 +15,9 @@ import java.time.LocalDateTime
 import java.util.*
 
 class NyStatusSakTests : DescribeSpec({
-    val stubbedKafkaProducer = FakeHendelseProdusent()
-
-    val database = testDatabase(Produsent.databaseConfig)
-    val produsentRepository = ProdusentRepositoryImpl(database)
-
-    val engine = ktorProdusentTestServer(
-        kafkaProducer = stubbedKafkaProducer,
-        produsentRepository = produsentRepository,
-    )
 
     describe("oppdater status") {
+        val (stubbedKafkaProducer, engine) = setupEngine()
         val nySakResponse = engine.nySak()
         it("vellykket nySak") {
             nySakResponse.getTypedContent<String>("$.nySak.__typename") shouldBe "NySakVellykket"
@@ -85,6 +77,17 @@ class NyStatusSakTests : DescribeSpec({
         }
     }
 })
+
+private fun DescribeSpec.setupEngine(): Pair<FakeHendelseProdusent, TestApplicationEngine> {
+    val stubbedKafkaProducer = FakeHendelseProdusent()
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentRepository = ProdusentRepositoryImpl(database)
+    val engine = ktorProdusentTestServer(
+        kafkaProducer = stubbedKafkaProducer,
+        produsentRepository = produsentRepository,
+    )
+    return Pair(stubbedKafkaProducer, engine)
+}
 
 private fun TestApplicationEngine.nyStatusSak(
     id: UUID,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/OppgaveUtførtTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/OppgaveUtførtTests.kt
@@ -3,6 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.ktor.server.testing.*
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
@@ -19,14 +20,6 @@ import java.util.*
 
 
 class OppgaveUtførtTests : DescribeSpec({
-    val database = testDatabase(Produsent.databaseConfig)
-    val produsentModel = ProdusentRepositoryImpl(database)
-    val stubbedKafkaProducer = FakeHendelseProdusent()
-
-    val engine = ktorProdusentTestServer(
-        kafkaProducer = stubbedKafkaProducer,
-        produsentRepository = produsentModel
-    )
 
 
     describe("OppgaveUtført-oppførsel") {
@@ -42,6 +35,7 @@ class OppgaveUtførtTests : DescribeSpec({
         val opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z")
 
         context("Eksisterende oppgave blir utført") {
+            val (produsentModel, stubbedKafkaProducer, engine) = setupEngine()
             val oppgaveOpprettet = OppgaveOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -106,6 +100,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Oppgave mangler") {
+            val (_, _, engine) = setupEngine()
             val response = engine.produsentApi(
                 """
                 mutation {
@@ -125,6 +120,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Oppgave med feil merkelapp") {
+            val (produsentModel, _, engine) = setupEngine()
             val oppgaveOpprettet = OppgaveOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = "feil merkelapp",
@@ -166,6 +162,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Er ikke oppgave, men beskjed") {
+            val (produsentModel, _, engine) = setupEngine()
             val beskjedOpprettet = BeskjedOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -218,6 +215,7 @@ class OppgaveUtførtTests : DescribeSpec({
         val opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z")
 
         context("Eksisterende oppgave blir utført") {
+            val (produsentModel, stubbedKafkaProducer, engine) = setupEngine()
             val oppgaveOpprettet = OppgaveOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -284,6 +282,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Oppgave mangler") {
+            val (_, _, engine) = setupEngine()
             val response = engine.produsentApi(
                 """
                 mutation {
@@ -303,6 +302,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Oppgave med feil merkelapp men riktig eksternId") {
+            val (produsentModel, _, engine) = setupEngine()
             val oppgaveOpprettet = OppgaveOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -344,6 +344,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Oppgave med feil eksternId men riktig merkelapp") {
+            val (produsentModel, _, engine) = setupEngine()
             val oppgaveOpprettet = OppgaveOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -385,6 +386,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Er ikke oppgave, men beskjed") {
+            val (produsentModel, _, engine) = setupEngine()
             val beskjedOpprettet = BeskjedOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -437,6 +439,7 @@ class OppgaveUtførtTests : DescribeSpec({
         val opprettetTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z")
 
         context("Eksisterende oppgave blir utført") {
+            val (produsentModel, stubbedKafkaProducer, engine) = setupEngine()
             val oppgaveOpprettet = OppgaveOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -503,6 +506,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Oppgave mangler") {
+            val (_, _, engine) = setupEngine()
             val response = engine.produsentApi(
                 """
                 mutation {
@@ -522,6 +526,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Oppgave med feil merkelapp men riktig eksternId") {
+            val (produsentModel, _, engine) = setupEngine()
             val oppgaveOpprettet = OppgaveOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -563,6 +568,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Oppgave med feil eksternId men riktig merkelapp") {
+            val (produsentModel, _, engine) = setupEngine()
             val oppgaveOpprettet = OppgaveOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -604,6 +610,7 @@ class OppgaveUtførtTests : DescribeSpec({
         }
 
         context("Er ikke oppgave, men beskjed") {
+            val (produsentModel, _, engine) = setupEngine()
             val beskjedOpprettet = BeskjedOpprettet(
                 virksomhetsnummer = "1",
                 merkelapp = merkelapp,
@@ -643,3 +650,14 @@ class OppgaveUtførtTests : DescribeSpec({
         }
     }
 })
+
+private fun DescribeSpec.setupEngine(): Triple<ProdusentRepositoryImpl, FakeHendelseProdusent, TestApplicationEngine> {
+    val database = testDatabase(Produsent.databaseConfig)
+    val produsentModel = ProdusentRepositoryImpl(database)
+    val stubbedKafkaProducer = FakeHendelseProdusent()
+    val engine = ktorProdusentTestServer(
+        kafkaProducer = stubbedKafkaProducer,
+        produsentRepository = produsentModel
+    )
+    return Triple(produsentModel, stubbedKafkaProducer, engine)
+}

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteIdempotensTests.kt
@@ -7,10 +7,10 @@ import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import java.time.Instant
 
 class SkedulertHardDeleteIdempotensTests : DescribeSpec({
-    val database = testDatabase(SkedulertHardDelete.databaseConfig)
-    val repository = SkedulertHardDeleteRepositoryImpl(database)
 
     describe("SkedulertHardDelete Idempotent oppførsel") {
+        val database = testDatabase(SkedulertHardDelete.databaseConfig)
+        val repository = SkedulertHardDeleteRepositoryImpl(database)
         withData(EksempelHendelse.Alle) { hendelse ->
             repository.oppdaterModellEtterHendelse(hendelse, Instant.EPOCH)
             repository.oppdaterModellEtterHendelse(hendelse, Instant.EPOCH)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteRepositoryFindToDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteRepositoryFindToDeleteTests.kt
@@ -12,10 +12,10 @@ import java.time.OffsetDateTime
 import java.time.Period
 
 class AutoSlettRepositoryFindToDeleteTests : DescribeSpec({
-    val database = testDatabase(SkedulertHardDelete.databaseConfig)
-    val repository = SkedulertHardDeleteRepositoryImpl(database)
 
     describe("SkedulertHardDeleteRepository#hentDeSomSkalSlettes") {
+        val database = testDatabase(SkedulertHardDelete.databaseConfig)
+        val repository = SkedulertHardDeleteRepositoryImpl(database)
         val baseline = OffsetDateTime.parse("2020-01-01T01:01:01.00Z")
 
         repository.insert(id = "1", beregnetSlettetid = baseline + Duration.ofDays(2))

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/statistikk/StatistikkModelTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/statistikk/StatistikkModelTests.kt
@@ -29,11 +29,9 @@ import java.time.temporal.ChronoUnit.MILLIS
 import java.util.*
 
 class StatistikkModelTests : DescribeSpec({
-    val database = testDatabase(Statistikk.databaseConfig)
-    val model = StatistikkModel(database)
 
 
-    suspend fun opprettSak(
+    fun opprettSak(
         id: String,
     ): HendelseModel.SakOpprettet {
         val uuid = uuid(id)
@@ -60,11 +58,11 @@ class StatistikkModelTests : DescribeSpec({
         )
     }
 
-    suspend fun opprettOppgave(
+    fun opprettOppgave(
         id: String,
         merkelapp: String,
         grupperingsid: String?,
-    ) = HendelseModel.OppgaveOpprettet(
+    ) = OppgaveOpprettet(
         virksomhetsnummer = "1",
         produsentId = "1",
         hendelseId = uuid(id),
@@ -204,6 +202,8 @@ class StatistikkModelTests : DescribeSpec({
 
 
         context("gitt hendelse med to varsler") {
+            val database = testDatabase(Statistikk.databaseConfig)
+            val model = StatistikkModel(database)
             val meterRegistry = SimpleMeterRegistry()
             val gauge = MultiGauge.builder("antall_varsler")
                 .description("Antall varsler")
@@ -235,6 +235,8 @@ class StatistikkModelTests : DescribeSpec({
         }
 
         context("SoftDelete") {
+            val database = testDatabase(Statistikk.databaseConfig)
+            val model = StatistikkModel(database)
             val softdelete = HendelseModel.SoftDelete(
                 virksomhetsnummer = "42",
                 aggregateId = UUID.randomUUID(),
@@ -255,6 +257,8 @@ class StatistikkModelTests : DescribeSpec({
     }
 
     describe("Statistikk Idempotent oppførsel") {
+        val database = testDatabase(Statistikk.databaseConfig)
+        val model = StatistikkModel(database)
         val metadata = HendelseMetadata(now())
         withData(EksempelHendelse.Alle) { hendelse ->
             model.oppdaterModellEtterHendelse(hendelse, metadata)
@@ -263,6 +267,8 @@ class StatistikkModelTests : DescribeSpec({
     }
 
     describe("SoftDelete på sak sletter også relaterte notifikasjoner") {
+        val database = testDatabase(Statistikk.databaseConfig)
+        val model = StatistikkModel(database)
         model.oppdaterModellEtterHendelse(opprettSak("1"), HendelseMetadata(now()))
         model.oppdaterModellEtterHendelse(opprettOppgave("01", "tag", "1"), HendelseMetadata(now()))
         model.oppdaterModellEtterHendelse(opprettOppgave("02", "tag", "2"), HendelseMetadata(now()))
@@ -291,6 +297,8 @@ class StatistikkModelTests : DescribeSpec({
     }
 
     describe("HardDelete av sak sletter også relaterte notifikasjoner") {
+        val database = testDatabase(Statistikk.databaseConfig)
+        val model = StatistikkModel(database)
         model.oppdaterModellEtterHendelse(opprettSak("1"), HendelseMetadata(now()))
         model.oppdaterModellEtterHendelse(opprettOppgave("01", "tag", "1"), HendelseMetadata(now()))
         model.oppdaterModellEtterHendelse(opprettOppgave("02", "tag", "2"), HendelseMetadata(now()))

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/PostgresTestListener.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/PostgresTestListener.kt
@@ -6,32 +6,71 @@ import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
+import java.sql.DriverManager
+import java.util.*
+
+val templateDbs = mutableMapOf<Database.Config, String>()
+val ids = generateSequence() { UUID.randomUUID() }.iterator()
+private suspend fun createDbFromTemplate(config: Database.Config): Database.Config {
+    val templateDb = templateDb(config)
+    val database = "${config.database}_${ids.next()}".also { db ->
+        DriverManager.getConnection(config.jdbcUrl, config.username, config.password).use { conn ->
+            conn.createStatement().use { stmt ->
+                @Suppress("SqlSourceToSinkFlow")
+                stmt.executeUpdate("""create database "$db" template "$templateDb"; """)
+            }
+        }
+    }
+    return config.copy(database = database)
+}
+
+/**
+ * henter template database for gitt config, eller lager en ny hvis den ikke finnes.
+ * template databasen brukes til å lage ferske databaser for hver test.
+ */
+@Suppress("SqlSourceToSinkFlow")
+private suspend fun templateDb(config: Database.Config): String {
+    val templateDb = templateDbs.getOrPut(config) {
+        "${config.database}_template".also { db ->
+            DriverManager.getConnection(config.jdbcUrl, config.username, config.password).use { conn ->
+                conn.createStatement().use { stmt ->
+                    stmt.executeUpdate("""drop database if exists "$db"; """)
+                    stmt.executeUpdate("""create database "$db" ; """)
+                }
+            }
+            Database.openDatabase(
+                config = config.copy(
+                    port = "1337",
+                    database = db,
+                ),
+                flywayAction = {
+                    migrate()
+                }
+            ).close()
+        }
+    }
+    return templateDb
+}
 
 fun TestConfiguration.testDatabase(config: Database.Config): Database =
     runBlocking {
+        val database = createDbFromTemplate(config).database
         Database.openDatabase(
             config = config.copy(
                 // https://github.com/flyway/flyway/issues/2323#issuecomment-804495818
                 jdbcOpts = mapOf("preparedStatementCacheQueries" to 0),
                 port = "1337",
+                database = database,
             ),
             flywayAction = {
-                /* noop. stuff happens in PostgresTestListener.beforeContainer. */
+                /* noop. created from template. */
             }
         )
-    }
-        .also { listener(PostgresTestListener(it)) }
+    }.also { listener(PostgresTestListener(it)) }
 
-class PostgresTestListener(private val database: Database): TestListener {
+class PostgresTestListener(private val database: Database) : TestListener {
 
     override suspend fun beforeContainer(testCase: TestCase) {
-        database.withFlyway({
-            cleanDisabled(false)
-            validateOnMigrate(false)
-        }) {
-            clean()
-            migrate()
-        }
     }
 
     override suspend fun afterSpec(spec: Spec) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRESQL_FSYNC: "off"
+      POSTGRESQL_FULL_PAGE_WRITES: "off"
     volumes:
       - ${PWD}/local-db-init.sql:/docker-entrypoint-initdb.d/init.sql
 


### PR DESCRIPTION
Før denne endringen ble det migrert med flyway mellom hver container (describe/context). Dette fungerte fint når vi hadde noen hundre tester. Nå har vi over 1000 tester og det begynner å ta noen minutter å kjøre disse. Ved å endre til å sette opp en template db så kan postgres raskere sette opp en ny database. Fjerner også "magien" ved at database cleares automatisk via listener. Nå gjøres dette eksplisitt ved at man henter en ny database i konteksten man trenger den.

Før denne endringen:
```bash
$ mvn clean test
[INFO] Total time:  03:49 min
```

Etter:
```bash
$ mvn clean test
[INFO] Total time:  01:09 min
```

![zoom](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXdpOWVmOGs3azV4eTZneGswd3M3ZXVmMDB5Y21sMzcxNmlxbWs4eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ggi1w9hUFxhmw/giphy.gif)