### PR TITLE
rework input validation

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -367,6 +367,10 @@ interface Altinn3VarselKlient {
             val succeeded: Int,
             val notifications: List<Notification>,
         ) : NotificationsResponse {
+
+            val isProcessing
+                get() = notifications.any { it.sendStatus.isProcessing }
+
             companion object {
                 fun fromJson(rawJson: JsonNode): Success {
                     return Success(
@@ -429,6 +433,13 @@ interface Altinn3VarselKlient {
                     val description: String,
                     val lastUpdate: String,
                 ) {
+                    val isProcessing
+                        get() = status in listOf(
+                            New,
+                            Sending,
+                            Succeeded
+                        )
+
                     companion object {
                         val New = "New"
                         val Sending = "Sending"

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
@@ -317,16 +317,12 @@ class EksternVarslingService(
             ProcessingStatus.Completed -> {
                 // Orderen er ferdig prosessert og alle notifikasjoner er blitt generert. Sjekker om notifikasjoner alle notifikasjoner er blitt sendt ut
                 altinn3VarselKlient.notifications(ordreId).let {
-                    if (!(it is Altinn3VarselKlient.NotificationsResponse.Success)) {
+                    if (it !is Altinn3VarselKlient.NotificationsResponse.Success) {
                         log.error("Feil ved henting av notifikasjoner: ${it.rå}")
                         return Pair(Altinn3VarselStatus.Prosesserer, it.rå)
                     }
 
-                    if (it.notifications.any { notification ->
-                            (notification.sendStatus.status === SendStatus.New
-                                    || notification.sendStatus.status === SendStatus.Sending
-                                    || notification.sendStatus.status === SendStatus.Succeeded)
-                        }) {
+                    if (it.isProcessing) {
                         return Pair(Altinn3VarselStatus.Prosesserer, it.rå)
                     }
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.future.future
 import kotlinx.coroutines.slf4j.MDCContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics.meterRegistry
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.coRecord
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.findCause
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.getTimer
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
@@ -77,7 +78,12 @@ fun <T> TypeRuntimeWiring.Builder.coDataFetcher(
             } catch (e: GraphqlErrorException) {
                 handleUnexpectedError(e, e)
             } catch (e: RuntimeException) {
-                handleUnexpectedError(e, UnhandledGraphQLExceptionError(e, fieldName))
+                val valideringsFeil = e.findCause<ValideringsFeil>()
+                if (valideringsFeil != null) {
+                    handleUnexpectedError(valideringsFeil, valideringsFeil)
+                } else {
+                    handleUnexpectedError(e, UnhandledGraphQLExceptionError(e, fieldName))
+                }
             }
         }
     }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQLValidation.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQLValidation.kt
@@ -1,223 +1,59 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql
 
 import graphql.GraphqlErrorException
-import graphql.schema.*
-import graphql.schema.idl.SchemaDirectiveWiring
-import graphql.schema.idl.SchemaDirectiveWiringEnvironment
 
-object ValidateDirective : SchemaDirectiveWiring {
+private typealias Validator<T> = (T) -> T
 
-    /* Find all validation annotations for this argument. */
-    override fun onArgument(environment: SchemaDirectiveWiringEnvironment<GraphQLArgument>): GraphQLArgument {
-        val argument = environment.element
-        val validator = argument.createValidator()
-            ?: return argument
-        val dataFetcher = environment.fieldDataFetcher
+object Validators {
+    fun NorwegianMobilePhoneNumber(path: String): Validator<String?> = { value ->
+        val regex = Regex("""(\+47|0047)?[49]\d{7}""")
+        if (value != null && !value.matches(regex)) {
+            throw ValideringsFeil("$path: verdien er ikke et gyldig norsk mobilnummer.")
+        }
+        value
+    }
 
-        environment.fieldDataFetcher = DataFetcher {
-            val value = it.getArgument<Any?>(argument.name)
+    fun NonIdentifying(path: String): Validator<String> = { value ->
+        val regex = Regex("""\d{11}""")
+        if (value.contains(regex)) {
+            throw ValideringsFeil("$path: verdien inneholder uønsket data: personnummer (11 siffer)")
+        }
+        value
+    }
+
+    fun MaxValue(path: String, upToIncluding: Int): Validator<Int> = { value ->
+        if (value > upToIncluding) {
+            throw ValideringsFeil("$path: verdien overstiger maks antall tegn: verdi=${value}, upToIncluding=${upToIncluding}.")
+        }
+        value
+    }
+
+    fun MaxLength(path: String, max: Int): Validator<String> = { value ->
+        if (value.length > max) {
+            throw ValideringsFeil("$path: verdien overstiger maks antall tegn, antall=${value.length}, maks=$max.")
+        }
+        value
+    }
+
+    fun ExactlyOneFieldGiven(path: String): Validator<Map<String, Any?>> = { value ->
+        val fieldsGiven = value.filterValues {
+            it != null
+        }
+        when (fieldsGiven.size) {
+            1 -> value
+            0 -> throw ValideringsFeil("$path: nøyaktig ett felt skal være satt. (Ingen felt er satt)")
+            else -> throw ValideringsFeil("$path: nøyaktig ett felt skal være satt. (${fieldsGiven.keys.joinToString(", ")} er gitt)")
+        }
+    }
+
+    fun <T> compose(
+        vararg validators: Validator<T>
+    ): Validator<T> = { value ->
+        for (validator in validators) {
             validator(value)
-            dataFetcher.get(it)
         }
-
-        return argument
-    }
-
-    private fun GraphQLArgument.createValidator(): Validator? {
-        val path = listOf("argument '${this.name}'")
-        val argumentValidator: Validator? = this.directives
-            .filter { it.name != "Validate" }
-            .map { directive ->
-            VALIDATORS[directive.name]
-                ?.createValidator(path, directive, this.type)
-                ?: throw Error("Unknown validation directive ${directive.name}")
-        }
-            .andAll()
-
-        val nestedValidators = this.type.createValidator(path)
-
-        return argumentValidator and nestedValidators
-    }
-
-    private fun GraphQLInputType.createValidator(path: Path): Validator? =
-        when (this) {
-            is GraphQLNonNull -> this.createValidator(path)
-            is GraphQLInputObjectType -> this.createValidator(path)
-            is GraphQLScalarType -> null
-            is GraphQLList -> this.createValidator(path)
-            is GraphQLEnumType -> null
-            else -> throw Error("Unexpected graphql type ${this.javaClass.canonicalName} in ${path.joinToString(", ")}")
-        }
-
-    private fun GraphQLList.createValidator(path: Path): Validator? =
-        (this.wrappedType as GraphQLInputType)
-            .createValidator(path + listOf("array element"))
-            ?.let { validate ->
-                { list ->
-                    if (list is List<Any?>) {
-                        for (value in list) {
-                            validate(value)
-                        }
-                    }
-                }
-            }
-
-
-    private fun GraphQLNonNull.createValidator(path: Path): Validator? =
-        (this.wrappedType as GraphQLInputType).createValidator(path)
-            ?.let { validate ->
-                { value ->
-                    validate(value)
-                }
-            }
-
-    private fun GraphQLInputObjectType.createValidator(path: Path): Validator? {
-        val extendedPath = path + listOf("object type '${this.name}'")
-        val objectValidators = this.directives.map { directive ->
-            VALIDATORS[directive.name]
-                ?.createValidator(extendedPath, directive, this)
-                ?: throw Error("Unknown directive '${directive.name}' to validate")
-        }
-        val fieldValidators = this.fields.mapNotNull { it.createValidator(path) }
-        val objValidator = (fieldValidators + objectValidators).andAll()
-
-        if (objValidator != null) {
-            return { obj ->
-                if (obj != null) {
-                    objValidator(obj)
-                }
-            }
-        } else {
-            return null
-        }
-    }
-
-    private fun GraphQLInputObjectField.createValidator(path: Path): Validator? {
-        val extendedPath = path + listOf("field '${this.name}'")
-        val validators = this.directives.map { directive ->
-            VALIDATORS[directive.name]
-                ?.createValidator(extendedPath, directive, this.type)
-                ?: throw Error("Unknown directive '${directive.name}' to validate")
-        }
-
-        val otherValidators = type.createValidator(extendedPath)
-
-        if (validators.isEmpty() && otherValidators == null) {
-            return null
-        } else {
-            return { objectValue ->
-                objectValue as Map<String, Any?>
-                val fieldValue = objectValue[name]
-
-                validators.forEach { validator ->
-                    validator(fieldValue)
-                }
-                otherValidators?.let { it(fieldValue) }
-            }
-        }
+        value
     }
 }
 
-private typealias Validator = (Any?) -> Unit
-
-private typealias Path = List<String>
-private fun Path.asString() = this.joinToString(", ")
-
-private infix fun Validator?.and(other: Validator?): Validator? =
-    if (this == null && other == null)
-        null
-    else
-        { value ->
-            if (this != null) {
-                this(value)
-            }
-            if (other != null) {
-                other(value)
-            }
-        }
-
-private fun List<Validator?>?.andAll(): Validator? =
-    this.orEmpty()
-        .fold(initial = null, operation = Validator?::and)
-
-interface ValueValidator {
-    val name: String
-    fun createValidator(path: List<String>, directive: GraphQLDirective, type: GraphQLType): Validator
-}
-
-private val VALIDATORS = listOf(
-    object : ValueValidator {
-        override val name = "MaxValue"
-
-        override fun createValidator(path: Path, directive: GraphQLDirective, type: GraphQLType): Validator {
-            val upToIncluding = (directive.getArgument("upToIncluding").argumentValue.value as graphql.language.IntValue).value.toInt()
-            return { value ->
-                val valueInt = value as Int?
-                if (valueInt != null && valueInt > upToIncluding) {
-                    throw ValideringsFeil("${path.asString()}: verdien overstiger maks antall tegn: verdi=${valueInt}, upToIncluding=${upToIncluding}.")
-                }
-            }
-        }
-    },
-    object : ValueValidator {
-        override val name = "MaxLength"
-
-        override fun createValidator(path: Path, directive: GraphQLDirective, type: GraphQLType): Validator {
-            val max = (directive.getArgument("max").argumentValue.value as graphql.language.IntValue).value.toInt()
-            return { value ->
-                val valueStr = value as String?
-                if (valueStr != null && valueStr.length > max) {
-                    throw ValideringsFeil("${path.asString()}: verdien overstiger maks antall tegn, antall=${valueStr.length}, maks=$max.")
-                }
-            }
-        }
-    },
-    object : ValueValidator {
-        override val name = "NonIdentifying"
-
-        override fun createValidator(path: Path, directive: GraphQLDirective, type: GraphQLType): Validator {
-            return { value ->
-                val valueStr = value as String?
-                if (valueStr != null && valueStr.contains(Regex("""\d{11}"""))) {
-                    throw ValideringsFeil("${path.asString()}: verdien inneholder uønsket data: personnummer (11 siffer)")
-                }
-            }
-        }
-    },
-    object : ValueValidator {
-        override val name = "ExactlyOneFieldGiven"
-
-        override fun createValidator(path: Path, directive: GraphQLDirective, type: GraphQLType): Validator {
-            type as GraphQLInputObjectType
-            val fieldNames = type.fields.map { it.name }.toSet()
-            return { value ->
-                value as Map<String, Any?>
-                val fieldsGiven = value.filter {
-                    fieldNames.contains(it.key) && it.value != null
-                }
-                when (fieldsGiven.size) {
-                    1 -> Unit
-                    0 -> throw ValideringsFeil("${path.asString()}: nøyaktig ett felt skal være satt. (Ingen felt er satt)")
-                    else -> throw ValideringsFeil("${path.asString()}: nøyaktig ett felt skal være satt. (${fieldsGiven.keys.joinToString(", ")} er gitt)")
-                }
-            }
-        }
-    },
-    object : ValueValidator {
-        override val name = "NorwegianMobilePhoneNumber"
-
-        override fun createValidator(path: Path, directive: GraphQLDirective, type: GraphQLType): Validator {
-            return { value ->
-                if (value == null) Unit
-
-                val valueStr = value as String
-
-                if (!valueStr.matches(Regex("""(\+47|0047)?[49]\d{7}"""))) {
-                    throw ValideringsFeil("${path.asString()}: verdien er ikke et gyldig norsk mobilnummer.")
-                }
-            }
-        }
-    },
-).associateBy { it.name }
-
-class ValideringsFeil(message: String): GraphqlErrorException(newErrorException().message(message))
+class ValideringsFeil(message: String) : GraphqlErrorException(newErrorException().message(message))

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/FellesGraphQLTypes.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/FellesGraphQLTypes.kt
@@ -2,12 +2,19 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.ISO8601Period
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.Validators
 import java.time.LocalDateTime
 
 data class FutureTemporalInput(
     val den: LocalDateTime?,
     val om: ISO8601Period?,
 ) {
+    init {
+        Validators.ExactlyOneFieldGiven("FutureTemporalInput")(mapOf(
+            "den" to den,
+            "om" to om,
+        ))
+    }
     fun tilHendelseModel(): HendelseModel.LocalDateTimeOrDuration {
         if (den != null) {
             return HendelseModel.LocalDateTimeOrDuration.LocalDateTime(den)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationKalenderavtale.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationKalenderavtale.kt
@@ -126,6 +126,13 @@ internal class MutationKalenderavtale(
         val paaminnelse: PaaminnelseInput?,
         val hardDelete: FutureTemporalInput?,
     ) {
+        init {
+            Validators.compose(
+                Validators.MaxLength("kalenderavtale.tekst", 300),
+                Validators.NonIdentifying("kalenderavtale.tekst")
+            )(tekst)
+        }
+
         inline fun somKalenderavtaleOpprettetHendelse(
             id: UUID,
             produsentId: String,
@@ -347,7 +354,16 @@ internal class MutationKalenderavtale(
         override val paaminnelse: PaaminnelseInput?,
         override val hardDelete: HardDeleteUpdateInput?,
         override val idempotenceKey: String?,
-    ) : OppdaterKalenderavtaleInput()
+    ) : OppdaterKalenderavtaleInput() {
+        init {
+            if (nyTekst != null) {
+                Validators.compose(
+                    Validators.MaxLength("kalenderavtale.tekst", 300),
+                    Validators.NonIdentifying("kalenderavtale.tekst")
+                )(nyTekst)
+            }
+        }
+    }
 
     data class OppdaterByEksternIdKalenderavtaleInput(
         val eksternId: String,
@@ -361,7 +377,16 @@ internal class MutationKalenderavtale(
         override val paaminnelse: PaaminnelseInput?,
         override val hardDelete: HardDeleteUpdateInput?,
         override val idempotenceKey: String?,
-    ) : OppdaterKalenderavtaleInput()
+    ) : OppdaterKalenderavtaleInput() {
+        init {
+            if (nyTekst != null) {
+                Validators.compose(
+                    Validators.MaxLength("kalenderavtale.tekst", 300),
+                    Validators.NonIdentifying("kalenderavtale.tekst")
+                )(nyTekst)
+            }
+        }
+    }
 
     private suspend fun kalenderavtaleOppdaterById(
         context: ProdusentAPI.Context,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -3,7 +3,6 @@ package no.nav.arbeidsgiver.notifikasjon.produsent.api
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import graphql.schema.idl.RuntimeWiring
-import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnRessursMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Mottaker
@@ -149,6 +148,19 @@ internal class MutationNySak(
         val nesteSteg: String?,
         val hardDelete: FutureTemporalInput?,
     ) {
+        init {
+            Validators.compose(
+                Validators.MaxLength("sak.tittel", 140),
+                Validators.NonIdentifying("sak.tittel")
+            )(tittel)
+            tilleggsinformasjon?.let {
+                Validators.compose(
+                    Validators.MaxLength("sak.tilleggsinformasjon", 140),
+                    Validators.NonIdentifying("sak.tilleggsinformasjon")
+                )(it)
+            }
+        }
+
         fun somSakOpprettetHendelse(
             id: UUID,
             produsentId: String,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationTilleggsinformasjonSak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationTilleggsinformasjonSak.kt
@@ -45,10 +45,19 @@ internal class MutationTilleggsinformasjonSak(
     }
 
 
-    data class TilleggsinformasjonSakInput(
+    data class  TilleggsinformasjonSakInput(
         val tilleggsinformasjon: String?,
         val idempotencyKey: String?,
     ) {
+        init {
+            if(tilleggsinformasjon != null) {
+                Validators.compose(
+                    Validators.MaxLength("tilleggsinformasjon", 140),
+                    Validators.NonIdentifying("tilleggsinformasjon"),
+                )(tilleggsinformasjon)
+            }
+        }
+
         fun tilleggsinformasjonSakHendelse(
             kildeAppNavn: String,
             produsentId: String,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentAPI.kt
@@ -29,9 +29,6 @@ object ProdusentAPI {
 
         return TypedGraphQL(
             createGraphQL("/produsent.graphql") {
-                directive("Validate", ValidateDirective)
-//                directiveWiring(ValidateDirective) // this eliminates the need for @Validate on every field
-
                 scalar(Scalars.ISO8601DateTime)
                 scalar(Scalars.ISO8601LocalDateTime)
                 scalar(Scalars.ISO8601Duration)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelse.kt
@@ -3,7 +3,6 @@ package no.nav.arbeidsgiver.notifikasjon.skedulert_påminnelse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.time.delay
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
@@ -45,7 +44,6 @@ object SkedulertPåminnelse {
                 pauseAfterEach = Duration.ofMinutes(10)
             ) {
                 service.sendAktuellePåminnelser()
-                delay(Duration.ofMinutes(1))
             }
 
             launchHttpServer(httpPort = httpPort)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelse.kt
@@ -12,6 +12,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.launchHttpServer
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.NOTIFIKASJON_TOPIC
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.lagKafkaHendelseProdusent
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.launchProcessingLoop
 import java.time.Duration
 
 object SkedulertPåminnelse {
@@ -39,7 +40,10 @@ object SkedulertPåminnelse {
                 }
             }
 
-            launch {
+            launchProcessingLoop(
+                "sendAktuellePåminnelser",
+                pauseAfterEach = Duration.ofMinutes(10)
+            ) {
                 service.sendAktuellePåminnelser()
                 delay(Duration.ofMinutes(1))
             }

--- a/app/src/main/resources/produsent.graphql
+++ b/app/src/main/resources/produsent.graphql
@@ -1,14 +1,6 @@
 # Denne dokumentasjonen er skrev i "du/dere"-form, hvor du/dere er produsenter, og "vi" er
 # notifikasjons-plattformen.
 
-
-directive @Validate on ARGUMENT_DEFINITION
-directive @MaxLength(max: Int) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
-directive @NonIdentifying on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
-directive @ExactlyOneFieldGiven on INPUT_OBJECT
-directive @MaxValue(upToIncluding: Int) on ARGUMENT_DEFINITION
-directive @NorwegianMobilePhoneNumber on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
-
 """
 DateTime etter ISO8601-standaren. F.eks. '2011-12-03T10:15:30+01:00'.
 Dersom tidssone/offset ikke er oppgitt, så antar vi at tidspunktet er Oslo-tid ('Europe/Oslo').
@@ -74,7 +66,7 @@ type Query {
     """
     mineNotifikasjoner(
         "antall notifikasjoner du ønsker å hente"
-        first: Int @Validate @MaxValue(upToIncluding: 10000)
+        first: Int
 
         """Cursor til notifikasjonen du henter fra. Cursor får du fra [NotifikasjonEdge](#notifikasjonedge)."""
         after: String
@@ -429,7 +421,7 @@ type Mutation {
         """
         Teksten som vises til brukeren.
         """
-        tekst: String! @MaxLength(max: 300) @NonIdentifying @Validate
+        tekst: String!
 
         """
         Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
@@ -439,7 +431,7 @@ type Mutation {
         """
         Her bestemmer dere hvem som skal få se kalenderavtalen.
         """
-        mottakere: [MottakerInput!]! @Validate
+        mottakere: [MottakerInput!]!
 
         """
         Når avtalen starter.
@@ -469,19 +461,19 @@ type Mutation {
         """
         tilstand: KalenderavtaleTilstand
 
-        eksterneVarsler: [EksterntVarselInput!]! = [] @Validate
+        eksterneVarsler: [EksterntVarselInput!]! = []
 
         """
         Her kan du spesifisere en påminnelse for kalenderavtalen.
         Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
         """
-        paaminnelse: PaaminnelseInput @Validate
+        paaminnelse: PaaminnelseInput
 
         """
         Oppgi dersom dere ønsker at hard delete skal skeduleres. Vi
         tolker relative datoer basert på når vi mottok kallet.
         """
-        hardDelete: FutureTemporalInput @Validate
+        hardDelete: FutureTemporalInput
     ): NyKalenderavtaleResultat!
 
     nySak(
@@ -504,20 +496,20 @@ type Mutation {
         NB. At en bruker har tilgang til en sak påvirker ikke om de har tilgang
         til en notifikasjon. De tilgangsstyres hver for seg.
         """
-        mottakere: [MottakerInput!]! @Validate
+        mottakere: [MottakerInput!]!
 
         """
         En tittel på saken, som vises til brukeren.
         Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
         """
-        tittel: String! @Validate @MaxLength(max: 140) @NonIdentifying
+        tittel: String!
 
         """
         Dette feltet er frivillig.
         Tilleggssinformasjon som vises under tittelen på en sak.
         Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
         """
-        tilleggsinformasjon: String @Validate @MaxLength(max: 140) @NonIdentifying
+        tilleggsinformasjon: String
 
         """
         Her oppgir dere en lenke som brukeren kan klikke på for å komme rett til saken.
@@ -555,7 +547,7 @@ type Mutation {
         tolker relative datoer basert på `opprettetTidspunkt` (eller
         når vi mottok kallet hvis dere ikke har oppgitt `opprettetTidspunkt`).
         """
-        hardDelete: FutureTemporalInput @Validate
+        hardDelete: FutureTemporalInput
     ): NySakResultat!
 
     nyStatusSak(
@@ -632,7 +624,7 @@ type Mutation {
         Her har dere mulighet til å vise virksomheten mer informasjon om saken.
         Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
         """
-        tilleggsinformasjon: String @Validate @MaxLength(max: 140) @NonIdentifying
+        tilleggsinformasjon: String
     ): TilleggsinformasjonSakResultat!
 
     tilleggsinformasjonSakByGrupperingsid(
@@ -645,7 +637,7 @@ type Mutation {
         Her har dere mulighet til å vise virksomheten mer informasjon om saken.
         Feltet er begrenset til 140 tegn og kan ikke inneholde fødselsnummer.
         """
-        tilleggsinformasjon: String @Validate @MaxLength(max: 140) @NonIdentifying
+        tilleggsinformasjon: String
     ): TilleggsinformasjonSakResultat!
 
 
@@ -681,12 +673,12 @@ type Mutation {
     """
     Opprett en ny beskjed.
     """
-    nyBeskjed(nyBeskjed: NyBeskjedInput! @Validate): NyBeskjedResultat!
+    nyBeskjed(nyBeskjed: NyBeskjedInput!): NyBeskjedResultat!
 
     """
     Opprett en ny oppgave.
     """
-    nyOppgave(nyOppgave: NyOppgaveInput! @Validate): NyOppgaveResultat!
+    nyOppgave(nyOppgave: NyOppgaveInput!): NyOppgaveResultat!
 
     """
     Marker en oppgave (identifisert ved id) som utført. Dersom oppgaven har påminnelse, vil denne og eventuelle eksterne varsler på påminnelsen bli kansellert.
@@ -700,7 +692,7 @@ type Mutation {
         """
         Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
         """
-        hardDelete: HardDeleteUpdateInput @Validate
+        hardDelete: HardDeleteUpdateInput
 
         """
         Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
@@ -735,7 +727,7 @@ type Mutation {
         """
         Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
         """
-        hardDelete: HardDeleteUpdateInput @Validate
+        hardDelete: HardDeleteUpdateInput
     ): OppgaveUtfoertResultat!
     @deprecated(reason:
     "Using the type ID for `eksternId` can lead to unexpected behaviour. Use oppgaveUtfoertByEksternId_V2 instead."
@@ -758,7 +750,7 @@ type Mutation {
         """
         Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
         """
-        hardDelete: HardDeleteUpdateInput @Validate
+        hardDelete: HardDeleteUpdateInput
 
         """
         Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
@@ -788,7 +780,7 @@ type Mutation {
         """
         Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
         """
-        hardDelete: HardDeleteUpdateInput @Validate
+        hardDelete: HardDeleteUpdateInput
 
         """
         Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
@@ -824,7 +816,7 @@ type Mutation {
         """
         Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
         """
-        hardDelete: HardDeleteUpdateInput @Validate
+        hardDelete: HardDeleteUpdateInput
 
         """
         Ny lenke som oppgaven peker på: overskriver lenken som ble gitt ved
@@ -868,7 +860,7 @@ type Mutation {
         Her kan du spesifisere en påminnelse for oppgaven.
         Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
         """
-        paaminnelse: PaaminnelseInput @Validate
+        paaminnelse: PaaminnelseInput
     ): OppgaveUtsettFristResultat!
 
 
@@ -903,7 +895,7 @@ type Mutation {
         Her kan du spesifisere en påminnelse for oppgaven.
         Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
         """
-        paaminnelse: PaaminnelseInput @Validate
+        paaminnelse: PaaminnelseInput
     ): OppgaveUtsettFristResultat!
 
     """
@@ -928,7 +920,7 @@ type Mutation {
         Dersom eksisterende påminnelse skal fjernes, spesifiser null
         Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
         """
-        paaminnelse: PaaminnelseInput @Validate
+        paaminnelse: PaaminnelseInput
     ) : OppgaveEndrePaaminnelseResultat!
 
     """
@@ -958,7 +950,7 @@ type Mutation {
         Dersom eksisterende påminnelse skal fjernes, spesifiser null
         Brukeren vil bli gjort oppmerksom via bjellen og evt ekstern varsling dersom du oppgir det.
         """
-        paaminnelse: PaaminnelseInput @Validate
+        paaminnelse: PaaminnelseInput
     ) : OppgaveEndrePaaminnelseResultat!
 
 
@@ -985,7 +977,7 @@ type Mutation {
         """
         Teksten som vises til brukeren.
         """
-        nyTekst: String @MaxLength(max: 300) @NonIdentifying @Validate
+        nyTekst: String
 
         """
         Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
@@ -1007,7 +999,7 @@ type Mutation {
         """
         Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
         """
-        hardDelete: HardDeleteUpdateInput @Validate
+        hardDelete: HardDeleteUpdateInput
 
         """
         Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
@@ -1020,7 +1012,7 @@ type Mutation {
         Disse varslene vil erstatte tidligere bestilte varsler som ikke er sendt enda.
         Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey for å unngå å sende samme varsel flere ganger.
         """
-        eksterneVarsler: [EksterntVarselInput!]! = [] @Validate
+        eksterneVarsler: [EksterntVarselInput!]! = []
 
         """
         Her kan du spesifisere en påminnelse for kalenderavtalen.
@@ -1028,7 +1020,7 @@ type Mutation {
         Dersom dere senere oppdaterer kalenderavtalen og setter den til AVLYST, vil vi kansellere registrerte påminnelser.
         Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey.
         """
-        paaminnelse: PaaminnelseInput @Validate
+        paaminnelse: PaaminnelseInput
     ): OppdaterKalenderavtaleResultat!
 
 
@@ -1060,7 +1052,7 @@ type Mutation {
         """
         Teksten som vises til brukeren.
         """
-        nyTekst: String @MaxLength(max: 300) @NonIdentifying @Validate
+        nyTekst: String
 
         """
         Lenken som brukeren føres til hvis de klikker på kalenderavtalen. Typisk en side i deres system som viser detaljer om avtalen.
@@ -1082,7 +1074,7 @@ type Mutation {
         """
         Se: [HardDeleteUpdateInput typen](#harddeleteupdateinput)
         """
-        hardDelete: HardDeleteUpdateInput @Validate
+        hardDelete: HardDeleteUpdateInput
 
         """
         Dersom dere angir idempotenceKey så vil konsekvente kall med samme idempotenceKey gi samme resultat.
@@ -1095,7 +1087,7 @@ type Mutation {
         Disse varslene vil erstatte tidligere bestilte varsler som ikke er sendt enda.
         Vi anbefaler dere å bruke denn i kombinasjon med idempoencyKey for å unngå å sende samme varsel flere ganger.
         """
-        eksterneVarsler: [EksterntVarselInput!]! = [] @Validate
+        eksterneVarsler: [EksterntVarselInput!]! = []
 
         """
         Her kan du spesifisere en påminnelse for kalenderavtalen.
@@ -1103,7 +1095,7 @@ type Mutation {
         Dersom dere senere oppdaterer kalenderavtalen og setter den til AVLYST, vil vi kansellere registrerte påminnelser.
         Vi anbefaler dere å bruke denne i kombinasjon med idempotencyKey.
         """
-        paaminnelse: PaaminnelseInput @Validate
+        paaminnelse: PaaminnelseInput
     ): OppdaterKalenderavtaleResultat!
 
     """
@@ -1459,7 +1451,7 @@ input PaaminnelseInput {
     eksterneVarsler: [PaaminnelseEksterntVarselInput!]! = []
 }
 
-input PaaminnelseTidspunktInput @ExactlyOneFieldGiven {
+input PaaminnelseTidspunktInput {
     """
     Konkret tidspunkt
     """
@@ -1480,10 +1472,11 @@ input PaaminnelseTidspunktInput @ExactlyOneFieldGiven {
     foerStartTidspunkt: ISO8601Duration
 }
 
-input PaaminnelseEksterntVarselInput @ExactlyOneFieldGiven {
+input PaaminnelseEksterntVarselInput {
     sms: PaaminnelseEksterntVarselSmsInput
     epost: PaaminnelseEksterntVarselEpostInput
     altinntjeneste: PaaminnelseEksterntVarselAltinntjenesteInput
+    altinnressurs: PaaminnelseEksterntVarselAltinnressursInput
 }
 
 input PaaminnelseEksterntVarselSmsInput {
@@ -1544,11 +1537,36 @@ input PaaminnelseEksterntVarselAltinntjenesteInput {
     sendevindu: Sendevindu!
 }
 
+input PaaminnelseEksterntVarselAltinnressursInput {
+    mottaker: AltinnRessursMottakerInput!
+    """
+    Subject/emne til e-posten
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    epostTittel: String!
+    """
+    Kroppen til e-posten. Kan inneholde HTML.
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    epostHtmlBody: String!
+    """
+    Teksten som sendes i SMS-en.
+    OBS: Det er ikke lov med personopplysninger i teksten.
+    """
+    smsTekst: String!
+    """
+    Vi sender eposten med utgangspunkt i påminnelsestidspunktet, men tar hensyn
+    til sendingsvinduet. Hvis påminnelsestidspunktet er utenfor vinduet, sender vi
+    det ved første mulighet.
+    """
+    sendevindu: Sendevindu!
+}
+
 """
 Input som definerer hvordan et eksternt varsel skal sendes.
 Kun ett av feltene i inputen kan være satt.
 """
-input EksterntVarselInput @ExactlyOneFieldGiven {
+input EksterntVarselInput {
     sms: EksterntVarselSmsInput
     epost: EksterntVarselEpostInput
     altinntjeneste: EksterntVarselAltinntjenesteInput
@@ -1592,7 +1610,7 @@ Med denne typen velger du når du ønsker at det eksterne varselet blir sendt.
 Du skal velge en (og kun en) av feltene, ellers blir forespørselen din avvist
 med en feil.
 """
-input SendetidspunktInput @ExactlyOneFieldGiven {
+input SendetidspunktInput {
     """
     Hvis du spesifiserer et tidspunkt på formen "YYYY-MM-DDThh:mm", så sender
     vi notifikasjonen på det tidspunktet. Oppgir du et tidspunkt i fortiden,
@@ -1693,7 +1711,7 @@ input EksterntVarselAltinnressursInput {
     sendetidspunkt: SendetidspunktInput!
 }
 
-input SmsMottakerInput @ExactlyOneFieldGiven {
+input SmsMottakerInput {
     kontaktinfo: SmsKontaktInfoInput
 }
 
@@ -1705,10 +1723,10 @@ input SmsKontaktInfoInput {
     Nummeret må være gyldig iht norske mobilnummer-regler (40000000-49999999, 90000000-99999999)
     se https://nkom.no/telefoni-og-telefonnummer/telefonnummer-og-den-norske-nummerplan/alle-nummerserier-for-norske-telefonnumre
     """
-    tlf: String! @NorwegianMobilePhoneNumber
+    tlf: String!
 }
 
-input EpostMottakerInput @ExactlyOneFieldGiven {
+input EpostMottakerInput {
     kontaktinfo: EpostKontaktInfoInput
 }
 
@@ -1735,7 +1753,7 @@ Du kan spesifisere mottaker av notifikasjoner på forskjellige måter. Du skal b
 
 Vi har implementert det på denne måten fordi GraphQL ikke støtter union-typer som input.
 """
-input MottakerInput @ExactlyOneFieldGiven {
+input MottakerInput {
     altinn: AltinnMottakerInput
     altinnRessurs: AltinnRessursMottakerInput
     naermesteLeder: NaermesteLederMottakerInput
@@ -1796,7 +1814,7 @@ input NotifikasjonInput {
     """
     Teksten som vises til brukeren. Feltet er begrenset til 300 tegn og kan ikke inneholde fødselsnummer.
     """
-    tekst: String! @MaxLength(max: 300) @NonIdentifying
+    tekst: String!
 
     """
     Lenken som brukeren føres til hvis de klikker på beskjeden.
@@ -1846,7 +1864,7 @@ input MetadataInput {
 """
 Med denne kan dere spesifiserer et konkret tidspunkt.
 """
-input FutureTemporalInput @ExactlyOneFieldGiven {
+input FutureTemporalInput {
     """
     En konkret dato. I Europe/Oslo-tidssone.
     """

--- a/test-produsent/src/Komponenter/EksternVarsling.tsx
+++ b/test-produsent/src/Komponenter/EksternVarsling.tsx
@@ -246,7 +246,7 @@ export const formaterPåminnelse = (påminnelseRef: React.MutableRefObject<Ekste
                         }
                     },
                     smsTekst: smsTekst,
-                    sendevindu: Sendevindu.NksAapningstid
+                    sendevindu: Sendevindu.Loepende
                 }
             }]
         }
@@ -270,7 +270,7 @@ export const formaterPåminnelse = (påminnelseRef: React.MutableRefObject<Ekste
                     },
                     epostTittel: epostTittel,
                     epostHtmlBody: epostHtmlBody,
-                    sendevindu: Sendevindu.NksAapningstid
+                    sendevindu: Sendevindu.Loepende
 
                 }
             }]
@@ -295,7 +295,7 @@ export const formaterPåminnelse = (påminnelseRef: React.MutableRefObject<Ekste
                     },
                     tittel: tittel,
                     innhold: innhold,
-                    sendevindu: Sendevindu.NksAapningstid
+                    sendevindu: Sendevindu.Loepende
                 }
             }]
         }
@@ -319,7 +319,7 @@ export const formaterPåminnelse = (påminnelseRef: React.MutableRefObject<Ekste
                     epostTittel: epostTittel,
                     epostHtmlBody: epostHtmlBody,
                     smsTekst: smsTekst,
-                    sendevindu: Sendevindu.NksAapningstid
+                    sendevindu: Sendevindu.Loepende
                 }
             }]
 

--- a/test-produsent/src/Komponenter/EksternVarsling.tsx
+++ b/test-produsent/src/Komponenter/EksternVarsling.tsx
@@ -299,6 +299,32 @@ export const formaterPåminnelse = (påminnelseRef: React.MutableRefObject<Ekste
                 }
             }]
         }
+    } else if ("ressursId" in varselfraref) {
+        const {ressursId, epostTittel, epostHtmlBody, smsTekst, tidspunkt} = varselfraref as Altinnressurs
+        if (nullIfEmpty(ressursId) === null ||
+            nullIfEmpty(epostTittel) === null ||
+            nullIfEmpty(epostHtmlBody) === null ||
+            nullIfEmpty(smsTekst) === null ||
+            nullIfEmpty(tidspunkt) === null
+        ) return null
+        return {
+            tidspunkt: {
+                etterOpprettelse: "PT1M"
+            },
+            eksterneVarsler: [{
+                altinnressurs: {
+                    mottaker: {
+                        ressursId: ressursId
+                    },
+                    epostTittel: epostTittel,
+                    epostHtmlBody: epostHtmlBody,
+                    smsTekst: smsTekst,
+                    sendevindu: Sendevindu.NksAapningstid
+                }
+            }]
+
+        }
+    } else {
+        return null
     }
-    return null
 }


### PR DESCRIPTION
Endrer fra validering med graphql directives, til en mer eksplisitt validering i DTOene.

Dette gjør at valideringen er mindre magisk, lettere å utvide, samt mer garantert å fungere som forventet. Krevde en liten endring i feilhåndteringslogikken i  TypeRuntimeWiring.Builder.coDataFetcher (GraphQL.kt) Siden jackson pakker inn feil i DTOer som deserialiseres via objectMapperen. Der er det nå endret til å sjekke om RuntimException er forårsaket av en ValideringsFeil og i såfall håndtere den som en valideringsfeil, hvis ikek gjør den som før.

---
og forresten, oppdaget at ressursId støtte manglet på varsel ved påminnelse 😬 , sniker det inn her