### PR TITLE
Optimaliser sletting etter kvittert

### DIFF
--- a/app/src/main/resources/db/migration/ekstern_varsling_model/V16__mv_evk_to_delete.sql
+++ b/app/src/main/resources/db/migration/ekstern_varsling_model/V16__mv_evk_to_delete.sql
@@ -1,0 +1,9 @@
+create materialized view ekstern_varsel_kontaktinfo_to_delete as
+select evk.notifikasjon_id
+from ekstern_varsel_kontaktinfo evk
+         join hard_delete hd on evk.notifikasjon_id = hd.notifikasjon_id
+where evk.state = 'KVITTERT';
+
+-- required for refresh ... concurrently
+create unique index idx_evk_to_delete_notifikasjon_id
+    on ekstern_varsel_kontaktinfo_to_delete (notifikasjon_id);

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/BackupRepositoryTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/BackupRepositoryTest.kt
@@ -5,6 +5,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.header.internals.RecordHeader
 import org.apache.kafka.common.header.internals.RecordHeaders
 import org.apache.kafka.common.record.TimestampType
+import java.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -135,11 +136,11 @@ fun record(
         offset,
         0L,
         TimestampType.NO_TIMESTAMP_TYPE,
-        0L,
         keyBytes.size,
         valueBytes?.size ?: 0,
         keyBytes,
         valueBytes,
         headers,
+        Optional.of(0)
     )
 }


### PR DESCRIPTION
# Problemet

EksternVarsling er skrevet til å garantere sending av varsler. Derfor venter man med sletting til varslene er markert som kvittert. Dette gjør at over tid blir join som gjøres mellom hard_delete tabellen og ekstern_varsel_kontaktinfo større og større. Over tid har denne vokst seg så stor i prod at join medfører seq scan som nå tar flere sekunder hver gang. Dette er ikke et problem i seg selv, da processen som sletter går i bakgrunnen hver 10 minutter, men det medfører støy i alertene.

# Løsning

Her endres prosessen som sjekker etter kvitterte men ikke slettede varsler (kontaktinfo) fra å være en sql join, til å sjekke mot et materialized view som inneholder samme grunnlag som join. Det er også lagt til en test som verifiserer at kontaktinfo kun slettes etter kvittering. Denne testen går grønn mot både gammel og ny implementasjon av deleteScheduledHardDeletes.