### PR TITLE
Refaktorering av shutdown signaling og håndtering i kafka consumer

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Health.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Health.kt
@@ -1,6 +1,5 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
-import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -13,8 +12,6 @@ enum class Subsystem {
 }
 
 object Health {
-    private val log = logger()
-
     val subsystemAlive = ConcurrentHashMap(mapOf(
         Subsystem.DATABASE to true,
         Subsystem.KAFKA to true,
@@ -38,23 +35,7 @@ object Health {
     val terminating: Boolean
         get() = !alive || terminatingAtomic.get()
 
-    init {
-        val shutdownTimeout = basedOnEnv(
-            prod = { Duration.ofSeconds(20) },
-            dev = { Duration.ofSeconds(20) },
-            other = { Duration.ofMillis(0) },
-        )
-
-        Runtime.getRuntime().addShutdownHook(object: Thread() {
-            override fun run() {
-                terminatingAtomic.set(true)
-                log.info("shutdown signal received")
-                try {
-                    sleep(shutdownTimeout.toMillis())
-                } catch (e: Exception) {
-                    // nothing to do
-                }
-            }
-        })
+    fun terminate() {
+        terminatingAtomic.set(true)
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -7,7 +7,7 @@ import io.micrometer.core.instrument.Timer
 import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
@@ -20,6 +20,7 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.schedule
@@ -107,31 +108,47 @@ private constructor(
         enabled = replayPeriodically,
     )
 
+    fun wakeup() {
+        consumer.wakeup()
+    }
+
+    fun close() {
+        consumer.close()
+        kafkaContext.close()
+        retryTimer.cancel()
+    }
+
     suspend fun forEach(
         stop: AtomicBoolean = AtomicBoolean(false),
         body: suspend (ConsumerRecord<K, V>) -> Unit
-    ) {
-        withContext(kafkaContext) {
-            while (!stop.get() && !Health.terminating) {
-                replayer.replayWhenLeap()
-                consumer.resume(resumeQueue.pollAll())
-                val records = try {
-                    consumer.poll(Duration.ofMillis(1000))
-                } catch (e: Exception) {
-                    log.error("Unrecoverable error during poll {}", consumer.assignment(), e)
-                    Health.subsystemAlive[Subsystem.KAFKA] = false
-                    throw e
-                }
+    ) = withContext(kafkaContext) {
+        while (isActive && !stop.get() && !Health.terminating) {
+            replayer.replayWhenLeap()
+            consumer.resume(resumeQueue.pollAll())
 
-                pollBodyTimer.record(Runnable {
-                    forEachRecord(records, body)
-                })
+            val records = try {
+                consumer.poll(Duration.ofMillis(1000))
+            } catch (e: Exception) {
+                log.error("Unrecoverable error during poll {}", consumer.assignment(), e)
+                Health.subsystemAlive[Subsystem.KAFKA] = false
+                throw e
             }
 
+            if (!records.isEmpty) {
+                val start = System.nanoTime()
+
+                try {
+                    forEachRecord(records, body)
+                } finally {
+                    val elapsed = System.nanoTime() - start
+                    pollBodyTimer.record(elapsed, TimeUnit.NANOSECONDS)
+                }
+            }
         }
+
     }
 
-    private fun forEachRecord(
+    private suspend fun forEachRecord(
         records: ConsumerRecords<K, V>,
         body: suspend (ConsumerRecord<K, V>) -> Unit
     ) {
@@ -145,7 +162,7 @@ private constructor(
                 try {
                     if (!seekToBeginning) log.info("processing {}", record.loggableToString())
                     iterationEntryCounter.increment()
-                    runBlocking(Dispatchers.IO) {
+                    withContext(Dispatchers.IO) {
                         body(record)
                     }
                     consumer.commitSync(mapOf(partition to OffsetAndMetadata(record.offset() + 1)))

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/HendelsesstrømKafkaImpl.kt
@@ -59,6 +59,9 @@ class HendelsesstrømKafkaImpl(
             }
         }
     }
+
+    fun wakeup() = consumer.wakeup()
+    fun close() = consumer.close()
 }
 
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaper.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaper.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.configureRouting
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.notifyOnShutdown
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.NOTIFIKASJON_TOPIC
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.lagKafkaHendelseProdusent
@@ -35,6 +36,8 @@ object KafkaReaper {
             }
 
             configureRouting { }
+
+            notifyOnShutdown(hendelsesstrøm)
         }.start(wait = true)
     }
 }


### PR DESCRIPTION
Vi får regelmessig støy på at applikasjonen ikke klarer å stenge ned på en ryddig måte. I form av `Failed to destroy application instance` Jeg er ganske sikker på at dette er pga at hendelsesstrømmen ikke får med seg at vi er på vei ned. Tidligere var appene orkestrert med structural concurrency på utsiden av ktor. Dette ble endret nylig til at ktor eier orkestreringen av coroutines. Skjedde i PR #903 https://github.com/navikt/arbeidsgiver-notifikasjon-produsent-api/pull/903

I denne commiten endrer jeg slik at vi lytter på ktor sin appstopping og appstopped events. i base oppsettet så signaliserer dette at healh.terminating er true. Som et tillegg lager jeg en signalsti fra ktor til hendelsesstrøm som sørger for at hendelsesstrømmen stoppes når ktor stoppes. Inne i selve kafka consumeren så har jeg også skrevet om slik at implementasjonen er mer coroutine aware, og ikke lenger benytter runblocking.

# TODO
- [ ] koble notifyOnShutdown i alle appene, ikke bare kafkareaper 