### PR TITLE
legg til index for å hindre seq scan

### DIFF
--- a/app/src/main/resources/db/migration/bruker_model/V50__add_index_kobling_notifikasjon.sql
+++ b/app/src/main/resources/db/migration/bruker_model/V50__add_index_kobling_notifikasjon.sql
@@ -1,0 +1,2 @@
+create index idx_notifikasjon_id
+    on hard_delete_sak_til_notifikasjon_kobling (notifikasjon_id);

--- a/app/src/main/resources/db/migration/dataprodukt_model/V19__add_index_kobling_notifikasjon.sql
+++ b/app/src/main/resources/db/migration/dataprodukt_model/V19__add_index_kobling_notifikasjon.sql
@@ -1,0 +1,2 @@
+create index idx_notifikasjon_id
+    on hard_delete_sak_til_notifikasjon_kobling (notifikasjon_id);

--- a/app/src/main/resources/db/migration/produsent_model/V30__add_index_kobling_notifikasjon.sql
+++ b/app/src/main/resources/db/migration/produsent_model/V30__add_index_kobling_notifikasjon.sql
@@ -1,0 +1,2 @@
+create index idx_notifikasjon_id
+    on hard_delete_sak_til_notifikasjon_kobling (notifikasjon_id);

--- a/app/src/main/resources/db/migration/skedulert_harddelete_model/V7__add_index_kobling_notifikasjon.sql
+++ b/app/src/main/resources/db/migration/skedulert_harddelete_model/V7__add_index_kobling_notifikasjon.sql
@@ -1,0 +1,2 @@
+create index idx_notifikasjon_id
+    on hard_delete_sak_til_notifikasjon_kobling (notifikasjon_id);

--- a/app/src/main/resources/db/migration/skedulert_utgatt_model/V2__add_index_kobling_notifikasjon.sql
+++ b/app/src/main/resources/db/migration/skedulert_utgatt_model/V2__add_index_kobling_notifikasjon.sql
@@ -1,0 +1,2 @@
+create index idx_notifikasjon_id
+    on hard_delete_sak_til_notifikasjon_kobling (notifikasjon_id);

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -1685,6 +1685,11 @@ input EpostKontaktInfoInput {
     epostadresse: String!
 }
 
+"""
+Ekstern varsling på Altinn 2 tjeneste.
+Ekstern varsling på Altinn 3 ressurs er ikke implementert, men er i backloggen.
+Ta kontakt derssom dere ønsker at vi prioriterer dette.
+"""
 input AltinntjenesteMottakerInput {
     serviceCode: String!
     serviceEdition: String!


### PR DESCRIPTION
Jeg tenkte at uniq indeksen tok seg av dette, men det virker ikke sånn.
Dette så vi når vi bygget skedulert-utgatt modellen [fra bunnen av i helgen](https://prometheus.prod-gcp.nav.cloud.nais.io/query?g0.expr=kafka_consumergroup_group_topic_sum_lag%7Btopic%3D%22fager.notifikasjon%22%2Cgroup%21%7E%22null%7Cskedulert-utgaatt-1%7Cskedulert-utgatt-model-builder%7Cskedulert-paaminnelse.*%7Creplay-validator%7Cmanuelt-vedlikehold-.*%7C.*rebuild.*%22%7D&g0.show_tree=0&g0.tab=graph&g0.end_input=2025-01-18+07%3A51%3A14&g0.moment_input=2025-01-18+07%3A51%3A14&g0.range_input=1d&g0.res_type=auto&g0.res_density=medium&g0.display_mode=lines&g0.show_exemplars=0). 
<img width="1981" alt="image" src="https://github.com/user-attachments/assets/94cd921f-f79e-4bcd-bea5-db0fffaceeca" />


Fra dokumentasjonen: https://www.postgresql.org/docs/current/indexes-multicolumn.html

A multicolumn B-tree index can be used with query conditions that involve any subset of the index's columns, but the index is most efficient when there are constraints on the leading (leftmost) columns. The exact rule is that equality constraints on leading columns, plus any inequality constraints on the first column that does not have an equality constraint, will be used to limit the portion of the index that is scanned. Constraints on columns to the right of these columns are checked in the index, so they save visits to the table proper, but they do not reduce the portion of the index that has to be scanned.