### PR TITLE
Improve resource utilization

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,4 +1,7 @@
 FROM gcr.io/distroless/java21-debian12
 COPY target/produsent-api/app.jar app.jar
 COPY target/produsent-api/lib lib
+
+ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=88"
+
 CMD ["app.jar"]

--- a/app/nais/dev-gcp-bruker-api-writer.yaml
+++ b/app/nais/dev-gcp-bruker-api-writer.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-bruker-api.yaml
+++ b/app/nais/dev-gcp-bruker-api.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   ingresses:
     - https://ag-notifikasjon-bruker-api.intern.dev.nav.no/
   liveness:

--- a/app/nais/dev-gcp-dataprodukt.yaml
+++ b/app/nais/dev-gcp-dataprodukt.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-ekstern-varsling.yaml
+++ b/app/nais/dev-gcp-ekstern-varsling.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-hendelse-transformer.yaml
+++ b/app/nais/dev-gcp-hendelse-transformer.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-kafka-backup.yaml
+++ b/app/nais/dev-gcp-kafka-backup.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     team: fager
 spec:
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   image: {{image}}
   liveness:
     path: /internal/alive

--- a/app/nais/dev-gcp-kafka-backup.yaml
+++ b/app/nais/dev-gcp-kafka-backup.yaml
@@ -6,13 +6,13 @@ metadata:
   labels:
     team: fager
 spec:
+  image: {{image}}
   resources:
     requests:
       cpu: 200m
       memory: 256Mi
     limits:
       memory: 512Mi
-  image: {{image}}
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-kafka-reaper.yaml
+++ b/app/nais/dev-gcp-kafka-reaper.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-manuelt-vedlikehold.yaml
+++ b/app/nais/dev-gcp-manuelt-vedlikehold.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-produsent-api.yaml
+++ b/app/nais/dev-gcp-produsent-api.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   ingresses:
     - https://ag-notifikasjon-produsent-api.intern.dev.nav.no/
   liveness:

--- a/app/nais/dev-gcp-replay-validator.yaml
+++ b/app/nais/dev-gcp-replay-validator.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-skedulert-harddelete.yaml
+++ b/app/nais/dev-gcp-skedulert-harddelete.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-skedulert-paaminnelse.yaml
+++ b/app/nais/dev-gcp-skedulert-paaminnelse.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-skedulert-utgaatt.yaml
+++ b/app/nais/dev-gcp-skedulert-utgaatt.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/dev-gcp-statistikk.yaml
+++ b/app/nais/dev-gcp-statistikk.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/prod-gcp-bruker-api-writer.yaml
+++ b/app/nais/prod-gcp-bruker-api-writer.yaml
@@ -12,7 +12,6 @@ spec:
       cpu: 400m
       memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   liveness:
     path: /internal/alive
@@ -24,8 +23,6 @@ spec:
   kafka:
     pool: nav-prod
   env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"
     - name: CLOUD_SQL_INSTANCE
       value: fager-prod-dd77:europe-north1:notifikasjon-bruker-api
   gcp:

--- a/app/nais/prod-gcp-bruker-api.yaml
+++ b/app/nais/prod-gcp-bruker-api.yaml
@@ -12,7 +12,6 @@ spec:
       cpu: 400m
       memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   replicas:
     max: 24
@@ -62,8 +61,5 @@ spec:
       external:
         - host: api-gw.oera.no # fallback for altinn-rettigheter-proxy-client
         - host: ereg-services.prod-fss-pub.nais.io # ereg brukes i bruker-api
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"
   envFrom:
     - secret: notifikasjon-bruker-api-secrets

--- a/app/nais/prod-gcp-dataprodukt.yaml
+++ b/app/nais/prod-gcp-dataprodukt.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 400m
+      memory: 512Mi
+    limits:
+      memory: 1024Mi
   liveness:
     path: /internal/alive
   readiness:
@@ -14,9 +20,6 @@ spec:
   replicas:
     min: 1
     max: 1
-  resources:
-    limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
   prometheus:
     enabled: true
     path: /internal/metrics
@@ -33,6 +36,3 @@ spec:
         autoBackupHour: 1
         maintenance:
           hour: 3
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"

--- a/app/nais/prod-gcp-ekstern-varsling.yaml
+++ b/app/nais/prod-gcp-ekstern-varsling.yaml
@@ -12,7 +12,6 @@ spec:
       cpu: 400m
       memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   liveness:
     path: /internal/alive
@@ -41,8 +40,5 @@ spec:
         autoBackupHour: 1
         maintenance:
           hour: 3
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"
   envFrom:
     - secret: altinn-basic-ws

--- a/app/nais/prod-gcp-kafka-backup.yaml
+++ b/app/nais/prod-gcp-kafka-backup.yaml
@@ -12,7 +12,6 @@ spec:
       cpu: 400m
       memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   liveness:
     path: /internal/alive
@@ -37,6 +36,3 @@ spec:
         autoBackupHour: 1
         maintenance:
           hour: 3
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"

--- a/app/nais/prod-gcp-kafka-reaper.yaml
+++ b/app/nais/prod-gcp-kafka-reaper.yaml
@@ -9,9 +9,9 @@ spec:
   image: {{image}}
   resources:
     requests:
+      cpu: 400m
       memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   liveness:
     path: /internal/alive
@@ -36,6 +36,3 @@ spec:
         autoBackupHour: 1
         maintenance:
           hour: 3
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"

--- a/app/nais/prod-gcp-produsent-api.yaml
+++ b/app/nais/prod-gcp-produsent-api.yaml
@@ -12,7 +12,6 @@ spec:
       cpu: 400m
       memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   ingresses:
     - https://ag-notifikasjon-produsent-api.intern.nav.no/
@@ -98,8 +97,5 @@ spec:
         autoBackupHour: 1
         maintenance:
           hour: 3
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"
   envFrom:
     - secret: notifikasjon-produsent-api-secrets

--- a/app/nais/prod-gcp-replay-validator.yaml
+++ b/app/nais/prod-gcp-replay-validator.yaml
@@ -9,9 +9,9 @@ spec:
   image: {{image}}
   resources:
     requests:
+      cpu: 400m
       memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   liveness:
     path: /internal/alive
@@ -25,6 +25,3 @@ spec:
     path: /internal/metrics
   kafka:
     pool: nav-prod
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"

--- a/app/nais/prod-gcp-skedulert-harddelete.yaml
+++ b/app/nais/prod-gcp-skedulert-harddelete.yaml
@@ -6,10 +6,12 @@ metadata:
   labels:
     team: fager
 spec:
-  image: {{{image}}}
+  image: {{image}}
   resources:
+    requests:
+      cpu: 400m
+      memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   liveness:
     path: /internal/alive
@@ -32,6 +34,3 @@ spec:
         databases:
           - name: skedulert-harddelete-model
             envVarPrefix: DB
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"

--- a/app/nais/prod-gcp-skedulert-paaminnelse.yaml
+++ b/app/nais/prod-gcp-skedulert-paaminnelse.yaml
@@ -7,6 +7,12 @@ metadata:
     team: fager
 spec:
   image: {{image}}
+  resources:
+    requests:
+      cpu: 400m
+      memory: 512Mi
+    limits:
+      memory: 1024Mi
   liveness:
     path: /internal/alive
   readiness:

--- a/app/nais/prod-gcp-skedulert-utgaatt.yaml
+++ b/app/nais/prod-gcp-skedulert-utgaatt.yaml
@@ -6,15 +6,17 @@ metadata:
   labels:
     team: fager
 spec:
-  image: {{{image}}}
+  image: {{image}}
+  resources:
+    requests:
+      cpu: 400m
+      memory: 512Mi
+    limits:
+      memory: 1024Mi
   replicas:
     disableAutoScaling: true
     min: 4
     max: 4
-  resources:
-    limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
-      memory: 2Gi
   liveness:
     path: /internal/alive
   readiness:
@@ -24,6 +26,3 @@ spec:
     path: /internal/metrics
   kafka:
     pool: nav-prod
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"

--- a/app/nais/prod-gcp-statistikk.yaml
+++ b/app/nais/prod-gcp-statistikk.yaml
@@ -9,9 +9,9 @@ spec:
   image: {{image}}
   resources:
     requests:
+      cpu: 400m
       memory: 512Mi
     limits:
-      cpu: 5000m # https://home.robusta.dev/blog/stop-using-cpu-limits/
       memory: 1024Mi
   liveness:
     path: /internal/alive
@@ -36,6 +36,3 @@ spec:
         autoBackupHour: 1
         maintenance:
           hour: 3
-  env:
-    - name: JAVA_OPTS
-      value: "-XX:+UseParallelGC -XX:MaxRAMPercentage=75.0 -XX:ActiveProcessorCount=2"


### PR DESCRIPTION
Resource utilization can be viewed in the nais console: https://console.nav.cloud.nais.io/team/fager/utilization

This PR fikses a couple of things:
1. explicitly define the resource requests in dev, so it will be easier to adjust to reduce overage
2. align the resource requests in production so it will be easier to adjust to reduce overage
3. fixes regression where we lost maxrampercentage jvm opts after moving to distroless. Distroless images do not respect `JAVA_OPTS`, the same way the old baseimages do. To achieve the same result in distroless set `JDK_JAVA_OPTIONS`.

Demonstrated by the following test using docker:
```Dockerfile
FROM gcr.io/distroless/java21-debian12
COPY target/app.jar app.jar
COPY target/lib lib

ENV JAVA_OPTS='-XX:MaxRAMPercentage=75'
#ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75"

CMD ["app.jar"]

```

```bash
$ docker run

JAVA_OPTS: -XX:MaxRAMPercentage=75
JDK_JAVA_OPTIONS: null
MaxRAMPercentage: 978 MB
```

```Dockerfile
FROM gcr.io/distroless/java21-debian12
COPY target/app.jar app.jar
COPY target/lib lib

#ENV JAVA_OPTS='-XX:MaxRAMPercentage=75'
ENV JDK_JAVA_OPTIONS="-XX:MaxRAMPercentage=75"

CMD ["app.jar"]
```

```bash
$ docker run

NOTE: Picked up JDK_JAVA_OPTIONS: -XX:MaxRAMPercentage=75
JAVA_OPTS: null
JDK_JAVA_OPTIONS: -XX:MaxRAMPercentage=75
MaxRAMPercentage: 2930 MB
```
