### PR TITLE
propager appname til mdc

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -16,6 +16,7 @@ import io.micrometer.core.instrument.Timer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.future
+import kotlinx.coroutines.slf4j.MDCContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics.meterRegistry
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.coRecord
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.getTimer
@@ -68,7 +69,7 @@ fun <T> TypeRuntimeWiring.Builder.coDataFetcher(
         .register(meterRegistry)
     dataFetcher(fieldName) { env ->
         val ctx = env.notifikasjonContext<WithCoroutineScope>()
-        ctx.coroutineScope.future(Dispatchers.IO) {
+        ctx.coroutineScope.future(Dispatchers.IO + MDCContext()) {
             try {
                 timer.coRecord {
                     fetcher(env)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpAuthProviders.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpAuthProviders.kt
@@ -1,22 +1,21 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.http
 
 import com.auth0.jwk.JwkProviderBuilder
-import com.auth0.jwt.interfaces.Claim
-import com.auth0.jwt.interfaces.DecodedJWT
 import com.auth0.jwt.interfaces.Verification
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import io.ktor.client.*
-import io.ktor.client.call.body
+import io.ktor.client.call.*
 import io.ktor.client.engine.apache.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
 import io.ktor.server.routing.*
 import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.azuread.AzurePreAuthorizedAppsImpl
+import org.slf4j.MDC
 import java.net.URL
 import java.util.concurrent.TimeUnit
 
@@ -24,9 +23,11 @@ data class BrukerPrincipal(
     val fnr: String,
 ) : Principal
 
-data class ProdusentPrincipal(
-    val appName: String,
-) : Principal
+data class ProdusentPrincipal(val appName: String) : Principal {
+    init {
+        MDC.put("preAuthorizedAppName", appName)
+    }
+}
 
 data class JWTAuthentication(
     val name: String,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.binder.logging.LogbackMetrics
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
 import kotlinx.coroutines.*
+import kotlinx.coroutines.slf4j.MDCContext
 import no.nav.arbeidsgiver.notifikasjon.bruker.BrukerAPI
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
@@ -103,7 +104,7 @@ fun <T : WithCoroutineScope> Application.graphqlSetup(
         authenticate(authProviders) {
             route("api") {
                 post("graphql") {
-                    withContext(this.coroutineContext + graphQLDispatcher) {
+                    withContext(this.coroutineContext + graphQLDispatcher + MDCContext()) {
                         val context = extractContext()
                         val request = call.receive<GraphQLRequest>()
                         val result = graphql.await().timedExecute(request, context)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/KalenderavtaleTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/KalenderavtaleTests.kt
@@ -35,7 +35,7 @@ class KalenderavtaleTests : DescribeSpec({
             merkelapp = "tag",
             grupperingsid = grupperingsid,
             mottakere = listOf(
-                HendelseModel.NærmesteLederMottaker(
+                NærmesteLederMottaker(
                     naermesteLederFnr = "12345678910",
                     ansattFnr = "321",
                     virksomhetsnummer = "42"


### PR DESCRIPTION
Denne settes opp i callLogging plugin, men der propageres det ikke. Den blir kun satt på logg kallet til slitt når responsen går ut.

Muligens relevant: https://youtrack.jetbrains.com/issue/KTOR-6862/CallLogging-Auth-principal-isnt-available-in-MDC-entry-provider-since-2.3.8#focus=Comments-27-9679688.0-0

se også denne tråden på slack: https://nav-it.slack.com/archives/C9T4KG12M/p1734687935473459