### PR TITLE
kvitter synkrone feil fra altinn

### DIFF
--- a/.github/workflows/platform_build_and_deploy.yaml
+++ b/.github/workflows/platform_build_and_deploy.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:12.10
+        image: postgres:17.4
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/Dataprodukt.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/Dataprodukt.kt
@@ -25,7 +25,13 @@ object Dataprodukt {
 
     fun main(httpPort: Int = 8080) {
         runBlocking(Dispatchers.Default) {
-            val database = openDatabaseAsync(databaseConfig) {
+            val database = openDatabaseAsync(config = databaseConfig, flywayAction = {
+                // en migrering feiler i testene etter oppgradering til postgres 17.4
+                //  midlertidig kjør repair og migrate for å oppdatere checksums databasen
+                // kan fjernes etter merge
+                repair()
+                migrate()
+            }) {
                 placeholders(
                     mapOf("SALT_VERDI" to saltVerdi),
                 )

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -132,11 +132,12 @@ class Database private constructor(
 
         fun CoroutineScope.openDatabaseAsync(
             config: Config,
+            flywayAction: Flyway.() -> Unit = { migrate() },
             fluentConfig: FluentConfiguration.() -> Unit = {},
         ): Deferred<Database> {
             return async {
                 try {
-                    openDatabase(config, fluentConfig = fluentConfig).also {
+                    openDatabase(config, flywayAction, fluentConfig = fluentConfig).also {
                         Health.subsystemReady[Subsystem.DATABASE] = true
                     }
                 } catch (e: Exception) {

--- a/app/src/main/resources/db/migration/dataprodukt_model/V3__grant_access_dataprodukt_service_user.sql
+++ b/app/src/main/resources/db/migration/dataprodukt_model/V3__grant_access_dataprodukt_service_user.sql
@@ -1,4 +1,4 @@
 grant select on all tables in schema public to sa_notifikasjon_dataprodukt_exporter;
 
 alter table sak
-    drop column virksomhetsnummer;
+    drop column virksomhetsnummer cascade;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - BITNAMI_DEBUG=true
 
   postgres:
-    image: "postgres:12.11"
+    image: "postgres:17.4"
     ports:
       - "1337:5432"
     environment:


### PR DESCRIPTION
altinn 3 kan feile synkront(http400) og asynkront (sendestatus).

De asynkrone feilene er allerede håndtert, men det var en mangel på håndtering av synkrone feil. Disse ble ikke kvittert og derfor ble jobben poppet inn og ut av job queue med timeout på lock.