### PR TITLE
fjerner runBlocking fra main og flytter init inn i embeddedServer

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerWriter.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerWriter.kt
@@ -3,9 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon.bruker
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabase
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.configureRouting
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.registerShutdownListener
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
@@ -17,16 +16,15 @@ object BrukerWriter {
 
     fun main(
         httpPort: Int = 8080
-    ) = runBlocking {
-        val hendelsesstrøm = HendelsesstrømKafkaImpl(
-            topic = NOTIFIKASJON_TOPIC,
-            groupId = "bruker-model-builder-2",
-            replayPeriodically = true,
-        )
-        val database = openDatabaseAsync(databaseConfig).await()
-
+    ) {
         embeddedServer(CIO, port = httpPort) {
+            val database = openDatabase(databaseConfig)
             val brukerRepository = BrukerRepositoryImpl(database)
+            val hendelsesstrøm = HendelsesstrømKafkaImpl(
+                topic = NOTIFIKASJON_TOPIC,
+                groupId = "bruker-model-builder-2",
+                replayPeriodically = true,
+            )
 
             launch {
                 hendelsesstrøm.forEach { event, metadata ->

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/Dataprodukt.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/Dataprodukt.kt
@@ -3,9 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon.dataprodukt
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabase
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.configureRouting
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.registerShutdownListener
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
@@ -17,21 +16,20 @@ object Dataprodukt {
     private val saltVerdi = System.getenv("SALT_VERDI")
         ?: error("Missing required environment variable: SALT_VERDI")
 
-
-    fun main(httpPort: Int = 8080) = runBlocking {
-        val hendelsesstrøm = HendelsesstrømKafkaImpl(
-            topic = NOTIFIKASJON_TOPIC,
-            groupId = "dataprodukt-model-builder-3",
-            replayPeriodically = true,
-        )
-        val database = openDatabaseAsync(databaseConfig) {
-            placeholders(
-                mapOf("SALT_VERDI" to saltVerdi),
-            )
-        }.await()
-
+    fun main(httpPort: Int = 8080) {
         embeddedServer(CIO, port = httpPort) {
+            val database = openDatabase(databaseConfig) {
+                placeholders(
+                    mapOf("SALT_VERDI" to saltVerdi),
+                )
+            }
             val dataproduktModel = DataproduktModel(database)
+
+            val hendelsesstrøm = HendelsesstrømKafkaImpl(
+                topic = NOTIFIKASJON_TOPIC,
+                groupId = "dataprodukt-model-builder-3",
+                replayPeriodically = true,
+            )
 
             launch {
                 hendelsesstrøm.forEach { hendelse, metadata ->

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/KafkaBackup.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_backup/KafkaBackup.kt
@@ -3,9 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon.kafka_backup
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabase
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.configureRouting
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.registerShutdownListener
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.NOTIFIKASJON_TOPIC
@@ -13,14 +12,13 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.NOTIFIKASJON_TOPIC
 object KafkaBackup {
     internal val databaseConfig = Database.config("kafka_backup_model")
 
-    fun main(httpPort: Int = 8080) = runBlocking {
-        val hendelsestrøm: RawKafkaReader = RawKafkaReaderImpl(
-            topic = NOTIFIKASJON_TOPIC,
-            groupId = "kafka-backup-model-builder",
-        )
-        val database = openDatabaseAsync(databaseConfig).await()
-
+    fun main(httpPort: Int = 8080) {
         embeddedServer(CIO, port = httpPort) {
+            val hendelsestrøm: RawKafkaReader = RawKafkaReaderImpl(
+                topic = NOTIFIKASJON_TOPIC,
+                groupId = "kafka-backup-model-builder",
+            )
+            val database = openDatabase(databaseConfig)
             launch {
                 val repository = BackupRepository(database)
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_bq/KafkaBQ.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_bq/KafkaBQ.kt
@@ -28,10 +28,10 @@ object KafkaBQ {
     )
 
     fun main(httpPort: Int = 8080) {
-        val hendelsesstrøm = HendelsesstrømKafkaImpl(groupId = "kafka-bq-v1")
-
         embeddedServer(CIO, port = httpPort) {
             Health.subsystemReady[Subsystem.DATABASE] = true
+
+            val hendelsesstrøm = HendelsesstrømKafkaImpl(groupId = "kafka-bq-v1")
 
             launch {
                 hendelsesstrøm.forEach { hendelse ->

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaper.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/kafka_reaper/KafkaReaper.kt
@@ -3,9 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon.kafka_reaper
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabase
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.configureRouting
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.registerShutdownListener
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
@@ -15,16 +14,15 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.lagKafkaHendelseProd
 object KafkaReaper {
     val databaseConfig = Database.config("kafka_reaper_model")
 
-    fun main(httpPort: Int = 8080) = runBlocking {
-        val hendelsesstrøm = HendelsesstrømKafkaImpl(
-            topic = NOTIFIKASJON_TOPIC,
-            groupId = "reaper-model-builder",
-            replayPeriodically = true,
-        )
-        val hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
-        val database = openDatabaseAsync(databaseConfig).await()
-
+    fun main(httpPort: Int = 8080) {
         embeddedServer(CIO, port = httpPort) {
+            val hendelsesstrøm = HendelsesstrømKafkaImpl(
+                topic = NOTIFIKASJON_TOPIC,
+                groupId = "reaper-model-builder",
+                replayPeriodically = true,
+            )
+            val hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
+            val database = openDatabase(databaseConfig)
             launch {
                 val kafkaReaperService = KafkaReaperServiceImpl(
                     KafkaReaperModelImpl(database),

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/Produsent.kt
@@ -3,9 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon.produsent
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabase
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.HttpAuthProviders
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.extractProdusentContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.graphqlSetup
@@ -23,23 +22,24 @@ object Produsent {
     fun main(
         httpPort: Int = 8080,
         produsentRegister: ProdusentRegister = PRODUSENT_REGISTER,
-    ) = runBlocking {
-        val hendelsesstrøm = HendelsesstrømKafkaImpl(
-            topic = NOTIFIKASJON_TOPIC,
-            groupId = "produsent-model-builder",
-            replayPeriodically = true
-        )
-
-        val database = openDatabaseAsync(databaseConfig).await()
-        val produsentRepository = ProdusentRepositoryImpl(database)
-        val hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
-
-        val graphql = ProdusentAPI.newGraphQL(
-            kafkaProducer = hendelseProdusent,
-            produsentRepository = produsentRepository,
-        )
+    ) {
 
         embeddedServer(CIO, port = httpPort) {
+            val database = openDatabase(databaseConfig)
+            val produsentRepository = ProdusentRepositoryImpl(database)
+
+            val hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
+            val graphql = ProdusentAPI.newGraphQL(
+                kafkaProducer = hendelseProdusent,
+                produsentRepository = produsentRepository,
+            )
+
+            val hendelsesstrøm = HendelsesstrømKafkaImpl(
+                topic = NOTIFIKASJON_TOPIC,
+                groupId = "produsent-model-builder",
+                replayPeriodically = true
+            )
+
             launch {
                 hendelsesstrøm.forEach { event, metadata ->
                     produsentRepository.oppdaterModellEtterHendelse(event, metadata)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidator.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/replay_validator/ReplayValidator.kt
@@ -11,14 +11,14 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafka
 
 object ReplayValidator {
     fun main(httpPort: Int = 8080) {
-        val hendelsesstrøm = HendelsesstrømKafkaImpl(
-            groupId = "replay-validator",
-            replayPeriodically = true,
-            seekToBeginning = true
-        )
-
         embeddedServer(CIO, port = httpPort) {
             Health.subsystemReady[Subsystem.DATABASE] = true
+
+            val hendelsesstrøm = HendelsesstrømKafkaImpl(
+                groupId = "replay-validator",
+                replayPeriodically = true,
+                seekToBeginning = true
+            )
 
             launch {
                 hendelsesstrøm.forEach { _ ->

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_påminnelse/SkedulertPåminnelse.kt
@@ -3,9 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon.skedulert_påminnelse
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabase
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.configureRouting
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.registerShutdownListener
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
@@ -17,18 +16,18 @@ import java.time.Duration
 object SkedulertPåminnelse {
     val databaseConfig = Database.config("skedulert_paaminnelse_model")
 
-    fun main(httpPort: Int = 8080) = runBlocking {
-        val hendelsesstrøm = HendelsesstrømKafkaImpl(
-            topic = NOTIFIKASJON_TOPIC,
-            groupId = "skedulert-paaminnelse-2",
-        )
-        val database = openDatabaseAsync(databaseConfig).await()
-        val hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
-
+    fun main(httpPort: Int = 8080) {
         embeddedServer(CIO, port = httpPort) {
+            val database = openDatabase(databaseConfig)
+            val hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
             val service = SkedulertPåminnelseService(
                 hendelseProdusent = hendelseProdusent,
                 database = database
+            )
+
+            val hendelsesstrøm = HendelsesstrømKafkaImpl(
+                topic = NOTIFIKASJON_TOPIC,
+                groupId = "skedulert-paaminnelse-2",
             )
 
             launch {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgått.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgått.kt
@@ -3,9 +3,8 @@ package no.nav.arbeidsgiver.notifikasjon.skedulert_utgått
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabaseAsync
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database.Companion.openDatabase
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.configureRouting
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.registerShutdownListener
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.HendelsesstrømKafkaImpl
@@ -17,20 +16,20 @@ import java.time.Duration
 object SkedulertUtgått {
     val databaseConfig = Database.config("skedulert_utgatt_model")
 
-    fun main(httpPort: Int = 8080) = runBlocking {
-        val database = openDatabaseAsync(databaseConfig).await()
-        val hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
-        val hendelsesstrøm = HendelsesstrømKafkaImpl(
-            topic = NOTIFIKASJON_TOPIC,
-            groupId = "skedulert-utgatt-model-builder-0",
-            replayPeriodically = true,
-        )
-
+    fun main(httpPort: Int = 8080) {
         embeddedServer(CIO, port = httpPort) {
+            val database = openDatabase(databaseConfig)
             val repository = SkedulertUtgåttRepository(database)
+            val hendelseProdusent = lagKafkaHendelseProdusent(topic = NOTIFIKASJON_TOPIC)
             val service = SkedulertUtgåttService(
                 repository = repository,
                 hendelseProdusent = hendelseProdusent
+            )
+
+            val hendelsesstrøm = HendelsesstrømKafkaImpl(
+                topic = NOTIFIKASJON_TOPIC,
+                groupId = "skedulert-utgatt-model-builder-0",
+                replayPeriodically = true,
             )
 
             launch {


### PR DESCRIPTION
Vi får en del feil av typen: 
`EmbeddedServer was stopped at io.ktor.server.engine.EmbeddedServer.currentApplication`
og `kotlinx.coroutines.TimeoutCancellationException: Timed out waiting for 5000 ms\n\tat kotlinx.coroutines.TimeoutKt.TimeoutCancellationException` Ved deploy og autoscaling.
Dette ser ut til å skyldes at noen tjenester settes opp (og av og til feiler) før serveren er startet.
Med denne endringen flyttes alt av oppsett inn i strukturert concurrency under ktor serveren.
