### PR TITLE
legg til compound index for å hindre seq scan ved deleteScheduledHard…

### DIFF
--- a/app/src/main/resources/db/migration/ekstern_varsling_model/V15__evk_compound_index.sql
+++ b/app/src/main/resources/db/migration/ekstern_varsling_model/V15__evk_compound_index.sql
@@ -1,0 +1,2 @@
+create index idx_evk_state_notifikasjon_id
+    on ekstern_varsel_kontaktinfo (state, notifikasjon_id);


### PR DESCRIPTION
…Deletes i ekstern-varsling


Gravde litt i [cloud.console](https://console.cloud.google.com/sql/instances/notifikasjon-ekstern-varsling-v2/insights;database=ekstern-varsling-model;duration=PT1H;trace=9abc64a7512fcff63fb79d34c447727b;span=cd60541597249924;query_hash=1350268152408847067;sort_by=TOTAL_EXEC_TIME/executed?hl=en&inv=1&invt=AbzXzw&project=fager-prod-dd77) og kom frem til at det er denne spørringen som har en høy kost. 
Dette skjer nok fordi hard_delete tabellen har vokst seg til en viss størrelse. 
Legger til en compound index som jeg tror skal gjøre at postgres velger en bedre plan. 