### PR TITLE
soft delete skal ikke påvirke hard deletes

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteRepositoryImpl.kt
@@ -178,20 +178,11 @@ class SkedulertHardDeleteRepositoryImpl(
                 )
             }
 
-            is HendelseModel.HardDelete,
-            is HendelseModel.SoftDelete ->
+            is HendelseModel.HardDelete ->
                 delete(
                     aggregateId = hendelse.aggregateId,
-                    merkelapp = when (hendelse) {
-                        is HendelseModel.HardDelete -> hendelse.merkelapp
-                        is HendelseModel.SoftDelete -> hendelse.merkelapp
-                        else -> throw IllegalStateException("unexpected event type")
-                    },
-                    grupperingsid = when (hendelse) {
-                        is HendelseModel.HardDelete -> hendelse.grupperingsid
-                        is HendelseModel.SoftDelete -> null
-                        else -> throw IllegalStateException("unexpected event type")
-                    }
+                    merkelapp = hendelse.merkelapp,
+                    grupperingsid = hendelse.grupperingsid,
                 )
 
             is HendelseModel.NesteStegSak,
@@ -202,6 +193,7 @@ class SkedulertHardDeleteRepositoryImpl(
             is HendelseModel.BrukerKlikket,
             is HendelseModel.PåminnelseOpprettet,
             is HendelseModel.FristUtsatt,
+            is HendelseModel.SoftDelete,
             is HendelseModel.OppgavePåminnelseEndret -> Unit
 
         }


### PR DESCRIPTION
Her gjorde jeg en glipp når jeg fikset feilen i skedulert hard delete. Når jeg tok i bruk HardDeletedRepository så gjorde jeg det likt som i produsent api, hvos vi også sjekker soft deletes. DEtte er vanligvis korrekt, men _ikke_ når det gjelder skedulering av hard deletes. Setter derfor tilbake til noop på soft delete.