### PR TITLE
kobling fra sak til kalenderavtale manglet i reaper

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaperModel.kt
@@ -39,12 +39,14 @@ class KafkaReaperModelImpl(
             is SakOpprettet -> hendelse.grupperingsid
             is OppgaveOpprettet -> hendelse.grupperingsid
             is BeskjedOpprettet -> hendelse.grupperingsid
+            is KalenderavtaleOpprettet -> hendelse.grupperingsid
             else -> null
         }
         val merkelapp = when (hendelse) {
             is SakOpprettet -> hendelse.merkelapp
             is OppgaveOpprettet -> hendelse.merkelapp
             is BeskjedOpprettet -> hendelse.merkelapp
+            is KalenderavtaleOpprettet -> hendelse.merkelapp
             else -> null
         }
 


### PR DESCRIPTION
når en harddelete gjøres på sak så sjekker kafka reaper om det finnes noen notifikasjoner på koordinatet merkelapp::grupperingsid som skal slettes. Dette manglet for kalenderavtale.

Ingen som har tatt det i bruk enda, så det krever ikke rydding så vidt jeg kan se.