### PR TITLE
WIP forslag til workaround

### DIFF
--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepositorySearchTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepositorySearchTest.kt
@@ -119,8 +119,8 @@ private suspend fun BrukerRepositoryImpl.insertSak(id: String, tekst: String) {
         mottattTidspunkt = OffsetDateTime.now(),
     )
     nyStatusSak(
-        sak = sak,
-        virksomhetsnummer = "1",
+        sakId = sak.sakId,
+        virksomhetsnummer = sak.virksomhetsnummer,
         status = HendelseModel.SakStatus.MOTTATT,
         overstyrStatustekstMed = null,
         mottattTidspunkt = OffsetDateTime.now(),

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/Common.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/Common.kt
@@ -12,6 +12,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveUtgått
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Påminnelse
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakStatus
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnTilgang
+import no.nav.arbeidsgiver.notifikasjon.produsent.api.IdempotenceKey
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -416,12 +417,42 @@ suspend fun BrukerRepository.nyStatusSak(
     idempotensKey: String,
     hardDelete: HardDeleteUpdate? = null,
     nyLenkeTilSak: String? = null,
-) = NyStatusSak(
+) = nyStatusSak(
     hendelseId = hendelseId,
     virksomhetsnummer = virksomhetsnummer,
     produsentId = produsentId,
     kildeAppNavn = kildeAppNavn,
     sakId = sak.sakId,
+    status = status,
+    overstyrStatustekstMed = overstyrStatustekstMed,
+    oppgittTidspunkt = oppgittTidspunkt,
+    mottattTidspunkt = mottattTidspunkt,
+    idempotensKey = idempotensKey,
+    hardDelete = hardDelete,
+    nyLenkeTilSak = nyLenkeTilSak,
+).also {
+    oppdaterModellEtterHendelse(it)
+}
+
+suspend fun BrukerRepository.nyStatusSak(
+    sakId: UUID,
+    virksomhetsnummer: String,
+    hendelseId: UUID = UUID.randomUUID(),
+    produsentId: String = randomProdusentId(),
+    kildeAppNavn: String = randomKildeAppNavn(),
+    status: SakStatus = randomSakStatus(),
+    overstyrStatustekstMed: String? = null,
+    oppgittTidspunkt: OffsetDateTime? = null,
+    mottattTidspunkt: OffsetDateTime = OffsetDateTime.now(),
+    idempotensKey: String = IdempotenceKey.initial(),
+    hardDelete: HardDeleteUpdate? = null,
+    nyLenkeTilSak: String? = null,
+) = NyStatusSak(
+    hendelseId = hendelseId,
+    virksomhetsnummer = virksomhetsnummer,
+    produsentId = produsentId,
+    kildeAppNavn = kildeAppNavn,
+    sakId = sakId,
     status = status,
     overstyrStatustekstMed = overstyrStatustekstMed,
     oppgittTidspunkt = oppgittTidspunkt,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/HardDeleteTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/HardDeleteTests.kt
@@ -110,10 +110,10 @@ class HardDeleteTests : DescribeSpec({
             virksomhetsnummer = mottaker.virksomhetsnummer,
         )
         suspend fun opprettStatusEvent(sak: HendelseModel.SakOpprettet) = brukerRepository.nyStatusSak(
-            sak,
-            virksomhetsnummer = mottaker.virksomhetsnummer,
-            idempotensKey = IdempotenceKey.initial(),
+            sakId = sak.sakId,
+            virksomhetsnummer = sak.virksomhetsnummer,
             status = HendelseModel.SakStatus.MOTTATT,
+            idempotensKey = IdempotenceKey.initial(),
         )
 
         val hardDeleteEvent = HardDelete(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NyLenkeTilSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/NyLenkeTilSakTests.kt
@@ -42,7 +42,8 @@ class NyLenkeTilSakTests : DescribeSpec({
         )
 
         brukerRepository.nyStatusSak(
-            sak = sakOpprettet,
+            sakId = sakOpprettet.sakId,
+            virksomhetsnummer = sakOpprettet.virksomhetsnummer,
             idempotensKey = IdempotenceKey.initial(),
         )
 
@@ -51,7 +52,8 @@ class NyLenkeTilSakTests : DescribeSpec({
         }
 
         brukerRepository.nyStatusSak(
-            sak = sakOpprettet,
+            sakId = sakOpprettet.sakId,
+            virksomhetsnummer = sakOpprettet.virksomhetsnummer,
             idempotensKey = IdempotenceKey.userSupplied("20202021"),
             nyLenkeTilSak = "#bar",
             oppgittTidspunkt = OffsetDateTime.parse("2020-01-01T12:00:00Z"),
@@ -66,7 +68,8 @@ class NyLenkeTilSakTests : DescribeSpec({
         }
 
         brukerRepository.nyStatusSak(
-            sak = sakOpprettet,
+            sakId = sakOpprettet.sakId,
+            virksomhetsnummer = sakOpprettet.virksomhetsnummer,
             idempotensKey = IdempotenceKey.userSupplied("123"),
             nyLenkeTilSak = null,
         )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerAntallMerkelapperTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerAntallMerkelapperTests.kt
@@ -141,16 +141,16 @@ private suspend fun BrukerRepository.opprettSak(
         tilleggsinformasjon = null
     )
     nyStatusSak(
-        sak = sak,
-        hendelseId = UUID.randomUUID(),
+        sakId = sak.sakId,
         virksomhetsnummer = sak.virksomhetsnummer,
+        hendelseId = UUID.randomUUID(),
         produsentId = sak.produsentId,
         kildeAppNavn = sak.kildeAppNavn,
         status = MOTTATT,
         overstyrStatustekstMed = "noe",
+        oppgittTidspunkt = null,
         mottattTidspunkt = oppgittTidspunkt,
         idempotensKey = IdempotenceKey.initial(),
-        oppgittTidspunkt = null,
         hardDelete = null,
         nyLenkeTilSak = null,
     )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerFristTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerFristTests.kt
@@ -249,9 +249,9 @@ private suspend fun BrukerRepository.opprettSak(
         tilleggsinformasjon = null
     )
     nyStatusSak(
-        sak = sakOpprettet,
-        hendelseId = UUID.randomUUID(),
+        sakId = sakOpprettet.sakId,
         virksomhetsnummer = sakOpprettet.virksomhetsnummer,
+        hendelseId = UUID.randomUUID(),
         produsentId = sakOpprettet.produsentId,
         kildeAppNavn = sakOpprettet.kildeAppNavn,
         status = MOTTATT,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakMedOppgaverMedFristMedPaaminnelseTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakMedOppgaverMedFristMedPaaminnelseTests.kt
@@ -77,9 +77,9 @@ private suspend fun BrukerRepository.opprettSak(
         hardDelete = null,
     ).let { sakOpprettet ->
         nyStatusSak(
-            sakOpprettet,
+            sakOpprettet.sakId,
+            sakOpprettet.virksomhetsnummer,
             hendelseId = UUID.randomUUID(),
-            virksomhetsnummer = "1",
             produsentId = "1",
             kildeAppNavn = "1",
             status = HendelseModel.SakStatus.MOTTATT,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakerMedOppgaveTilstandTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakerMedOppgaveTilstandTests.kt
@@ -181,9 +181,9 @@ private suspend fun BrukerRepository.opprettOppgave(
 )
 
 private suspend fun BrukerRepository.opprettStatus(sak: HendelseModel.SakOpprettet) = nyStatusSak(
-    sak = sak,
+    sakId = sak.sakId,
+    virksomhetsnummer = sak.virksomhetsnummer,
     hendelseId = UUID.randomUUID(),
-    virksomhetsnummer = "1",
     produsentId = "1",
     kildeAppNavn = "1",
     status = HendelseModel.SakStatus.MOTTATT,


### PR DESCRIPTION
Som jeg skriver i koden så er det en caveat her at vi ikke vet at grunnen til at vi hopper over er at det har vært en softdelete.
Det kan i teorien åpne opp for at vi hopper over statuser hvor det er andre underliggende feil som gjør at saken ikke finnes. Ganske sikker på at dette er mer teoretisk mulighet enn et reelt problem. Uansett en risiko man påtar seg ved å løse det på denne måten.

Edit:
En alternativ løsning kan være å utvide "HardDeleteRepository" til å også håndtere SoftDeletes. Og kanskje gi den et annet navn (e.g. DeleteRepository).  Dermed blir eneste endring på hard og soft delete at det faktisk tombstones hendelser på kafka. Er nok ikke så mye mer jobb enn det som ligger på denne PR, og så er det mye tryggere mtp caveat over.

--

På lang sikt må vi gjøre noe med Soft og Hard delete. Forskjellen mellom disse fortsetter å skape problemer. 
De to beste alternativene i mitt hode er som følger:

1. fjerne softdelete til fordel for harddelete. 
    1. I praksis endre tolkning av SoftDelete eventet til å bety det samme som hard delete og fjerne det som egen mutasjon. 
    1. Krever at vi snakker med team som bruker softdelete og får dem med på løsningen.
1. aligne soft delete og hard delete slik at de fungerer likt med unntak av tombstones på kafka
   1. samme mekanismer for cascade delte og holde styr på hva som er slettet (re harddeleterepo)
   1. dersom vi går for denne må vi 
       1. ha tydelig for oss hvorfor softdelete bør brukes, forstå selv når det gir mening å bruke den
       1. dokumentere tydelig når softdelete gir mening, og når harddelete gir mening. Forskjellene på dem osv. 

Test som reproduserer feilen: 
* [app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModelIdempotensTests.kt](https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/800/files#diff-54989f367c4c336db9925c4273f25d6bdfc3ef5973569a60e3f802d446cfc5b4)

"Fiks": 
* https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/800/files#diff-85b7da68b11f99e81cb1aeaf3d30a83f20730665dd32c4ca5cb6fdb7383fffe9
