### PR TITLE
Endrer build pipeline tilbake til bygg og push

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,16 +5,10 @@ on:
       - fake-produsent-api/**
       - test-produsent/**
   pull_request:
-    types:
-      - closed
   workflow_dispatch:
-
-env:
-  push_to_main: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, 'Merge pull request') }}
 
 jobs:
   build:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: "read"
       id-token: "write"
@@ -71,6 +65,7 @@ jobs:
         working-directory: app
 
       - uses: nais/docker-build-push@v0
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         id: gar-push
         with:
           team: fager
@@ -82,7 +77,7 @@ jobs:
           byosbom: app/target/bom.json
 
   deploy:
-    if: ${{ always() }}
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: [build]
     runs-on: ubuntu-latest
     permissions:
@@ -125,8 +120,7 @@ jobs:
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
           team: fager
 
-      - if: env.push_to_main == 'true' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-        uses: nais/deploy/actions/deploy@v1
+      - uses: nais/deploy/actions/deploy@v1
         name: "${{ matrix.cluster }}: deploy ${{ matrix.app }}"
         env:
           IMAGE: ${{ steps.login.outputs.registry }}/arbeidsgiver-notifikasjon-produsent-api:${{ env.DEPLOY_SHA }}

--- a/.github/workflows/deploy-replay-validator-prod.yaml
+++ b/.github/workflows/deploy-replay-validator-prod.yaml
@@ -7,10 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: nais/login@v0
+        id: login
+        with:
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+          team: fager
       - uses: nais/deploy/actions/deploy@v1
         name: "prod-gcp: deploy replay-validator"
         env:
-          IMAGE: ghcr.io/${{ github.repository }}/arbeidsgiver-notifikasjon-produsent-api:${{ github.sha }}
+          IMAGE: ${{ steps.login.outputs.registry }}/arbeidsgiver-notifikasjon-produsent-api:${{ github.sha }}
           REF: ${{ github.sha }}
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-gcp


### PR DESCRIPTION
Det er en del støy på endringer gjort i ./test-produsent og ./fake-produsent-api som følge av det "optimaliserte" oppsettet. Støyen er i form av image pull backoff på deploy når det ikke er laget noen produsent-api image på kodeendringer i disse sub mappene. Det kan la seg gjøre å fikse dette med enda mer konfig, men tenker det er bedre å gå tilbake til et enklere oppsett.

Hensikten  med optimaliseringen var å få ned turnaround på merge til prod, men det kom på bekostning av et litt mer komplisert oppsett. Nå som byggtiden er redusert er det ikke like mye verdt det med et mer komplisert oppsett.

reverter endringen gjort her:
* https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/606

se også
* https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/649