### PR TITLE
fjern tiltak-refusjon-api. er ikke i bruk

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegisterImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegisterImpl.kt
@@ -43,7 +43,6 @@ val ARBEIDSGIVER_TILTAK = Produsent(
         },
         other = {
             listOf(
-                "dev-gcp:arbeidsgiver:tiltak-refusjon-api",
                 "dev-fss:arbeidsgiver:tiltaksgjennomforing-api",
                 "dev-gcp:team-tiltak:tiltak-notifikasjon",
             )

--- a/config/dev-gcp-produsent-api.yaml
+++ b/config/dev-gcp-produsent-api.yaml
@@ -42,10 +42,6 @@ spec:
       rules:
         - application: notifikasjon-test-produsent-v2
 
-        - application: tiltak-refusjon-api
-          namespace: arbeidsgiver
-          cluster: dev-gcp
-
         - application: tiltaksgjennomforing-api
           namespace: arbeidsgiver
           cluster: dev-fss


### PR DESCRIPTION
Det er ingen outbound policy eller kode som kaller oss i denne appen: 
* https://github.com/navikt/tiltak-refusjon-api/blob/master/.nais/nais.yml
* https://github.com/navikt/arbeidsgiver-notifikasjon-produsenter/pull/37