### PR TITLE
remove corrupt event bugfix

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/Config.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/Config.kt
@@ -1,7 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka
 
 import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -40,28 +39,9 @@ abstract class JsonDeserializer<T>(private val clazz: Class<T>) : Deserializer<T
     }
 }
 
-abstract class JsonDeserializerBugfix<T>(private val clazz: Class<T>) : Deserializer<T> {
-    private val log = logger()
-
-    override fun deserialize(topic: String?, data: ByteArray?): T? {
-        return try {
-            kafkaObjectMapper.readValue(data, clazz)
-        } catch (e: Exception) {
-            // temporary fix for broken hendelse i dev-gcp 22.03.2024
-            val json = kafkaObjectMapper.readValue(data, JsonNode::class.java)
-            if (json.at("/hendelseId").asText() == "37f5df5e-c8a2-42ca-80c4-377eb57d8c5f") {
-                return null
-            }
-            throw e
-        }
-    }
-}
-
 class ValueSerializer : JsonSerializer<Hendelse>
 
-// TODO: reenable this when the bug is fixed
-class ValueDeserializer : JsonDeserializerBugfix<Hendelse>(Hendelse::class.java)
-//class ValueDeserializer : JsonDeserializer<Hendelse>(Hendelse::class.java)
+class ValueDeserializer : JsonDeserializer<Hendelse>(Hendelse::class.java)
 
 val COMMON_PROPERTIES = mapOf(
     CommonProp.BOOTSTRAP_SERVERS_CONFIG to (getenv("KAFKA_BROKERS") ?: "localhost:9092"),

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/KafkaSerializerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/KafkaSerializerTests.kt
@@ -19,48 +19,4 @@ class KafkaSerializerTests : DescribeSpec({
             deserialized shouldBe hendelse
         }
     }
-
-    describe("korrupt hendelse i dev-gcp") {
-        val deserializer = ValueDeserializer()
-
-        /**
-         * pga en feil i test i dev ble det laget en korrupt hendelse. Dette er kode som rydder opp. Kan slettes når
-         * hendelsen er tombstonet og compacted.
-         */
-        it("skips corrupt event in dev-gcp") {
-            val serialized = """
-                {
-                  "@type": "PaaminnelseOpprettet",
-                  "virksomhetsnummer": "910825526",
-                  "hendelseId": "37f5df5e-c8a2-42ca-80c4-377eb57d8c5f",
-                  "produsentId": "fager",
-                  "kildeAppNavn": "dev-gcp:fager:notifikasjon-skedulert-paaminnelse",
-                  "notifikasjonId": "de8ac3c3-4f51-41e5-bcc1-455fcf1cee7e",
-                  "bestillingHendelseId": "de8ac3c3-4f51-41e5-bcc1-455fcf1cee7e",
-                  "opprettetTidpunkt": "2024-03-22T12:01:57.465888822Z",
-                  "fristOpprettetTidspunkt": "2024-03-22T11:44:03.941061085Z",
-                  "frist": null,
-                  "tidspunkt": {
-                    "@type": "PaaminnelseTidspunkt.FoerStartTidspunkt",
-                    "foerStartTidspunkt": "PT5M",
-                    "paaminnelseTidspunkt": "2024-03-22T11:47:10.983Z"
-                  },
-                  "eksterneVarsler": [
-                    {
-                      "@type": "LinkedHashMap",
-                      "varselId": "bee8f018-5d30-4293-a2e5-a8f2aa00a1a6",
-                      "epostAddr": "ken.gullaksen@nav.no",
-                      "fnrEllerOrgnr": "910825526",
-                      "tittel": "Varsel ved påminnelse fra testpodusent",
-                      "htmlBody": "<h1>Hei</h1><p>Dette er en påminnelse</p>",
-                      "sendevindu": "LØPENDE",
-                      "sendeTidspunkt": null
-                    }
-                  ]
-                }
-            """.trimIndent().toByteArray()
-            val deserialized = deserializer.deserialize("", serialized)
-            deserialized shouldBe null
-        }
-    }
 })


### PR DESCRIPTION
Fjerner workaround for korrupt event i dev.
Kan merges når tomstone er compactet. Bør ta ca 7 dager fra den ble tomstonet. tombstone er på
| partition | offset | timestamp |
| :--- | :--- | :--- |
| 12 | 87018 | 1712068860201 |

compaction kan sjekkes med:
```
./kafka-console-consumer.sh --bootstrap-server $KAFKA_BROKERS \
    --consumer.config $KAFKA_CONFIG/kafka.properties \
    -topic fager.notifikasjon \
    --formatter kafka.tools.DefaultMessageFormatter \
    --property print.key=true --property print.value=true --property print.offset=true --property print.timestamp=true \
    --partition 12 --offset 80148 --max-messages 5
```

ref:
* https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/667