### PR TITLE
Widget-meny blir opp til 30rem bred

### DIFF
--- a/widget/brukerapi-mock/package-lock.json
+++ b/widget/brukerapi-mock/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjoner-brukerapi-mock",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "license": "MIT",
       "dependencies": {
         "apollo-server": "^3.10.2",

--- a/widget/brukerapi-mock/package.json
+++ b/widget/brukerapi-mock/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/navikt/arbeidsgiver-notifikasjon-widget.git"
   },
-  "version": "7.1.1",
+  "version": "7.1.2",
   "license": "MIT",
   "main": "dist/notifikasjonMockMiddleware.js",
   "files": [

--- a/widget/component/package-lock.json
+++ b/widget/component/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@navikt/arbeidsgiver-notifikasjon-widget",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "dependencies": {
         "@apollo/client": "^3.10.8",
         "graphql": "^16.9.0"

--- a/widget/component/package.json
+++ b/widget/component/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git+https://github.com/navikt/arbeidsgiver-notifikasjon-widget.git"
   },
-  "version": "7.1.1",
+  "version": "7.1.2",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/esm/index.d.ts",

--- a/widget/component/src/NotifikasjonWidget/NotifikasjonPanel/Dropdown.css
+++ b/widget/component/src/NotifikasjonWidget/NotifikasjonPanel/Dropdown.css
@@ -7,7 +7,7 @@
   margin: 0;
   padding: 0;
   width: 100vw;
-  max-width: 26.25rem;
+  max-width: 30rem;
   border: solid 2px var(--a-deepblue-700);
   border-radius: 4px;
   max-height: 65vh;


### PR DESCRIPTION
Nå blir dropdown fra notifikasjonsbjellen opp til 30 rem bred. Det er for å tilpasse størrelsen som blir tilgjengelig av bedriftwsmenyen. Dermed blir bedriftsmenyen og notifikasjon-dropdown like brede. 