### PR TITLE
får regelmessige feilmelding på requeue

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
@@ -634,7 +634,9 @@ class EksternVarslingRepository(
                 where 
                     state in ('${EksterntVarselTilstand.NY}', '${EksterntVarselTilstand.SENDT}')
                     and varsel_id not in (select varsel_id from job_queue)
+                    and varsel_id not in (select varsel_id from wait_queue)
             )
+            on conflict do nothing
         """
         )
     }


### PR DESCRIPTION
Dette ser ut til å skje fordi to processing loops forsøker å gjøre det samme:

`requeue-lost-work` går hvert 10. minutt og oppretter jobber for varsler som ikke er ferdige og ikke allerede ligger i job queue

`resume-scheduled-work` går hvert 5. minutt og flytter ting som ligger på wait_queue til job_queue

Feilmeldingen oppstår når en varsling som ligger i wait queue blir forsøkt opprettet av requeue-lost-work.

Dette skjer fordi de kjører omtrent samtidi siden 10 og 5 har overlapp hvert 10. minutt. Det vil også kunne skje når en pod restartes siden det ikek er en initiell pause på loppene.


Eksempel fra prod logger. 2 log linjer omtrent samtidig. Samme pod. Viser at loopene går i beina på hverandre:
```
[
  {
    "cluster": [
      "prod-gcp"
    ],
    "pod": [
      "notifikasjon-ekstern-varsling-7746b7b8f8-k5cvg"
    ],
    "level": [
      "Error"
    ],
    "message": [
      "exception org.postgresql.util.PSQLException in processing loop requeue-lost-work"
    ],
    "component": [
      "no.nav.processing_loop.requeue-lost-work"
    ],
    "@timestamp": [
      "2025-04-03T20:35:52.341Z"
    ],
    "application": [
      "notifikasjon-ekstern-varsling"
    ],
    "namespace": [
      "fager"
    ],
    "stack_trace": [
      "org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint \"idx_job_queue_varsel_id_unique\"\n  Detail: Key (varsel_id)=(d4609bf7-8cf1-43b2-b7f1-8c6f59f079ed) already exists....
    ]
  },
  {
    "cluster": [
      "prod-gcp"
    ],
    "pod": [
      "notifikasjon-ekstern-varsling-7746b7b8f8-k5cvg"
    ],
    "level": [
      "Info"
    ],
    "message": [
      "resumed 3 jobs from wait queue"
    ],
    "component": [
      "no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.EksternVarslingService"
    ],
    "@timestamp": [
      "2025-04-03T20:35:52.224Z"
    ],
    "application": [
      "notifikasjon-ekstern-varsling"
    ],
    "namespace": [
      "fager"
    ]
  }
]
```