### PR TITLE
Ikke propager cancellation exception som en graphql error.

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpServer.kt
@@ -50,7 +50,7 @@ val extractBrukerContext = fun RoutingContext.(): BrukerAPI.Context {
     return BrukerAPI.Context(
         fnr = principal.fnr,
         authHeader,
-        coroutineScope = this.call
+        coroutineScope = CoroutineScope(call.coroutineContext + MDCContext())
     )
 }
 
@@ -60,7 +60,7 @@ fun extractProdusentContext(produsentRegister: ProdusentRegister) =
         return ProdusentAPI.Context(
             appName = principal.appName,
             produsent = produsentRegister.finn(principal.appName),
-            coroutineScope = this.call
+            coroutineScope = CoroutineScope(call.coroutineContext + MDCContext())
         )
     }
 
@@ -110,7 +110,7 @@ fun <T : WithCoroutineScope> Application.graphqlSetup(
             }
 
             post("graphql") {
-                withContext(this.call.coroutineContext + graphQLDispatcher + MDCContext()) {
+                withContext(call.coroutineContext + graphQLDispatcher + MDCContext()) {
                     val context = extractContext()
                     val request = call.receive<GraphQLRequest>()
                     val result = graphql.await().timedExecute(request, context)


### PR DESCRIPTION
Når en klient avbryter en request så ender det som en cancellation. Ekssiterende feilhåndtering gjør dette til en GraphQLError og logger det som en feil. (2 log error per slik feil)

Denne endringen forsøker å sørge for at cancellation blir respektert, og at det ikke logges som støy.