### PR TITLE
støtte cascade delete fra sak i HardDeletedRepository

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -689,6 +689,9 @@ class BrukerRepositoryImpl(
         }.getOrNull(0)
 
     override suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse, metadata: HendelseMetadata) {
+        if (hendelse is HendelseModel.AggregatOpprettet) {
+            registrerKoblingForCascadeDelete(hendelse)
+        }
         if (erHardDeleted(hendelse.aggregateId)) {
             log.info("skipping harddeleted event {}", hendelse)
             return

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktModel.kt
@@ -42,11 +42,15 @@ class DataproduktModel(
     val log = logger()
 
     suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse, metadata: HendelseMetadata) {
+        if (hendelse is HendelseModel.AggregatOpprettet) {
+            registrerKoblingForCascadeDelete(hendelse)
+        }
         if (erHardDeleted(hendelse.aggregateId)) {
             log.info("skipping harddeleted event {}", hendelse)
             return
         }
-        database.nonTransactionalExecuteUpdate("""
+        database.nonTransactionalExecuteUpdate(
+            """
             insert into aggregat_hendelse(
                 hendelse_id,
                 hendelse_type,
@@ -57,7 +61,8 @@ class DataproduktModel(
                 kafka_timestamp 
             ) values (?, ?, ?, ?, ? ,?, ?)
             on conflict do nothing
-        """) {
+        """
+        ) {
             with(hendelse) {
                 uuid(hendelseId)
                 text(hendelse::class.simpleName!!)
@@ -130,6 +135,7 @@ class DataproduktModel(
                     statusUtsending = "UTSENDING_BESTILT",
                 )
             }
+
             is OppgaveOpprettet -> {
                 database.nonTransactionalExecuteUpdate(
                     """
@@ -207,6 +213,7 @@ class DataproduktModel(
                     statusUtsending = "UTSENDING_BESTILT",
                 )
             }
+
             is OppgaveUtført -> {
                 with(hendelse) {
                     if (hardDelete != null) {
@@ -236,6 +243,7 @@ class DataproduktModel(
                     uuid(hendelse.notifikasjonId)
                 }
             }
+
             is OppgaveUtgått -> {
                 markerIngenUtsendingPåPåminnelseEksterneVarsler(hendelse.notifikasjonId)
 
@@ -247,7 +255,10 @@ class DataproduktModel(
                             bestillingType = "STATUSENDRING",
                             strategi = hardDelete.strategi.toString(),
                             spesifikasjon = hardDelete.nyTid,
-                            utregnetTidspunkt = ScheduledTime(hardDelete.nyTid, utgaattTidspunkt.toInstant()).happensAt(),
+                            utregnetTidspunkt = ScheduledTime(
+                                hardDelete.nyTid,
+                                utgaattTidspunkt.toInstant()
+                            ).happensAt(),
                         )
                     }
                 }
@@ -300,6 +311,7 @@ class DataproduktModel(
                 }
 
             }
+
             is EksterntVarselVellykket -> {
                 updateEksternVarsel(listOf(hendelse.varselId), "UTSENDING_VELLYKKET", null, metadata.timestamp)
                 database.nonTransactionalExecuteBatch(
@@ -324,39 +336,52 @@ class DataproduktModel(
                     text(it["resultat_type"]!!)
                 }
             }
+
             is EksterntVarselFeilet -> {
-                updateEksternVarsel(listOf(hendelse.varselId), "UTSENDING_FEILET", hendelse.altinnFeilkode,  metadata.timestamp)
+                updateEksternVarsel(
+                    listOf(hendelse.varselId),
+                    "UTSENDING_FEILET",
+                    hendelse.altinnFeilkode,
+                    metadata.timestamp
+                )
             }
+
             is HendelseModel.EksterntVarselKansellert -> {
-                updateEksternVarsel(listOf(hendelse.varselId), "UTSENDING_KANSELLERT", null,  metadata.timestamp)
+                updateEksternVarsel(listOf(hendelse.varselId), "UTSENDING_KANSELLERT", null, metadata.timestamp)
             }
 
             is SoftDelete -> {
-                if (hendelse.grupperingsid != null && hendelse.merkelapp != null){
-                    database.nonTransactionalExecuteUpdate("""
+                if (hendelse.grupperingsid != null && hendelse.merkelapp != null) {
+                    database.nonTransactionalExecuteUpdate(
+                        """
                         update notifikasjon
                         set soft_deleted_tidspunkt = ?
                         where grupperingsid = ?
                         and merkelapp = ?
-                    """) {
+                    """
+                    ) {
                         instantAsText(metadata.timestamp)
                         text(hendelse.grupperingsid)
                         text(hendelse.merkelapp)
                     }
                 }
-                database.nonTransactionalExecuteUpdate("""
+                database.nonTransactionalExecuteUpdate(
+                    """
                     update notifikasjon
                     set soft_deleted_tidspunkt = ?
                     where notifikasjon_id = ?
-                """) {
+                """
+                ) {
                     instantAsText(metadata.timestamp)
                     uuid(hendelse.aggregateId)
                 }
-                database.nonTransactionalExecuteUpdate("""
+                database.nonTransactionalExecuteUpdate(
+                    """
                     update sak 
                     set soft_deleted_tidspunkt = ?
                     where sak_id = ?
-                """) {
+                """
+                ) {
                     instantAsText(metadata.timestamp)
                     uuid(hendelse.aggregateId)
                 }
@@ -364,32 +389,40 @@ class DataproduktModel(
 
             is HardDelete -> {
                 database.transaction {
-                    if (hendelse.grupperingsid != null && hendelse.merkelapp != null){
-                        executeUpdate("""
+                    if (hendelse.grupperingsid != null && hendelse.merkelapp != null) {
+                        executeUpdate(
+                            """
                             delete from notifikasjon
                             where grupperingsid = ?
                             and merkelapp = ?
-                        """) {
+                        """
+                        ) {
                             text(hendelse.grupperingsid)
                             text(hendelse.merkelapp)
                         }
                     }
-                    executeUpdate("""
+                    executeUpdate(
+                        """
                         delete from notifikasjon
                         where notifikasjon_id = ?
-                    """) {
+                    """
+                    ) {
                         uuid(hendelse.aggregateId)
                     }
-                    executeUpdate("""
+                    executeUpdate(
+                        """
                         delete from sak 
                         where sak_id = ?
-                    """) {
+                    """
+                    ) {
                         uuid(hendelse.aggregateId)
                     }
-                    executeUpdate("""
+                    executeUpdate(
+                        """
                         delete from aggregat_hendelse
                         where aggregat_id = ?
-                    """) {
+                    """
+                    ) {
                         uuid(hendelse.aggregateId)
                     }
                     registrerHardDelete(this, hendelse)
@@ -429,8 +462,14 @@ class DataproduktModel(
                             utregnetTidspunkt = ScheduledTime(hardDelete, metadata.timestamp).happensAt(),
                         )
                     }
+                    storeMottakere(
+                        notifikasjonId = null,
+                        sakId = sakId,
+                        mottakere = mottakere,
+                    )
                 }
             }
+
             is NyStatusSak -> {
                 database.nonTransactionalExecuteUpdate(
                     """
@@ -459,20 +498,26 @@ class DataproduktModel(
                             bestillingType = "STATUSENDRING",
                             strategi = hardDelete.strategi.toString(),
                             spesifikasjon = hardDelete.nyTid,
-                            utregnetTidspunkt = ScheduledTime(hardDelete.nyTid, opprettetTidspunkt.toInstant()).happensAt(),
+                            utregnetTidspunkt = ScheduledTime(
+                                hardDelete.nyTid,
+                                opprettetTidspunkt.toInstant()
+                            ).happensAt(),
                         )
                     }
                 }
             }
+
             is FristUtsatt -> {
-                database.nonTransactionalExecuteUpdate("""
+                database.nonTransactionalExecuteUpdate(
+                    """
                     update notifikasjon
                     set frist = ?,
                         paaminnelse_bestilling_spesifikasjon_type = ?,
                         paaminnelse_bestilling_spesifikasjon_tid = ?,
                         paaminnelse_bestilling_utregnet_tid = ?
                     where notifikasjon_id = ?
-                """) {
+                """
+                ) {
                     date(hendelse.frist)
                     setPåminnelseFelter(hendelse.påminnelse)
                     uuid(hendelse.notifikasjonId)
@@ -491,22 +536,26 @@ class DataproduktModel(
             }
 
             is TilleggsinformasjonSak -> {
-                database.nonTransactionalExecuteUpdate("""
+                database.nonTransactionalExecuteUpdate(
+                    """
                     update sak
                     set tilleggsinformasjon = ?
                     where sak_id = ?
-                """.trimIndent()) {
+                """.trimIndent()
+                ) {
                     nullableText(hendelse.tilleggsinformasjon)
                     uuid(hendelse.sakId)
                 }
             }
 
             is NesteStegSak -> {
-                database.nonTransactionalExecuteUpdate("""
+                database.nonTransactionalExecuteUpdate(
+                    """
                     update sak
                     set neste_steg = ?
                     where sak_id = ?
-                """.trimIndent()) {
+                """.trimIndent()
+                ) {
                     nullableText(hendelse.nesteSteg)
                     uuid(hendelse.sakId)
                 }
@@ -639,7 +688,8 @@ class DataproduktModel(
                     opprettVarselBestilling(
                         notifikasjonId = hendelse.notifikasjonId,
                         produsentId = hendelse.produsentId,
-                        merkelapp = hendelse.merkelapp ?: "?",  // bakoverkompabilitet, glemte å legge til merkelapp før hendelser ble registrert i dev
+                        merkelapp = hendelse.merkelapp
+                            ?: "?",  // bakoverkompabilitet, glemte å legge til merkelapp før hendelser ble registrert i dev
                         eksterneVarsler = hendelse.påminnelse.eksterneVarsler,
                         opprinnelse = "OppgavePåminnelseEndret.påminnelse",
                         statusUtsending = "UTSENDING_IKKE_AVGJORT",
@@ -727,7 +777,8 @@ class DataproduktModel(
         spesifikasjon: HendelseModel.LocalDateTimeOrDuration,
         utregnetTidspunkt: Instant,
     ) {
-        database.nonTransactionalExecuteUpdate("""
+        database.nonTransactionalExecuteUpdate(
+            """
             insert into hard_delete_bestilling
             (
                 aggregat_id,
@@ -739,7 +790,8 @@ class DataproduktModel(
             )
             values (?, ?, ?, ?, ?, ?)
             on conflict do nothing
-        """) {
+        """
+        ) {
             uuid(aggregatId)
             text(bestillingType)
             uuid(bestillingHendelsesid)
@@ -750,32 +802,55 @@ class DataproduktModel(
     }
 
     private suspend fun storeMottakere(notifikasjonId: UUID?, sakId: UUID?, mottakere: List<Mottaker>) {
-        database.nonTransactionalExecuteBatch("""
-            insert into mottaker_naermeste_leder (sak_id, notifikasjon_id, virksomhetsnummer, fnr_leder, fnr_ansatt)
-            values (?, ?, ?, ?, ?)
-            on conflict do nothing
-        """,
-            mottakere.filterIsInstance<NærmesteLederMottaker>()
-        ) {
-            nullableUuid(sakId)
-            nullableUuid(notifikasjonId)
-            text(it.virksomhetsnummer)
-            text(it.naermesteLederFnr)
-            text(it.ansattFnr)
-        }
+        mottakere.forEach {
+            when (it) {
+                is AltinnMottaker -> {
+                    database.nonTransactionalExecuteUpdate(
+                        """
+                            insert into mottaker_enkeltrettighet (sak_id, notifikasjon_id, virksomhetsnummer, service_code, service_edition)
+                            values (?, ?, ?, ?, ?)
+                            on conflict do nothing
+                        """
+                    ) {
+                        nullableUuid(sakId)
+                        nullableUuid(notifikasjonId)
+                        text(it.virksomhetsnummer)
+                        text(it.serviceCode)
+                        text(it.serviceEdition)
+                    }
+                }
 
-        database.nonTransactionalExecuteBatch("""
-            insert into mottaker_enkeltrettighet (sak_id, notifikasjon_id, virksomhetsnummer, service_code, service_edition)
-            values (?, ?, ?, ?, ?)
-            on conflict do nothing
-        """,
-            mottakere.filterIsInstance<AltinnMottaker>()
-        ) {
-            nullableUuid(sakId)
-            nullableUuid(notifikasjonId)
-            text(it.virksomhetsnummer)
-            text(it.serviceCode)
-            text(it.serviceEdition)
+                is NærmesteLederMottaker -> {
+                    database.nonTransactionalExecuteUpdate(
+                        """
+                            insert into mottaker_naermeste_leder (sak_id, notifikasjon_id, virksomhetsnummer, fnr_leder, fnr_ansatt)
+                            values (?, ?, ?, ?, ?)
+                            on conflict do nothing
+                        """
+                    ) {
+                        nullableUuid(sakId)
+                        nullableUuid(notifikasjonId)
+                        text(it.virksomhetsnummer)
+                        text(it.naermesteLederFnr)
+                        text(it.ansattFnr)
+                    }
+                }
+
+                is HendelseModel.AltinnRessursMottaker -> {
+                    database.nonTransactionalExecuteUpdate(
+                        """
+                            insert into mottaker_altinn_ressurs (sak_id, notifikasjon_id, virksomhetsnummer, ressursid)
+                            values (?, ?, ?, ?)
+                            on conflict do nothing
+                        """
+                    ) {
+                        nullableUuid(sakId)
+                        nullableUuid(notifikasjonId)
+                        text(it.virksomhetsnummer)
+                        text(it.ressursId)
+                    }
+                }
+            }
         }
     }
 
@@ -831,6 +906,7 @@ class DataproduktModel(
                         text(statusUtsending)
                     }
                 }
+
                 is SmsVarselKontaktinfo -> {
                     with(eksterntVarsel) {
                         uuid(varselId)
@@ -869,7 +945,8 @@ class DataproduktModel(
             }
         }
 
-        database.nonTransactionalExecuteBatch("""
+        database.nonTransactionalExecuteBatch(
+            """
             insert into ekstern_varsel_mottaker_tlf(varsel_id, tlf) 
             values (?, ?)
             on conflict do nothing
@@ -880,7 +957,8 @@ class DataproduktModel(
             text(it.tlfnr)
         }
 
-        database.nonTransactionalExecuteBatch("""
+        database.nonTransactionalExecuteBatch(
+            """
             insert into ekstern_varsel_mottaker_epost (varsel_id, epost) 
             values (?, ?)
             on conflict do nothing
@@ -891,7 +969,8 @@ class DataproduktModel(
             text(it.epostAddr)
         }
 
-        database.nonTransactionalExecuteBatch("""
+        database.nonTransactionalExecuteBatch(
+            """
             insert into ekstern_varsel_mottaker_tjeneste (varsel_id, tjenestekode, tjenesteversjon) 
             values (?, ?, ?)
             on conflict do nothing

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/HardDeletedRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/HardDeletedRepository.kt
@@ -10,7 +10,35 @@ open class HardDeletedRepository(private val database: Database) {
             select * from hard_deleted_aggregates where aggregate_id = ?
             """,
             { uuid(aggregateId) }
+        ) {}.isNotEmpty() || erCascadeHardDeleted(aggregateId)
+
+    private suspend fun erCascadeHardDeleted(notifikasjonId: UUID) =
+        database.nonTransactionalExecuteQuery("""
+            select * from hard_delete_sak_til_notifikasjon_kobling
+             inner join hard_deleted_aggregates on hard_delete_sak_til_notifikasjon_kobling.sak_id = hard_deleted_aggregates.aggregate_id 
+            where hard_delete_sak_til_notifikasjon_kobling.aggregate_id = ?
+            """,
+            { uuid(notifikasjonId) }
         ) {}.isNotEmpty()
+
+    /**
+     * her lagres kobling mellom sak og notifikasjon slik at vi kan vite at en notifikasjon er cascade slettet
+     */
+    suspend fun registrerKoblingForCascadeDelete(hendelse: HendelseModel.AggregatOpprettet) {
+        val sakId = hendelse.sakId
+
+        // hopp over hvis sakId er null eller hvis det er opprettelse av sak
+        if (sakId != null && sakId != hendelse.aggregateId) {
+            database.nonTransactionalExecuteUpdate("""
+                insert into hard_delete_sak_til_notifikasjon_kobling(sak_id, aggregate_id) values (?, ?)
+                on conflict do nothing
+            """) {
+                uuid(sakId)
+                uuid(hendelse.aggregateId)
+            }
+        }
+
+    }
 
     fun registrerHardDelete(tx: Transaction, hendelse: HendelseModel.Hendelse) {
         if (hendelse !is HendelseModel.HardDelete) {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/HardDeletedRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/HardDeletedRepository.kt
@@ -16,7 +16,7 @@ open class HardDeletedRepository(private val database: Database) {
         database.nonTransactionalExecuteQuery("""
             select * from hard_delete_sak_til_notifikasjon_kobling
              inner join hard_deleted_aggregates on hard_delete_sak_til_notifikasjon_kobling.sak_id = hard_deleted_aggregates.aggregate_id 
-            where hard_delete_sak_til_notifikasjon_kobling.aggregate_id = ?
+            where hard_delete_sak_til_notifikasjon_kobling.notifikasjon_id = ?
             """,
             { uuid(notifikasjonId) }
         ) {}.isNotEmpty()
@@ -30,7 +30,7 @@ open class HardDeletedRepository(private val database: Database) {
         // hopp over hvis sakId er null eller hvis det er opprettelse av sak
         if (sakId != null && sakId != hendelse.aggregateId) {
             database.nonTransactionalExecuteUpdate("""
-                insert into hard_delete_sak_til_notifikasjon_kobling(sak_id, aggregate_id) values (?, ?)
+                insert into hard_delete_sak_til_notifikasjon_kobling(sak_id, notifikasjon_id) values (?, ?)
                 on conflict do nothing
             """) {
                 uuid(sakId)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
@@ -28,6 +28,13 @@ object HendelseModel {
 
     }
 
+    sealed class AggregatOpprettet : Hendelse() {
+        abstract val sakId: UUID? // P.T. er sak ikke påkrevd, så denne må være nullable
+
+        abstract val grupperingsid: String?
+        abstract val merkelapp: String
+    }
+
     data class HendelseMetadata(
         val timestamp: Instant
     ) {
@@ -345,17 +352,17 @@ object HendelseModel {
         override val hendelseId: UUID,
         override val produsentId: String,
         override val kildeAppNavn: String,
-        val merkelapp: String,
+        override val merkelapp: String,
         val eksternId: String,
         val mottakere: List<Mottaker>,
         val tekst: String,
-        val grupperingsid: String?,
+        override val grupperingsid: String?,
         val lenke: String,
         val opprettetTidspunkt: OffsetDateTime,
         val eksterneVarsler: List<EksterntVarsel>,
         val hardDelete: LocalDateTimeOrDuration?,
-        val sakId: UUID?,
-    ) : Hendelse(), Notifikasjon {
+        override val sakId: UUID?,
+    ) : AggregatOpprettet(), Notifikasjon {
         init {
             requireGraphql(mottakere.isNotEmpty()) {
                 "minst 1 mottaker må gis"
@@ -417,19 +424,19 @@ object HendelseModel {
         override val hendelseId: UUID,
         override val produsentId: String,
         override val kildeAppNavn: String,
-        val merkelapp: String,
+        override val merkelapp: String,
         val eksternId: String,
         val mottakere: List<Mottaker>,
         val tekst: String,
-        val grupperingsid: String?,
+        override val grupperingsid: String?,
         val lenke: String,
         val opprettetTidspunkt: OffsetDateTime,
         val eksterneVarsler: List<EksterntVarsel>,
         val hardDelete: LocalDateTimeOrDuration?,
         val frist: LocalDate?,
         val påminnelse: Påminnelse?,
-        val sakId: UUID?,
-    ) : Hendelse(), Notifikasjon {
+        override val sakId: UUID?,
+    ) : AggregatOpprettet(), Notifikasjon {
         init {
             requireGraphql(mottakere.isNotEmpty()) {
                 "minst 1 mottaker må gis"
@@ -490,12 +497,12 @@ object HendelseModel {
         override val hendelseId: UUID,
         override val produsentId: String,
         override val kildeAppNavn: String,
-        val merkelapp: String,
-        val grupperingsid: String,
+        override val merkelapp: String,
+        override val grupperingsid: String,
         val eksternId: String,
         val mottakere: List<Mottaker>,
         val hardDelete: LocalDateTimeOrDuration?,
-        val sakId: UUID,
+        override val sakId: UUID,
         val lenke: String,
         val tekst: String,
         val opprettetTidspunkt: OffsetDateTime,
@@ -506,7 +513,7 @@ object HendelseModel {
         val erDigitalt: Boolean,
         val eksterneVarsler: List<EksterntVarsel>,
         val påminnelse: Påminnelse?,
-    ) : Hendelse(), Notifikasjon {
+    ) : AggregatOpprettet(), Notifikasjon {
         init {
             requireGraphql(mottakere.isNotEmpty()) {
                 "minst 1 mottaker må gis"

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
@@ -258,9 +258,9 @@ object HendelseModel {
         override val produsentId: String,
         override val kildeAppNavn: String,
         override val sakId: UUID,
+        override val grupperingsid: String,
+        override val merkelapp: String,
 
-        val grupperingsid: String,
-        val merkelapp: String,
         val mottakere: List<Mottaker>,
         val tittel: String,
         val tilleggsinformasjon: String?,
@@ -269,7 +269,7 @@ object HendelseModel {
         val mottattTidspunkt: OffsetDateTime?,
         val nesteSteg: String?,
         val hardDelete: LocalDateTimeOrDuration?,
-    ) : Hendelse(), Sak {
+    ) : AggregatOpprettet(), Sak {
         @JsonIgnore
         override val aggregateId: UUID = sakId
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -307,6 +307,9 @@ class ProdusentRepositoryImpl(
         }
 
     override suspend fun oppdaterModellEtterHendelse(hendelse: Hendelse, metadata: HendelseMetadata) {
+        if (hendelse is HendelseModel.AggregatOpprettet) {
+            registrerKoblingForCascadeDelete(hendelse)
+        }
         if (erHardDeleted(hendelse.aggregateId)) {
             log.info("skipping harddeleted event {}", hendelse)
             return

--- a/app/src/main/resources/db/migration/bruker_model/V48__hard_deleted_via_cascade.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V48__hard_deleted_via_cascade.sql
@@ -4,9 +4,9 @@
 create table hard_delete_sak_til_notifikasjon_kobling
 (
     sak_id       uuid not null,
-    aggregate_id uuid not null
+    notifikasjon_id uuid not null
 );
 
 
 create unique index hard_delete_sak_til_notifikasjon_kobling_uniq
-    on hard_delete_sak_til_notifikasjon_kobling (sak_id, aggregate_id)
+    on hard_delete_sak_til_notifikasjon_kobling (sak_id, notifikasjon_id)

--- a/app/src/main/resources/db/migration/bruker_model/V48__hard_deleted_via_cascade.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V48__hard_deleted_via_cascade.sql
@@ -1,0 +1,12 @@
+
+-- denne tabellen er en koblingstabell mellom sak og notifikasjon
+-- det at noe ligger i den betyr ikke at det er slettet, men brukes for å sjekke cascade delete
+create table hard_delete_sak_til_notifikasjon_kobling
+(
+    sak_id       uuid not null,
+    aggregate_id uuid not null
+);
+
+
+create unique index hard_delete_sak_til_notifikasjon_kobling_uniq
+    on hard_delete_sak_til_notifikasjon_kobling (sak_id, aggregate_id)

--- a/app/src/main/resources/db/migration/dataprodukt_model/V17__mottaker_altinn_ressurs.sql
+++ b/app/src/main/resources/db/migration/dataprodukt_model/V17__mottaker_altinn_ressurs.sql
@@ -1,0 +1,17 @@
+create table mottaker_altinn_ressurs
+(
+    sak_id                  uuid references sak (sak_id) on delete cascade,
+    notifikasjon_id         uuid references notifikasjon (notifikasjon_id) on delete cascade,
+    virksomhetsnummer       text not null,
+    virksomhetsnummer_pseud text generated always as (pseudonymize(virksomhetsnummer)) stored,
+    ressursid               text not null
+);
+revoke select (virksomhetsnummer) on mottaker_altinn_ressurs from public;
+
+create unique index mottaker_altinn_ressurs_unique
+    on mottaker_altinn_ressurs (
+                                coalesce(notifikasjon_id, '00000000-00000000-00000000-00000000'),
+                                coalesce(sak_id, '00000000-00000000-00000000-00000000'),
+                                virksomhetsnummer,
+                                ressursid
+        );

--- a/app/src/main/resources/db/migration/dataprodukt_model/V18__hard_deleted_via_cascade.sql
+++ b/app/src/main/resources/db/migration/dataprodukt_model/V18__hard_deleted_via_cascade.sql
@@ -4,9 +4,9 @@
 create table hard_delete_sak_til_notifikasjon_kobling
 (
     sak_id       uuid not null,
-    aggregate_id uuid not null
+    notifikasjon_id uuid not null
 );
 
 
 create unique index hard_delete_sak_til_notifikasjon_kobling_uniq
-    on hard_delete_sak_til_notifikasjon_kobling (sak_id, aggregate_id)
+    on hard_delete_sak_til_notifikasjon_kobling (sak_id, notifikasjon_id)

--- a/app/src/main/resources/db/migration/dataprodukt_model/V18__hard_deleted_via_cascade.sql
+++ b/app/src/main/resources/db/migration/dataprodukt_model/V18__hard_deleted_via_cascade.sql
@@ -1,0 +1,12 @@
+
+-- denne tabellen er en koblingstabell mellom sak og notifikasjon
+-- det at noe ligger i den betyr ikke at det er slettet, men brukes for å sjekke cascade delete
+create table hard_delete_sak_til_notifikasjon_kobling
+(
+    sak_id       uuid not null,
+    aggregate_id uuid not null
+);
+
+
+create unique index hard_delete_sak_til_notifikasjon_kobling_uniq
+    on hard_delete_sak_til_notifikasjon_kobling (sak_id, aggregate_id)

--- a/app/src/main/resources/db/migration/produsent_model/V29__hard_deleted_via_cascade.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V29__hard_deleted_via_cascade.sql
@@ -4,9 +4,9 @@
 create table hard_delete_sak_til_notifikasjon_kobling
 (
     sak_id       uuid not null,
-    aggregate_id uuid not null
+    notifikasjon_id uuid not null
 );
 
 
 create unique index hard_delete_sak_til_notifikasjon_kobling_uniq
-    on hard_delete_sak_til_notifikasjon_kobling (sak_id, aggregate_id)
+    on hard_delete_sak_til_notifikasjon_kobling (sak_id, notifikasjon_id)

--- a/app/src/main/resources/db/migration/produsent_model/V29__hard_deleted_via_cascade.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V29__hard_deleted_via_cascade.sql
@@ -1,0 +1,12 @@
+
+-- denne tabellen er en koblingstabell mellom sak og notifikasjon
+-- det at noe ligger i den betyr ikke at det er slettet, men brukes for å sjekke cascade delete
+create table hard_delete_sak_til_notifikasjon_kobling
+(
+    sak_id       uuid not null,
+    aggregate_id uuid not null
+);
+
+
+create unique index hard_delete_sak_til_notifikasjon_kobling_uniq
+    on hard_delete_sak_til_notifikasjon_kobling (sak_id, aggregate_id)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt
@@ -1,11 +1,18 @@
 package no.nav.arbeidsgiver.notifikasjon.bruker
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.scopes.DescribeSpecContainerScope
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.kafka_reaper.typeNavn
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
+import no.nav.arbeidsgiver.notifikasjon.util.asMap
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import no.nav.arbeidsgiver.notifikasjon.util.uuid
+import java.time.OffsetDateTime
+import java.util.*
 
 class BrukerModelIdempotensTests : DescribeSpec({
 
@@ -26,7 +33,8 @@ class BrukerModelIdempotensTests : DescribeSpec({
         brukerRepository.oppdaterModellEtterHendelse(EksempelHendelse.BeskjedOpprettet)
 
         it("ingen duplikat mottaker") {
-            val antallMottakere = database.nonTransactionalExecuteQuery("""
+            val antallMottakere = database.nonTransactionalExecuteQuery(
+                """
             select * from mottaker_altinn_tilgang
             where notifikasjon_id = '${EksempelHendelse.BeskjedOpprettet.notifikasjonId}'
         """
@@ -41,12 +49,112 @@ class BrukerModelIdempotensTests : DescribeSpec({
             context("$i - ${hendelse.typeNavn}") {
                 val database = testDatabase(Bruker.databaseConfig)
                 val brukerRepository = BrukerRepositoryImpl(database)
-                brukerRepository.oppdaterModellEtterHendelse(EksempelHendelse.HardDelete.copy(
-                    virksomhetsnummer = hendelse.virksomhetsnummer,
-                    aggregateId = hendelse.aggregateId,
-                ))
+                brukerRepository.oppdaterModellEtterHendelse(
+                    EksempelHendelse.HardDelete.copy(
+                        virksomhetsnummer = hendelse.virksomhetsnummer,
+                        aggregateId = hendelse.aggregateId,
+                    )
+                )
                 brukerRepository.oppdaterModellEtterHendelse(hendelse)
             }
         }
     }
+
+    describe("hard delete på sak sletter alt og kan replayes") {
+        val database = testDatabase(Bruker.databaseConfig)
+        val brukerRepository = BrukerRepositoryImpl(database)
+        val merkelapp = "idempotenstest"
+        val grupperingsid = "gr-42"
+        val sakId = uuid("42")
+        val notifikasjonId = uuid("314")
+
+        val hendelsesforløp = listOf(
+            brukerRepository.sakOpprettet(
+                sakId = sakId,
+                virksomhetsnummer = TEST_VIRKSOMHET_1,
+                merkelapp = merkelapp,
+                grupperingsid = grupperingsid,
+                mottakere = listOf(TEST_MOTTAKER_1, TEST_MOTTAKER_2),
+            ),
+            brukerRepository.beskjedOpprettet(
+                sakId = sakId,
+                notifikasjonId = notifikasjonId,
+                virksomhetsnummer = TEST_VIRKSOMHET_1,
+                merkelapp = merkelapp,
+                grupperingsid = grupperingsid,
+                mottakere = listOf(TEST_MOTTAKER_1, TEST_MOTTAKER_2),
+            ),
+            HendelseModel.HardDelete(
+                hendelseId = UUID.randomUUID(),
+                virksomhetsnummer = TEST_VIRKSOMHET_1,
+                aggregateId = sakId,
+                produsentId = "",
+                kildeAppNavn = "",
+                deletedAt = OffsetDateTime.now(),
+                grupperingsid = grupperingsid,
+                merkelapp = merkelapp,
+            ).also {
+                brukerRepository.oppdaterModellEtterHendelse(it)
+            }
+        )
+
+        assertDeleted(database, sakId, notifikasjonId, grupperingsid, merkelapp)
+
+        // replay events
+        hendelsesforløp.forEach {
+            brukerRepository.oppdaterModellEtterHendelse(it)
+        }
+
+        assertDeleted(database, sakId, notifikasjonId, grupperingsid, merkelapp)
+
+
+    }
 })
+
+private suspend fun DescribeSpecContainerScope.assertDeleted(
+    database: Database,
+    sakId: UUID,
+    notifikasjonId: UUID,
+    grupperingsid: String,
+    merkelapp: String
+) {
+    it("sak is deleted") {
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from sak where id = '${sakId}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+    }
+
+    it("notifikasjon is deleted") {
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from notifikasjon where grupperingsid = '${grupperingsid}' and merkelapp = '${merkelapp}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+    }
+
+    it("mottaker sak is deleted") {
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from mottaker_altinn_tilgang where sak_id = '${sakId}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+    }
+
+    it("mottaker notifikasjon is deleted") {
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from mottaker_altinn_tilgang where notifikasjon_id = '${notifikasjonId}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+    }
+}

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepositoryTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepositoryTests.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.instanceOf
+import jakarta.xml.bind.JAXBElement
 import kotlinx.coroutines.delay
 import no.altinn.services.common.fault._2009._10.AltinnFault
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
@@ -23,15 +24,14 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.EpostVarselKontak
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SmsVarselKontaktinfo
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.getUuid
+import no.nav.arbeidsgiver.notifikasjon.util.asMap
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
-import java.sql.ResultSet
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.util.*
-import jakarta.xml.bind.JAXBElement
 import javax.xml.namespace.QName
 
 class EksternVarslingRepositoryTests : DescribeSpec({
@@ -735,7 +735,3 @@ class EksternVarslingRepositoryTests : DescribeSpec({
     }
 
 })
-
-private fun ResultSet.asMap() = (1..this.metaData.columnCount).associate {
-    this.metaData.getColumnName(it) to this.getObject(it)
-}

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTests.kt
@@ -19,11 +19,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SmsVarselKontaktinfo
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTid
-import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
-import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
-import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
-import no.nav.arbeidsgiver.notifikasjon.util.uuid
-import java.sql.ResultSet
+import no.nav.arbeidsgiver.notifikasjon.util.*
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
@@ -575,6 +571,3 @@ fun mockOsloTid(mockNow: LocalDateTime) = object : OsloTid {
     override fun localDateNow() = mockNow.toLocalDate()
 }
 
-private fun ResultSet.asMap() = (1..this.metaData.columnCount).associate {
-    this.metaData.getColumnName(it) to this.getObject(it)
-}

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTests.kt
@@ -1,15 +1,23 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.scopes.DescribeSpecContainerScope
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import no.nav.arbeidsgiver.notifikasjon.bruker.TEST_MOTTAKER_1
+import no.nav.arbeidsgiver.notifikasjon.bruker.TEST_MOTTAKER_2
+import no.nav.arbeidsgiver.notifikasjon.bruker.TEST_VIRKSOMHET_1
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.kafka_reaper.typeNavn
 import no.nav.arbeidsgiver.notifikasjon.produsent.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepositoryImpl
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
+import no.nav.arbeidsgiver.notifikasjon.util.asMap
 import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import no.nav.arbeidsgiver.notifikasjon.util.uuid
+import java.time.OffsetDateTime
 import java.util.*
 
 class ProdusentModelIdempotensTests : DescribeSpec({
@@ -80,7 +88,122 @@ class ProdusentModelIdempotensTests : DescribeSpec({
             }
         }
     }
+
+    describe("hard delete på sak sletter alt og kan replayes") {
+        val (database, produsentModel) = setupEngine()
+        val merkelapp = "idempotenstest"
+        val grupperingsid = "gr-42"
+        val sakId = uuid("42")
+        val notifikasjonId = uuid("314")
+
+        val hendelsesforløp = listOf(
+            EksempelHendelse.SakOpprettet.copy(
+                sakId = sakId,
+                virksomhetsnummer = TEST_VIRKSOMHET_1,
+                merkelapp = merkelapp,
+                grupperingsid = grupperingsid,
+                mottakere = listOf(TEST_MOTTAKER_1, TEST_MOTTAKER_2),
+            ).also {
+                produsentModel.oppdaterModellEtterHendelse(it)
+            },
+            EksempelHendelse.BeskjedOpprettet.copy(
+                sakId = sakId,
+                notifikasjonId = notifikasjonId,
+                virksomhetsnummer = TEST_VIRKSOMHET_1,
+                merkelapp = merkelapp,
+                grupperingsid = grupperingsid,
+                mottakere = listOf(TEST_MOTTAKER_1, TEST_MOTTAKER_2),
+            ).also {
+                produsentModel.oppdaterModellEtterHendelse(it)
+            },
+            HendelseModel.HardDelete(
+                hendelseId = UUID.randomUUID(),
+                virksomhetsnummer = TEST_VIRKSOMHET_1,
+                aggregateId = sakId,
+                produsentId = "",
+                kildeAppNavn = "",
+                deletedAt = OffsetDateTime.now(),
+                grupperingsid = grupperingsid,
+                merkelapp = merkelapp,
+            ).also {
+                produsentModel.oppdaterModellEtterHendelse(it)
+            }
+        )
+
+        assertDeleted(database, sakId, notifikasjonId, grupperingsid, merkelapp)
+
+        // replay events
+        hendelsesforløp.forEach {
+            produsentModel.oppdaterModellEtterHendelse(it)
+        }
+
+        assertDeleted(database, sakId, notifikasjonId, grupperingsid, merkelapp)
+
+
+    }
 })
+
+private suspend fun DescribeSpecContainerScope.assertDeleted(
+    database: Database,
+    sakId: UUID,
+    notifikasjonId: UUID,
+    grupperingsid: String,
+    merkelapp: String
+) {
+    it("sak is deleted") {
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from sak where id = '${sakId}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+    }
+
+    it("notifikasjon is deleted") {
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from notifikasjon where grupperingsid = '${grupperingsid}' and merkelapp = '${merkelapp}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+    }
+
+    it("mottaker sak is deleted") {
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from mottaker_altinn_enkeltrettighet where notifikasjon_id = '${sakId}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from mottaker_altinn_ressurs where notifikasjon_id = '${sakId}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+    }
+
+    it("mottaker notifikasjon is deleted") {
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from mottaker_altinn_enkeltrettighet where notifikasjon_id = '${notifikasjonId}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+        database.nonTransactionalExecuteQuery(
+            """
+                select * from mottaker_altinn_ressurs where notifikasjon_id = '${notifikasjonId}'
+            """
+        ) {
+            asMap()
+        }.size shouldBe 0
+    }
+}
 
 private fun DescribeSpec.setupEngine(): Pair<Database, ProdusentRepositoryImpl> {
     val database = testDatabase(Produsent.databaseConfig)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/Utils.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/Utils.kt
@@ -1,0 +1,7 @@
+package no.nav.arbeidsgiver.notifikasjon.util
+
+import java.sql.ResultSet
+
+fun ResultSet.asMap() = (1..this.metaData.columnCount).associate {
+    this.metaData.getColumnName(it) to this.getObject(it)
+}

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -60,7 +60,7 @@ resource "google_bigquery_data_transfer_config" "notifikasjon" {
   data_source_id         = "scheduled_query"
   display_name           = "notifikasjon"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.notifikasjon.table_id
@@ -119,7 +119,7 @@ resource "google_bigquery_data_transfer_config" "aggregat_hendelse" {
   data_source_id         = "scheduled_query"
   display_name           = "aggregat_hendelse"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.aggregat_hendelse.table_id
@@ -160,7 +160,7 @@ resource "google_bigquery_data_transfer_config" "sak" {
   data_source_id         = "scheduled_query"
   display_name           = "sak"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.sak.table_id
@@ -205,7 +205,7 @@ resource "google_bigquery_data_transfer_config" "sak_status" {
   data_source_id         = "scheduled_query"
   display_name           = "sak_status"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.sak_status.table_id
@@ -248,7 +248,7 @@ resource "google_bigquery_data_transfer_config" "hard_delete_bestilling" {
   data_source_id         = "scheduled_query"
   display_name           = "hard_delete_bestilling"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.hard_delete_bestilling.table_id
@@ -287,7 +287,7 @@ resource "google_bigquery_data_transfer_config" "mottaker_naermeste_leder" {
   data_source_id         = "scheduled_query"
   display_name           = "mottaker_naermeste_leder"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.mottaker_naermeste_leder.table_id
@@ -324,7 +324,7 @@ resource "google_bigquery_data_transfer_config" "mottaker_enkeltrettighet" {
   data_source_id         = "scheduled_query"
   display_name           = "mottaker_enkeltrettighet"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.mottaker_enkeltrettighet.table_id
@@ -361,7 +361,7 @@ resource "google_bigquery_data_transfer_config" "notifikasjon_klikk" {
   data_source_id         = "scheduled_query"
   display_name           = "notifikasjon_klikk"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.notifikasjon_klikk.table_id
@@ -396,7 +396,7 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel" {
   data_source_id         = "scheduled_query"
   display_name           = "ekstern_varsel"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.ekstern_varsel.table_id
@@ -455,7 +455,7 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel_mottaker_tlf" {
   data_source_id         = "scheduled_query"
   display_name           = "ekstern_varsel_mottaker_tlf"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.ekstern_varsel_mottaker_tlf.table_id
@@ -486,7 +486,7 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel_mottaker_epost" 
   data_source_id         = "scheduled_query"
   display_name           = "ekstern_varsel_mottaker_epost"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.ekstern_varsel_mottaker_epost.table_id
@@ -517,7 +517,7 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel_resultat" {
   data_source_id         = "scheduled_query"
   display_name           = "ekstern_varsel_resultat"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.ekstern_varsel_resultat.table_id
@@ -552,7 +552,7 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel_mottaker_tjenest
   data_source_id         = "scheduled_query"
   display_name           = "ekstern_varsel_mottaker_tjeneste"
   location               = var.region
-  schedule               = "every day 00:00"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.ekstern_varsel_mottaker_tjeneste.table_id


### PR DESCRIPTION
fikser bug der replay fører til at notifikasjoner som er hard delete via cascade fra sak gjennoppstår.

fikser: https://trello.com/c/8IgQTllr/117-feil-rundt-harddelete-og-kafka-replay-i-brukerapi