### PR TITLE
KAlenderavtale støtter AVHOLDT

### DIFF
--- a/app/nais/dev-gcp-skedulert-utgaatt.yaml
+++ b/app/nais/dev-gcp-skedulert-utgaatt.yaml
@@ -25,3 +25,12 @@ spec:
     path: /internal/metrics
   kafka:
     pool: nav-dev
+  gcp:
+    sqlInstances:
+      - type: POSTGRES_17
+        tier: db-f1-micro
+        diskAutoresize: true
+        highAvailability: false
+        databases:
+          - name: skedulert-utgatt-model
+            envVarPrefix: DB

--- a/app/nais/prod-gcp-skedulert-utgaatt.yaml
+++ b/app/nais/prod-gcp-skedulert-utgaatt.yaml
@@ -26,3 +26,12 @@ spec:
     path: /internal/metrics
   kafka:
     pool: nav-prod
+  gcp:
+    sqlInstances:
+      - type: POSTGRES_17
+        tier: db-custom-1-3840
+        diskAutoresize: true
+        highAvailability: false
+        databases:
+          - name: skedulert-utgatt-model
+            envVarPrefix: DB

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
@@ -108,7 +108,8 @@ object BrukerAPI {
                 ARBEIDSGIVER_VIL_AVLYSE,
                 ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED,
                 ARBEIDSGIVER_HAR_GODTATT,
-                AVLYST;
+                AVLYST,
+                AVHOLDT;
 
                 companion object {
                     fun BrukerModel.Kalenderavtale.Tilstand.tilBrukerAPI(): Tilstand = when (this) {
@@ -117,6 +118,7 @@ object BrukerAPI {
                         BrukerModel.Kalenderavtale.Tilstand.ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED -> ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED
                         BrukerModel.Kalenderavtale.Tilstand.ARBEIDSGIVER_HAR_GODTATT -> ARBEIDSGIVER_HAR_GODTATT
                         BrukerModel.Kalenderavtale.Tilstand.AVLYST -> AVLYST
+                        BrukerModel.Kalenderavtale.Tilstand.AVHOLDT -> AVHOLDT
                     }
                 }
             }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerModel.kt
@@ -106,6 +106,7 @@ object BrukerModel {
             ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED,
             ARBEIDSGIVER_HAR_GODTATT,
             AVLYST,
+            AVHOLDT,
         }
     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -786,6 +786,7 @@ class BrukerRepositoryImpl(
             where 
                 n.type = 'KALENDERAVTALE' and
                 n.tilstand != 'AVLYST' and
+                n.tilstand != 'AVHOLDT' and
                 n.start_tidspunkt::timestamp > now() and
                 n.virksomhetsnummer = any(?)
             order by 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelse.kt
@@ -557,6 +557,7 @@ object HendelseModel {
         ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED,
         ARBEIDSGIVER_HAR_GODTATT,
         AVLYST,
+        AVHOLDT,
     }
 
     @JsonTypeName("Lokasjon")

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/local_database/EphemeralDatabase.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/local_database/EphemeralDatabase.kt
@@ -130,6 +130,7 @@ fun ResultSet.getUUID(columnLabel: String): UUID = UUID.fromString(getString(col
 fun ResultSet.getInstant(columnLabel: String): Instant = Instant.parse(getString(columnLabel))
 fun ResultSet.getLocalDate(columnLabel: String): LocalDate = LocalDate.parse(getString(columnLabel))
 fun ResultSet.getLocalDateOrNull(columnLabel: String) = getString(columnLabel)?.let(LocalDate::parse)
+fun ResultSet.getLocalDateTime(columnLabel: String) = LocalDateTime.parse(getString(columnLabel))
 fun ResultSet.getLocalDateTimeOrNull(columnLabel: String) = getString(columnLabel)?.let(LocalDateTime::parse)
 inline fun <reified E: Enum<E>> ResultSet.getEnum(columnLabel: String): E = enumValueOf(getString(columnLabel))
 inline fun <reified A> ResultSet.getJson(columnLabel: String) = ephemeralDatabaseObjectMapper.readValue<A>(getString(columnLabel))

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentModel.kt
@@ -194,6 +194,7 @@ object ProdusentModel {
             ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED,
             ARBEIDSGIVER_HAR_GODTATT,
             AVLYST,
+            AVHOLDT,
         }
 
         override fun erDuplikatAv(other: Notifikasjon): Boolean {
@@ -318,6 +319,7 @@ fun KalenderavtaleOpprettet.tilProdusentModel() =
             KalenderavtaleTilstand.ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED -> ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED
             KalenderavtaleTilstand.ARBEIDSGIVER_HAR_GODTATT -> ARBEIDSGIVER_HAR_GODTATT
             KalenderavtaleTilstand.AVLYST -> AVLYST
+            KalenderavtaleTilstand.AVHOLDT -> AVHOLDT
         },
         deletedAt = null,
         eksterneVarsler = eksterneVarsler.map(EksterntVarsel::tilProdusentModel),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgått.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgått.kt
@@ -1,19 +1,27 @@
 package no.nav.arbeidsgiver.notifikasjon.skedulert_utgått
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.launchHttpServer
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionAwareHendelsesstrøm
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.NOTIFIKASJON_TOPIC
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.lagKafkaHendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.launchProcessingLoop
+import java.time.Duration
 
 object SkedulertUtgått {
+    val databaseConfig = Database.config("skedulert_utgatt_model")
     private val hendelsesstrøm by lazy {
-        PartitionAwareHendelsesstrøm(
-            groupId = "skedulert-utgaatt-1",
-            newPartitionProcessor = { SkedulertUtgåttService(hendelseProdusent = lagKafkaHendelseProdusent()) },
+        HendelsesstrømKafkaImpl(
+            topic = NOTIFIKASJON_TOPIC,
+            groupId = "skedulert-harddelete-model-builder-1",
+            replayPeriodically = true,
         )
     }
 
@@ -21,9 +29,36 @@ object SkedulertUtgått {
         Health.subsystemReady[Subsystem.DATABASE] = true
 
         runBlocking(Dispatchers.Default) {
-            launch {
-                hendelsesstrøm.start()
+            val database = openDatabaseAsync(databaseConfig)
+            val repoAsync = async {
+                SkedulertUtgåttRepository(database.await())
             }
+            launch {
+                val repo = repoAsync.await()
+                hendelsesstrøm.forEach { hendelse, metadata ->
+                    repo.oppdaterModellEtterHendelse(hendelse)
+                }
+            }
+
+            val service = async {
+                SkedulertUtgåttService(
+                    repository = repoAsync.await(),
+                    hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
+                )
+            }
+            launchProcessingLoop(
+                "utgaatt-oppgaver-service",
+                pauseAfterEach = Duration.ofMinutes(1)
+            ) {
+                service.await().settOppgaverUtgåttBasertPåFrist()
+            }
+            launchProcessingLoop(
+                "avholdt-kalenderavtaler-service",
+                pauseAfterEach = Duration.ofMinutes(1)
+            ) {
+                service.await().settKalenderavtalerAvholdtBasertPåTidspunkt()
+            }
+
             launchHttpServer(httpPort = httpPort)
         }
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttService.kt
@@ -1,16 +1,12 @@
 package no.nav.arbeidsgiver.notifikasjon.skedulert_utgått
 
-import kotlinx.coroutines.time.delay
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.NaisEnvironment
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionProcessor
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTid
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTidImpl
-import no.nav.arbeidsgiver.notifikasjon.tid.asOsloLocalDate
 import no.nav.arbeidsgiver.notifikasjon.tid.atOslo
-import java.time.Duration
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -18,99 +14,12 @@ import java.util.*
 
 
 class SkedulertUtgåttService(
+    private val repository: SkedulertUtgåttRepository,
     private val hendelseProdusent: HendelseProdusent,
     private val osloTid: OsloTid = OsloTidImpl
-): PartitionProcessor {
-    private val repository = SkedulertUtgåttRepository()
-
-    override fun close() = repository.close()
-
-    override suspend fun processHendelse(hendelse: HendelseModel.Hendelse, metadata: PartitionHendelseMetadata) {
-        @Suppress("UNUSED_VARIABLE")
-        val ignored = when (hendelse) {
-            is HendelseModel.OppgaveOpprettet -> {
-                /* Vi må huske saks-id uavhengig av om det er frist på oppgaven, for
-                 * det kan komme en frist senere. */
-                if (hendelse.sakId != null) {
-                    repository.huskSakOppgaveKobling(
-                        sakId = hendelse.sakId,
-                        oppgaveId = hendelse.aggregateId
-                    )
-                }
-
-                if (hendelse.frist != null) {
-                    repository.skedulerUtgått(
-                        SkedulertUtgåttRepository.SkedulertUtgått(
-                            oppgaveId = hendelse.notifikasjonId,
-                            frist = hendelse.frist,
-                            virksomhetsnummer = hendelse.virksomhetsnummer,
-                            produsentId = hendelse.produsentId,
-                        )
-                    )
-                }
-
-                Unit
-            }
-
-            is HendelseModel.FristUtsatt -> {
-                repository.skedulerUtgått(
-                    SkedulertUtgåttRepository.SkedulertUtgått(
-                        oppgaveId = hendelse.notifikasjonId,
-                        frist = hendelse.frist,
-                        virksomhetsnummer = hendelse.virksomhetsnummer,
-                        produsentId = hendelse.produsentId,
-                    )
-                )
-            }
-
-            is HendelseModel.OppgaveUtgått ->
-                repository.slettOmEldre(
-                    oppgaveId = hendelse.aggregateId,
-                    utgaattTidspunkt = hendelse.utgaattTidspunkt.asOsloLocalDate()
-                )
-
-            is HendelseModel.OppgaveUtført ->
-                repository.slettOppgave(aggregateId = hendelse.aggregateId)
-
-            is HendelseModel.HardDelete -> {
-                repository.slettOgHuskSlett(
-                    aggregateId = hendelse.aggregateId,
-                    merkelapp = hendelse.merkelapp,
-                    grupperingsid = hendelse.grupperingsid,
-                )
-            }
-
-            is HendelseModel.SoftDelete -> {
-                repository.slettOgHuskSlett(
-                    aggregateId = hendelse.aggregateId,
-                    merkelapp = hendelse.merkelapp,
-                    grupperingsid = hendelse.grupperingsid,
-                )
-            }
-
-            is HendelseModel.BeskjedOpprettet,
-            is HendelseModel.KalenderavtaleOpprettet,
-            is HendelseModel.KalenderavtaleOppdatert,
-            is HendelseModel.BrukerKlikket,
-            is HendelseModel.PåminnelseOpprettet,
-            is HendelseModel.SakOpprettet,
-            is HendelseModel.NyStatusSak,
-            is HendelseModel.NesteStegSak,
-            is HendelseModel.TilleggsinformasjonSak,
-            is HendelseModel.EksterntVarselFeilet,
-            is HendelseModel.EksterntVarselKansellert,
-            is HendelseModel.OppgavePåminnelseEndret,
-            is HendelseModel.EksterntVarselVellykket -> Unit
-        }
-    }
-
-    override suspend fun processingLoopStep() {
-        sendVedUtgåttFrist()
-        delay(Duration.ofSeconds(1))
-    }
-
-    suspend fun sendVedUtgåttFrist(now: LocalDate = osloTid.localDateNow()) {
-        val utgåttFrist = repository.hentOgFjernAlleMedFrist(now)
+) {
+    suspend fun settOppgaverUtgåttBasertPåFrist(now: LocalDate = osloTid.localDateNow()) {
+        val utgåttFrist = repository.hentOgFjernAlleUtgåtteOppgaver(now)
         utgåttFrist.forEach { utgått ->
             val fristLocalDateTime = LocalDateTime.of(utgått.frist, LocalTime.MAX)
             hendelseProdusent.send(HendelseModel.OppgaveUtgått(
@@ -122,6 +31,33 @@ class SkedulertUtgåttService(
                 hardDelete = null,
                 utgaattTidspunkt = fristLocalDateTime.atOslo().toOffsetDateTime(),
                 nyLenke = null,
+            ))
+        }
+    }
+
+    suspend fun settKalenderavtalerAvholdtBasertPåTidspunkt(now: LocalDateTime = osloTid.localDateTimeNow()) {
+        repository.hentOgFjernAlleAvholdteKalenderavtaler(now).forEach { avholdt ->
+            hendelseProdusent.send(HendelseModel.KalenderavtaleOppdatert(
+                virksomhetsnummer = avholdt.virksomhetsnummer,
+                notifikasjonId = avholdt.kalenderavtaleId,
+                hendelseId = UUID.randomUUID(),
+                produsentId = avholdt.produsentId,
+                kildeAppNavn = NaisEnvironment.clientId,
+                merkelapp = avholdt.merkelapp,
+                grupperingsid = avholdt.grupperingsid,
+                opprettetTidspunkt = avholdt.opprettetTidspunkt,
+                oppdatertTidspunkt = Instant.now(),
+                tilstand = HendelseModel.KalenderavtaleTilstand.AVHOLDT,
+                lenke = null,
+                tekst = null,
+                startTidspunkt = null,
+                sluttTidspunkt = null,
+                lokasjon = null,
+                erDigitalt = null,
+                påminnelse = null,
+                idempotenceKey = null,
+                hardDelete = null,
+                eksterneVarsler = emptyList(),
             ))
         }
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/statistikk/StatistikkModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/statistikk/StatistikkModel.kt
@@ -29,7 +29,6 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SmsVarselKontakti
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SoftDelete
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.TilleggsinformasjonSak
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
 import java.security.MessageDigest
 import java.time.ZoneOffset.UTC

--- a/app/src/main/resources/bruker.graphql
+++ b/app/src/main/resources/bruker.graphql
@@ -218,6 +218,7 @@ enum KalenderavtaleTilstand {
     ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED
     ARBEIDSGIVER_HAR_GODTATT
     AVLYST
+    AVHOLDT
 }
 
 type Virksomhet {

--- a/app/src/main/resources/db/migration/skedulert_utgatt_model/V1__init.sql
+++ b/app/src/main/resources/db/migration/skedulert_utgatt_model/V1__init.sql
@@ -1,0 +1,70 @@
+create table oppgave
+(
+    oppgave_id        uuid not null primary key,
+    frist             text not null,
+    virksomhetsnummer text not null,
+    produsent_id      text not null
+);
+
+create index oppgave_frist_idx on oppgave (frist);
+
+create table oppgave_sak_kobling
+(
+    oppgave_id uuid not null primary key,
+    sak_id     uuid not null
+);
+
+create table kalenderavtale
+(
+    kalenderavtale_id   uuid not null primary key,
+    start_tidspunkt     text not null,
+    tilstand            text not null,
+    virksomhetsnummer   text not null,
+    produsent_id        text not null,
+    merkelapp           text not null,
+    grupperingsid       text not null,
+    opprettet_tidspunkt text not null
+);
+
+create index kalenderavtale_starttidspunkt_idx on kalenderavtale (start_tidspunkt);
+
+create table kalenderavtale_sak_kobling
+(
+    kalenderavtale_id uuid not null primary key,
+    sak_id            uuid not null
+);
+
+create table skedulert_utgatt
+(
+    aggregat_id   uuid not null primary key,
+    aggregat_type text not null
+);
+
+
+create table hard_deleted_aggregates
+(
+    aggregate_id uuid not null primary key
+);
+
+create table hard_deleted_aggregates_metadata
+(
+    aggregate_id   uuid not null references hard_deleted_aggregates (aggregate_id) on delete cascade,
+    aggregate_type text not null,
+    grupperingsid  text,
+    merkelapp      text
+);
+
+create index on hard_deleted_aggregates_metadata (aggregate_type, grupperingsid, merkelapp);
+
+
+-- denne tabellen er en koblingstabell mellom sak og notifikasjon
+-- det at noe ligger i den betyr ikke at det er slettet, men brukes for å sjekke cascade delete
+create table hard_delete_sak_til_notifikasjon_kobling
+(
+    sak_id          uuid not null,
+    notifikasjon_id uuid not null
+);
+
+
+create unique index hard_delete_sak_til_notifikasjon_kobling_uniq
+    on hard_delete_sak_til_notifikasjon_kobling (sak_id, notifikasjon_id)

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -1883,6 +1883,10 @@ enum KalenderavtaleTilstand {
     Avtalen er avlyst
     """
     AVLYST
+    """
+    Avtalen er avholdt, dette skjer automatisk når starttidspunkt har passert, men kan også settes manuelt
+    """
+    AVHOLDT
 }
 
 union NyOppgaveResultat =

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QueryKommendeKalenderavtalerTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QueryKommendeKalenderavtalerTests.kt
@@ -33,7 +33,7 @@ class QueryKommendeKalenderavtalerTests: DescribeSpec({
             grupperingsid = grupperingsid,
         )
         val sak2 = brukerRepository.sakOpprettet(
-            sakId = uuid("1"),
+            sakId = uuid("2"),
             mottakere = listOf(TEST_MOTTAKER_2),
             virksomhetsnummer = TEST_VIRKSOMHET_2,
             merkelapp = merkelapp,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTidslinjeTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/QuerySakerTidslinjeTest.kt
@@ -160,9 +160,9 @@ class QuerySakerTidslinjeTest: DescribeSpec({
                 it.startTidspunkt.toInstant() shouldBe kalenderavtale.startTidspunkt.atOslo().toInstant()
                 it.sluttTidspunkt?.toInstant() shouldBe kalenderavtale.sluttTidspunkt?.atOslo()?.toInstant()
                 it.lokasjon.shouldNotBeNull()
-                it.lokasjon.adresse shouldBe kalenderavtale.lokasjon!!.adresse
-                it.lokasjon.poststed shouldBe kalenderavtale.lokasjon.poststed
-                it.lokasjon.postnummer shouldBe kalenderavtale.lokasjon.postnummer
+                it.lokasjon!!.adresse shouldBe kalenderavtale.lokasjon!!.adresse
+                it.lokasjon!!.poststed shouldBe kalenderavtale.lokasjon!!.poststed
+                it.lokasjon!!.postnummer shouldBe kalenderavtale.lokasjon!!.postnummer
                 it.digitalt shouldBe kalenderavtale.erDigitalt
             }
             instanceOf<BrukerAPI.BeskjedTidslinjeElement, TidslinjeElement>(tidslinje1[1]) {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakerMedOppgaveTilstandTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/SakerMedOppgaveTilstandTests.kt
@@ -96,7 +96,7 @@ class SakerMedOppgaveTilstandTests : DescribeSpec({
         repo.opprettOppgave(sak1, LocalDate.parse("2023-05-15"))
         repo.opprettOppgave(sak1, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtgått(it) }
 
-        val sak2 = repo.opprettSak("2").also { sak ->
+        repo.opprettSak("2").also { sak ->
             repo.opprettOppgave(sak, LocalDate.parse("2023-01-15")).also { repo.oppgaveTilstandUtført(it) }
             repo.opprettOppgave(sak, LocalDate.parse("2023-05-15")).also { repo.oppgaveTilstandUtført(it) }
             repo.opprettOppgave(sak, LocalDate.parse("2023-05-15")).also { repo.oppgaveTilstandUtgått(it) }
@@ -105,6 +105,7 @@ class SakerMedOppgaveTilstandTests : DescribeSpec({
                 HendelseModel.KalenderavtaleTilstand.ARBEIDSGIVER_VIL_ENDRE_TID_ELLER_STED,
                 HendelseModel.KalenderavtaleTilstand.ARBEIDSGIVER_HAR_GODTATT,
                 HendelseModel.KalenderavtaleTilstand.AVLYST,
+                HendelseModel.KalenderavtaleTilstand.AVHOLDT,
             )) {
                 repo.kalenderavtaleOpprettet(
                     sakId = sak.sakId,

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyStatusSakTests.kt
@@ -76,13 +76,27 @@ class NyStatusSakTests : DescribeSpec({
         val r6 = engine.nyStatusSak(
             id = sakId,
             SaksStatus.FERDIG,
-            hardDelete = LocalDateTime.MAX
+            hardDelete = LocalDateTime.MAX.minusDays(1)
         )
         it("vellyket oppdatering med harddelete satt i kafka") {
             r6.getTypedContent<String>("$.nyStatusSak.__typename") shouldBe "NyStatusSakVellykket"
             val hendelse = stubbedKafkaProducer.hendelser.last()
             hendelse should beInstanceOf<HendelseModel.NyStatusSak>()
             (hendelse as HendelseModel.NyStatusSak).hardDelete shouldNotBe null
+            hendelse.hardDelete!!.nyTid.denOrNull() shouldBe LocalDateTime.MAX.minusDays(1)
+        }
+
+        val r7 = engine.nyStatusSak(
+            id = sakId,
+            SaksStatus.FERDIG,
+            hardDelete = LocalDateTime.MAX
+        )
+        it("vellyket oppdatering med harddelete satt i kafka") {
+            r7.getTypedContent<String>("$.nyStatusSak.__typename") shouldBe "NyStatusSakVellykket"
+            val hendelse = stubbedKafkaProducer.hendelser.last()
+            hendelse should beInstanceOf<HendelseModel.NyStatusSak>()
+            (hendelse as HendelseModel.NyStatusSak).hardDelete shouldNotBe null
+            hendelse.hardDelete!!.nyTid.denOrNull() shouldBe LocalDateTime.MAX
         }
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/KalenderavtaleAvholdtTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/KalenderavtaleAvholdtTests.kt
@@ -1,0 +1,245 @@
+package no.nav.arbeidsgiver.notifikasjon.skedulert_utgått
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.KalenderavtaleTilstand.*
+import no.nav.arbeidsgiver.notifikasjon.util.FakeHendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
+import no.nav.arbeidsgiver.notifikasjon.util.uuid
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.util.*
+
+class KalenderavtaleAvholdtTests : DescribeSpec({
+    val localDateTimeNow = LocalDateTime.now()
+    val tidspunktSomHarPassert = localDateTimeNow.minusHours(1)
+    val tidspunktSomIkkeHarPassert = localDateTimeNow.plusHours(1)
+
+    val sakOpprettet = HendelseModel.SakOpprettet(
+        hendelseId = uuid("1"),
+        virksomhetsnummer = "1",
+        produsentId = "",
+        kildeAppNavn = "",
+        sakId = uuid("1"),
+        grupperingsid = "42",
+        merkelapp = "test",
+        mottakere = listOf(
+            HendelseModel.AltinnMottaker(
+                virksomhetsnummer = "1",
+                serviceCode = "1",
+                serviceEdition = "1"
+            )
+        ),
+        tittel = "test",
+        tilleggsinformasjon = null,
+        lenke = "#test",
+        oppgittTidspunkt = OffsetDateTime.now(),
+        mottattTidspunkt = OffsetDateTime.now(),
+        nesteSteg = null,
+        hardDelete = null,
+    )
+    val opprettet = HendelseModel.KalenderavtaleOpprettet(
+        virksomhetsnummer = sakOpprettet.virksomhetsnummer,
+        merkelapp = sakOpprettet.merkelapp,
+        eksternId = "42",
+        mottakere = sakOpprettet.mottakere,
+        hendelseId = uuid("2"),
+        notifikasjonId = uuid("2"),
+        tekst = "test",
+        lenke = "#test",
+        opprettetTidspunkt = OffsetDateTime.now(),
+        kildeAppNavn = "",
+        produsentId = "",
+        grupperingsid = "42",
+        eksterneVarsler = listOf(),
+        hardDelete = null,
+        sakId = sakOpprettet.sakId,
+        påminnelse = null,
+        tilstand = HendelseModel.KalenderavtaleTilstand.VENTER_SVAR_FRA_ARBEIDSGIVER,
+        startTidspunkt = localDateTimeNow,
+        sluttTidspunkt = null,
+        lokasjon = null,
+        erDigitalt = false,
+    )
+    val oppdatert = HendelseModel.KalenderavtaleOppdatert(
+        virksomhetsnummer = sakOpprettet.virksomhetsnummer,
+        merkelapp = sakOpprettet.merkelapp,
+        hendelseId = uuid("3"),
+        notifikasjonId = uuid("2"),
+        tekst = "test",
+        lenke = "#test",
+        opprettetTidspunkt = Instant.now(),
+        oppdatertTidspunkt = opprettet.opprettetTidspunkt.toInstant(),
+        kildeAppNavn = "",
+        produsentId = "",
+        grupperingsid = "42",
+        eksterneVarsler = listOf(),
+        hardDelete = null,
+        påminnelse = null,
+        tilstand = HendelseModel.KalenderavtaleTilstand.VENTER_SVAR_FRA_ARBEIDSGIVER,
+        startTidspunkt = localDateTimeNow,
+        sluttTidspunkt = null,
+        lokasjon = null,
+        erDigitalt = false,
+        idempotenceKey = null,
+    )
+
+    describe("noop når starttidspunkt ikke har passert enda") {
+        val (repo, hendelseProdusent, service) = setupTestApp()
+
+        repo.oppdaterModellEtterHendelse(opprettet.copy(startTidspunkt = tidspunktSomIkkeHarPassert))
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+
+        hendelseProdusent.hendelser shouldBe emptyList()
+    }
+
+    describe("noop når aggregat er fjernet") {
+        val (repo, hendelseProdusent, service) = setupTestApp()
+        withData(
+            listOf(
+                HendelseModel.HardDelete(
+                    aggregateId = opprettet.aggregateId,
+                    virksomhetsnummer = opprettet.virksomhetsnummer,
+                    hendelseId = UUID.randomUUID(),
+                    produsentId = opprettet.virksomhetsnummer,
+                    kildeAppNavn = opprettet.virksomhetsnummer,
+                    deletedAt = OffsetDateTime.now(),
+                    grupperingsid = null,
+                    merkelapp = opprettet.merkelapp,
+                ),
+                opprettet.copy(startTidspunkt = tidspunktSomHarPassert),
+                oppdatert.copy(startTidspunkt = tidspunktSomHarPassert),
+            )
+        ) {
+
+            repo.oppdaterModellEtterHendelse(it)
+            service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+            hendelseProdusent.hendelser shouldBe emptyList()
+        }
+    }
+
+    describe("noop når status er avholdt elelr avlyst") {
+        val (repo, hendelseProdusent, service) = setupTestApp()
+
+        repo.oppdaterModellEtterHendelse(opprettet.copy(
+            notifikasjonId = uuid("11"),
+            startTidspunkt = tidspunktSomHarPassert,
+            tilstand = AVLYST
+        ))
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+        hendelseProdusent.hendelser shouldBe emptyList()
+
+        repo.oppdaterModellEtterHendelse(opprettet.copy(
+            notifikasjonId = uuid("22"),
+            startTidspunkt = tidspunktSomHarPassert,
+            tilstand = AVHOLDT
+        ))
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+        hendelseProdusent.hendelser shouldBe emptyList()
+    }
+
+    describe("Skedulerer avholdt når starttidspunkt har passert") {
+        val (repo, hendelseProdusent, service) = setupTestApp()
+
+        repo.oppdaterModellEtterHendelse(opprettet.copy(startTidspunkt = tidspunktSomHarPassert))
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+
+        hendelseProdusent.hendelser.first().also {
+            it as HendelseModel.KalenderavtaleOppdatert
+            it.tilstand shouldBe AVHOLDT
+        }
+    }
+
+    describe("Skedulerer avholdt når starttidspunkt har passert og det finnes et starttidspunkt på kø som ikke har passert") {
+        /**
+         * denne testen passer på at vi klarer å skille på forskjellige aggregater
+         */
+
+        val (repo, hendelseProdusent, service) = setupTestApp()
+
+        repo.oppdaterModellEtterHendelse(
+            opprettet.copy(
+                notifikasjonId = uuid("11"),
+                startTidspunkt = tidspunktSomIkkeHarPassert
+            )
+        )
+        repo.oppdaterModellEtterHendelse(
+            opprettet.copy(
+                notifikasjonId = uuid("22"),
+                startTidspunkt = tidspunktSomHarPassert
+            )
+        )
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+
+        hendelseProdusent.hendelser shouldHaveSize 1
+        hendelseProdusent.hendelser.first().also {
+            it as HendelseModel.KalenderavtaleOppdatert
+            it.tilstand shouldBe AVHOLDT
+            it.aggregateId shouldBe uuid("22")
+        }
+    }
+
+    describe("skedulering fjernes når kalenderavtale setter til slutt tilstand") {
+        val (repo, hendelseProdusent, service) = setupTestApp()
+
+        repo.oppdaterModellEtterHendelse(opprettet.copy(startTidspunkt = tidspunktSomHarPassert))
+        repo.oppdaterModellEtterHendelse(oppdatert.copy(tilstand = AVLYST))
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+
+        hendelseProdusent.hendelser shouldBe emptyList()
+
+        repo.oppdaterModellEtterHendelse(
+            opprettet.copy(
+                notifikasjonId = uuid("42"),
+                startTidspunkt = tidspunktSomHarPassert
+            )
+        )
+        repo.oppdaterModellEtterHendelse(
+            oppdatert.copy(
+                notifikasjonId = uuid("42"),
+                tilstand = AVHOLDT
+            )
+        )
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+
+        hendelseProdusent.hendelser shouldBe emptyList()
+    }
+
+
+    describe("oppdater etter avholdt fører til ny skedulert avholdt") {
+        /**
+         * siden tilstand kan settes via API og vi automatisk setter til avholdt
+         * så bør vi passe på at oppgaver som gjenåpnes fortsatt settes til avholdt
+         * tenkt scenario er at lagg i en produsent fører til at vi får en oppdatering på tilstand etter at vi har satt
+         * avholdt. da bør kalenderavtalen forbli avholdt og ikke ende i en åpen state
+         */
+
+        val (repo, hendelseProdusent, service) = setupTestApp()
+
+        repo.oppdaterModellEtterHendelse(opprettet.copy(startTidspunkt = tidspunktSomHarPassert))
+        repo.oppdaterModellEtterHendelse(oppdatert.copy(tilstand = AVLYST))
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+        hendelseProdusent.hendelser shouldBe emptyList()
+
+        repo.oppdaterModellEtterHendelse(oppdatert.copy(tilstand = ARBEIDSGIVER_HAR_GODTATT))
+        service.settKalenderavtalerAvholdtBasertPåTidspunkt(now = localDateTimeNow)
+
+        hendelseProdusent.hendelser.first().also {
+            it as HendelseModel.KalenderavtaleOppdatert
+            it.tilstand shouldBe AVHOLDT
+        }
+    }
+
+})
+
+private fun DescribeSpec.setupTestApp(): Triple<SkedulertUtgåttRepository, FakeHendelseProdusent, SkedulertUtgåttService> {
+    val database = testDatabase(SkedulertUtgått.databaseConfig)
+    val repo = SkedulertUtgåttRepository(database)
+    val hendelseProdusent = FakeHendelseProdusent()
+    val service = SkedulertUtgåttService(repo, hendelseProdusent)
+    return Triple(repo, hendelseProdusent, service)
+}

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttIdempotensTests.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttIdempotensTests.kt
@@ -2,17 +2,18 @@ package no.nav.arbeidsgiver.notifikasjon.skedulert_utgått
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.datatest.withData
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
-import no.nav.arbeidsgiver.notifikasjon.util.NoopHendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.util.testDatabase
 
 class SkedulertUtgåttIdempotensTests : DescribeSpec({
-    val service = SkedulertUtgåttService(NoopHendelseProdusent)
-
     describe("SkedulertUtgått Idempotent oppførsel") {
+        val repo = SkedulertUtgåttRepository(
+            testDatabase(SkedulertUtgått.databaseConfig)
+        )
+
         withData(EksempelHendelse.Alle) { hendelse ->
-            service.processHendelse(hendelse, PartitionHendelseMetadata(0, 0))
-            service.processHendelse(hendelse, PartitionHendelseMetadata(0, 0))
+            repo.oppdaterModellEtterHendelse(hendelse)
+            repo.oppdaterModellEtterHendelse(hendelse)
         }
     }
 })

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/EksempelHendelser.kt
@@ -8,6 +8,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.EksterntVarselSendingsvindu
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.EpostVarselKontaktinfo
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Hendelse
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.KalenderavtaleTilstand.AVHOLDT
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.KalenderavtaleTilstand.VENTER_SVAR_FRA_ARBEIDSGIVER
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NærmesteLederMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SmsVarselKontaktinfo
@@ -790,7 +791,7 @@ object EksempelHendelse {
         ),
         lenke = "https://foo.no",
         tekst = "foo",
-        tilstand = VENTER_SVAR_FRA_ARBEIDSGIVER,
+        tilstand = AVHOLDT,
         startTidspunkt = LocalDateTime.now().plusHours(1),
         sluttTidspunkt = LocalDateTime.now().plusHours(2),
         lokasjon = HendelseModel.Lokasjon("foo", "bar", "baz"),

--- a/local-db-init.sql
+++ b/local-db-init.sql
@@ -21,6 +21,9 @@ GRANT ALL PRIVILEGES ON DATABASE "ekstern-varsling-model" TO postgres;
 CREATE DATABASE "skedulert-harddelete-model";
 GRANT ALL PRIVILEGES ON DATABASE "skedulert-harddelete-model" TO postgres;
 
+CREATE DATABASE "skedulert-utgatt-model";
+GRANT ALL PRIVILEGES ON DATABASE "skedulert-utgatt-model" TO postgres;
+
 CREATE DATABASE "kafka-backup-model";
 GRANT ALL PRIVILEGES ON DATABASE "kafka-backup-model" TO postgres;
 

--- a/widget/component/src/NotifikasjonWidget/NotifikasjonPanel/NotifikasjonListeElement/NotifikasjonListeElement.tsx
+++ b/widget/component/src/NotifikasjonWidget/NotifikasjonPanel/NotifikasjonListeElement/NotifikasjonListeElement.tsx
@@ -222,6 +222,26 @@ export const NotifikasjonListeElement = (props: Props) => {
               }
             />
           );
+        case KalenderavtaleTilstand.Avholdt:
+          return (
+            <NotifikasjonBeskjed
+              notifikasjon={notifikasjon}
+              props={props}
+              erTodo={false}
+              ikon={
+                <KalenderavtaleIkon
+                  variant="grå"
+                  title="Kalenderavtale som er avholdt."
+                />
+              }
+              tittel={kalenderavtaleTekst(notifikasjon)}
+              statuslinje={
+                <Tag size="small" variant="info">
+                  Avholdt
+                </Tag>
+              }
+            />
+          );
         default:
           console.error(`ukjent avtaletilstand ${avtaletilstand}: ignorerer`);
           return null;


### PR DESCRIPTION
Kalenderavtale kan settes som avholdt, ny slutttilstand. Når starttidspunkt passerer så vil SkedulertUtgått trigge at kalenderavtalen blir markert som AVHOLDT, dersom den er i en åpen tilstand.

SkedulertUtgått tjenesten skrives ut av EphemeralDatabase til fordel for postgreSQL.