### PR TITLE
assign repository før service legges til i processors

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidator.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidator.kt
@@ -1,6 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon.replay_validator
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
@@ -10,6 +11,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionAwareHendel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.launchProcessingLoop
 import java.time.Duration
 import kotlin.collections.set
+import kotlin.time.Duration.Companion.seconds
 
 object ReplayValidator {
     private val services = mutableListOf<ReplayValidatorService>()
@@ -31,6 +33,7 @@ object ReplayValidator {
 
             launchProcessingLoop(
                 "replay-validator-update-gauge",
+                init = { delay(10.seconds) },
                 pauseAfterEach = Duration.ofMinutes(1),
             ) {
                 services.toList().forEach(ReplayValidatorService::updateMetrics)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidatorService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidatorService.kt
@@ -17,13 +17,16 @@ class ReplayValidatorService(
     private val processors: MutableList<ReplayValidatorService>
 ) : PartitionProcessor {
 
-    init {
-        processors.add(this)
-    }
-
     private val log = logger()
 
-    internal val repository = ReplayValidatorRepository()
+    internal val repository: ReplayValidatorRepository
+
+    init {
+        ReplayValidatorRepository().also {
+            repository = it
+        }
+        processors.add(this)
+    }
 
     override fun close() {
         processors.remove(this)


### PR DESCRIPTION
i noen tilfeller blir service metrikk pollet før repoet faktisk var instansiert. Dette medførte en nullpointer.
Endrer koden slik at det blir litt mer tydelig at intensjonen er at repoet skal være instansiert før service er klar til prosessering.

```
java.lang.NullPointerException: Cannot invoke "no.nav.arbeidsgiver.notifikasjon.replay_validator.ReplayValidatorRepository.findNotifikasjonCreatesAfterHardDeleteSak()" because "this.repository" is null
	at no.nav.arbeidsgiver.notifikasjon.replay_validator.ReplayValidatorService.updateMetrics(ReplayValidatorService.kt:93)
	at no.nav.arbeidsgiver.notifikasjon.replay_validator.ReplayValidator$main$1$2.invokeSuspend(ReplayValidator.kt:36)
	at no.nav.arbeidsgiver.notifikasjon.replay_validator.ReplayValidator$main$1$2.invoke(ReplayValidator.kt)
	at no.nav.arbeidsgiver.notifikasjon.replay_validator.ReplayValidator$main$1$2.invoke(ReplayValidator.kt)
	at no.nav.arbeidsgiver.notifikasjon.infrastruktur.ProcessingLoopKt$launchProcessingLoop$2.invokeSuspend(ProcessingLoop.kt:27)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:811)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:715)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
```