### PR TITLE
Migrate Altinn 3 varsel klient fra deprecated /orders til /future/ord…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,132 @@
+# GitHub Copilot Instructions
+
+## Project Overview
+
+This is the **arbeidsgiver-notifikasjon-produsent-api** monorepo — a notification platform for employers ("arbeidsgivere") built on an Event Sourcing architecture. The central Kafka topic `fager.notifikasjon` is the event backbone, and multiple microservices consume from it to build their own materialized views in separate PostgreSQL databases.
+
+The platform is owned by **team fager** in NAV (Norwegian Labour and Welfare Administration) and runs on the NAIS platform (Kubernetes on GCP).
+
+## Monorepo Structure
+
+| Module | Stack | Purpose |
+|---|---|---|
+| `app/` | Kotlin, Maven, Ktor 3, GraphQL | Main backend — all microservices in one build |
+| `test-produsent/` | TypeScript, React 19, Vite, Apollo Client | Interactive test UI for the producer API |
+| `fake-produsent-api/` | Node.js, Express, Apollo Server | Mock GraphQL server for testing |
+| `widget/` | TypeScript, React, Vite, NPM package | Published component `@navikt/arbeidsgiver-notifikasjon-widget` |
+| `terraform/` | HCL | BigQuery datasets, service accounts, GCP infra |
+| `docs/` | Markdown | User-facing documentation (GitHub Pages) |
+| `adr/` | Markdown | Architecture Decision Records |
+
+## Language & Framework Guidelines
+
+### Kotlin (app/)
+
+- **Kotlin 2.1+** targeting **JVM 21**
+- **Ktor 3** with CIO engine for HTTP servers
+- **graphql-java** for GraphQL schema-first API (schemas in `src/main/resources/*.graphql`)
+- **Jackson** with `JavaTimeModule` for JSON serialization
+- **kotlinx-coroutines** for async operations
+- **Kafka Clients 3.9** for event production/consumption
+- **PostgreSQL** with HikariCP connection pooling and **Flyway** migrations
+- **Micrometer + Prometheus** for metrics
+- **Apache CXF** for Altinn SOAP/WSDL integration
+- **Code style**: Kotlin Official (ktfmt). Use `when` expressions, sealed classes, data classes, and extension functions idiomatically.
+- **Package root**: `no.nav.arbeidsgiver.notifikasjon`
+
+### TypeScript / React (test-produsent/, widget/)
+
+- **TypeScript 5.9+**, **React 19**, **Vite 7**
+- **Apollo Client** for GraphQL
+- **NAV Design System** (`@navikt/ds-react`, `@navikt/ds-css`)
+- **GraphQL Codegen** for type generation from `.graphql` schemas
+- **Prettier**: 4 spaces, single quotes, trailing commas (es5), semicolons, 100 char width
+- **ESLint** with `@typescript-eslint` and React hooks rules
+- **Vitest** for testing with Testing Library
+
+## Architecture Concepts
+
+### Event Sourcing
+
+All state changes are modeled as events (hendelser) published to the Kafka topic. Each microservice builds its own read model from these events. The `HendelseModel.kt` sealed class hierarchy defines all event types.
+
+Core notification types (union `Notifikasjon`):
+- **Beskjed** — informational message
+- **Oppgave** — task with optional deadline and reminder
+- **Kalenderavtale** — calendar appointment
+
+Recipient types (mottakere):
+- `AltinnMottaker` — service code based (legacy Altinn)
+- `AltinnRessursMottaker` — resource ID based (new Altinn)
+- `NaermesteLederMottaker` — nearest manager relation
+
+### Microservices (all in app/)
+
+All services are defined in `Main.kt` and share a single Maven build. Each service runs as its own container in production, dispatched by an environment variable or command-line argument.
+
+Key services: `produsent-api`, `bruker-api`, `bruker-api-writer`, `kafka-reaper`, `ekstern-varsling`, `skedulert-utgaatt`, `skedulert-paaminnelse`, `skedulert-harddelete`, `kafka-backup`, `dataprodukt`, `hendelse-transformer`, `replay-validator`.
+
+### GraphQL APIs
+
+Two schema-first GraphQL APIs:
+- **Produsent API** (`produsent.graphql`) — for producing systems to create notifications, tasks, calendar events, and cases
+- **Bruker API** (`bruker.graphql`) — for end-user-facing applications to read notifications
+
+Custom scalars: `ISO8601DateTime`, `ISO8601LocalDateTime`, `ISO8601Duration`, `ISO8601Date`.
+
+### Database Pattern
+
+Each microservice has its own PostgreSQL database (CQRS). Migrations are managed with Flyway and auto-run on startup. Database names follow the pattern `<service>-model` (e.g., `produsent-model`, `bruker-model`).
+
+## Coding Conventions
+
+### Kotlin
+
+- GraphQL mutations live in `produsent/api/Mutation*.kt` files (one file per mutation)
+- GraphQL queries live in `produsent/api/Query*.kt` files
+- Infrastructure code (HTTP, Kafka, DB, auth) is in `infrastruktur/`
+- Use sealed classes and `when` expressions for exhaustive type matching
+- Prefer immutable data structures (`val`, `data class`)
+- Test with JUnit 5, use `PostgresTestListener` for DB tests and `LocalKafka` for Kafka tests
+- Norwegian naming is acceptable and common in domain types (e.g., `Beskjed`, `Oppgave`, `Mottaker`, `Hendelse`)
+
+### TypeScript
+
+- Use functional components with hooks
+- Use Apollo Client hooks (`useQuery`, `useMutation`) for GraphQL
+- Generate types from GraphQL schemas — don't hand-write GraphQL types
+
+### Infrastructure
+
+- NAIS application manifests in `app/nais/` follow the pattern `{env}-{service}.yaml`
+- Health endpoints: `/internal/alive`, `/internal/ready`, `/internal/metrics`
+- All services use structured JSON logging (logstash-logback-encoder)
+- Observability: Prometheus metrics, Loki logging, Java auto-instrumentation
+
+## Testing
+
+- **Kotlin**: `mvn test` runs JUnit 5 tests with embedded PostgreSQL and Kafka
+- **Widget**: `npm test` runs Vitest
+- **CI**: GitHub Actions workflows in `.github/workflows/`
+
+## Local Development
+
+```bash
+# Start dependencies
+docker-compose up   # Kafka (port 9092), PostgreSQL (port 1337)
+
+# Run the app
+# Use LocalMain.kt in IntelliJ IDEA
+
+# GraphQL IDE
+# http://ag-notifikasjon-produsent-api.localhost:8081/api/ide
+# http://ag-notifikasjon-bruker-api.localhost:8081/api/ide
+```
+
+## Important Warnings
+
+- **Do not** rely on Kafka metadata timestamps for event creation time — use explicit fields (see ADR #2)
+- **Do not** change the Kafka topic cleanup policy or partition count without team coordination
+- **Do not** modify shared event types in `HendelseModel.kt` without considering all downstream consumers
+- **Be careful** with hard deletes — they tombstone events in Kafka and are irreversible
+- The `fager.notifikasjon` topic uses log compaction, not time-based retention

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,163 @@
+# AGENTS.md — GitHub Copilot Agent Mode Instructions
+
+This file provides instructions for AI coding agents (GitHub Copilot Agent Mode in IntelliJ IDEA and VS Code) working in this monorepo.
+
+## Repository Map
+
+```
+arbeidsgiver-notifikasjon-produsent-api/
+├── app/                          # Kotlin backend (all microservices)
+│   ├── pom.xml                   # Maven build (Kotlin 2.1, JVM 21)
+│   ├── Dockerfile
+│   ├── nais/                     # NAIS deployment manifests (dev + prod)
+│   └── src/main/
+│       ├── kotlin/no/nav/arbeidsgiver/notifikasjon/
+│       │   ├── Main.kt                   # Entry point — dispatches to services
+│       │   ├── hendelse/HendelseModel.kt # Sealed class: all event types
+│       │   ├── produsent/api/            # Producer GraphQL mutations & queries
+│       │   ├── bruker/                   # User-facing API
+│       │   ├── ekstern_varsling/         # External notification (SMS/email)
+│       │   ├── kafka_reaper/             # Event deletion (tombstoning)
+│       │   ├── kafka_backup/             # Raw event backup
+│       │   ├── skedulert_harddelete/     # Scheduled hard deletes
+│       │   ├── skedulert_utgaatt/        # Scheduled expiration
+│       │   ├── skedulert_paaminnelse/    # Scheduled reminders
+│       │   ├── dataprodukt/              # BigQuery analytics export
+│       │   └── infrastruktur/            # Shared infra (HTTP, Kafka, DB, auth)
+│       └── resources/
+│           ├── produsent.graphql          # Producer API schema (primary)
+│           └── bruker.graphql             # User API schema
+├── test-produsent/               # React test UI (TypeScript, Vite, Apollo)
+├── fake-produsent-api/           # Mock GraphQL server (Node.js, Express)
+├── widget/                       # NPM package @navikt/arbeidsgiver-notifikasjon-widget
+├── terraform/                    # GCP infrastructure (BigQuery, service accounts)
+├── docs/                         # User documentation (GitHub Pages)
+├── adr/                          # Architecture Decision Records
+├── docker-compose.yml            # Local dev: Kafka + PostgreSQL
+└── local-db-init.sql             # Creates databases for all services
+```
+
+## Build & Test Commands
+
+### Kotlin backend (app/)
+
+```bash
+# Build
+cd app && mvn package -DskipTests
+
+# Run tests (requires Docker for PostgreSQL and Kafka)
+cd app && mvn test
+
+# Run locally (after docker-compose up)
+# Use LocalMain.kt run configuration in IntelliJ IDEA
+```
+
+### TypeScript test UI (test-produsent/)
+
+```bash
+cd test-produsent && npm ci && npm run build
+```
+
+### Widget (widget/)
+
+```bash
+cd widget/component && npm ci && npm test && npm run build
+```
+
+### Local environment
+
+```bash
+docker-compose up  # Starts Kafka (9092) and PostgreSQL (1337)
+```
+
+## Agent Task Guidelines
+
+### When modifying Kotlin code
+
+1. **Follow Kotlin Official code style** (ktfmt). IntelliJ formats on save.
+2. **Sealed class exhaustiveness**: When adding a new event type to `HendelseModel.kt`, you must handle it in every `when` expression across all consumers. Search for `is HendelseModel.` to find all pattern matches.
+3. **GraphQL schema-first**: Modify the `.graphql` schema file first, then implement the resolver in Kotlin. Mutations go in `produsent/api/Mutation*.kt`, queries in `Query*.kt`.
+4. **Database migrations**: Add Flyway migration files in the appropriate service's resources directory. Migrations run automatically on startup.
+5. **Test with embedded services**: Use `PostgresTestListener` and `LocalKafka` in tests — don't mock the database or Kafka.
+6. **Coroutines**: The codebase uses `kotlinx-coroutines`. Use `suspend` functions and structured concurrency.
+
+### When modifying TypeScript/React code
+
+1. **Format with Prettier** (config in `.prettierrc`): 4-space indent, single quotes, semicolons.
+2. **Lint with ESLint**: Run `npm run lint` before committing.
+3. **GraphQL types are generated**: Run `npm run codegen` after changing `.graphql` files. Don't hand-write GraphQL types.
+4. **Use NAV Design System components** (`@navikt/ds-react`) for UI.
+
+### When modifying infrastructure
+
+1. **NAIS manifests**: Dev configs in `app/nais/dev-gcp-*.yaml`, prod in `prod-gcp-*.yaml`.
+2. **Terraform**: Run `terraform plan` before applying. Separate tfvars for dev/prod.
+3. **GitHub Actions**: Workflows in `.github/workflows/`. The main build uses matrix strategy for all services.
+
+## Critical Domain Knowledge
+
+### Event Sourcing Architecture
+
+- All state mutations produce events to the Kafka topic `fager.notifikasjon`
+- Each microservice consumes the full event stream and builds its own PostgreSQL database
+- The topic uses **log compaction** (not time-based retention) — events persist indefinitely until compacted
+- Hard deletes write tombstone records to Kafka — this is **irreversible**
+
+### Event Model (HendelseModel.kt)
+
+The `HendelseModel` sealed class is the source of truth for all event types. Key subtypes:
+
+- `BeskjedOpprettet`, `OppgaveOpprettet`, `KalenderavtaleOpprettet` — creation events
+- `SakOpprettet`, `NyStatusSak`, `NesteStegSak` — case lifecycle
+- `OppgaveUtført`, `OppgaveUtgått` — task completion
+- `SoftDelete`, `HardDelete` — deletion events
+- `EksterntVarselVellykket`, `EksterntVarselFeilet` — notification delivery status
+- `PåminnelseOpprettet` — reminder events
+
+**Warning**: Adding or changing event types affects ALL downstream services. The event schema is the contract between services.
+
+### GraphQL API Design Patterns
+
+- Mutations return a union type of success/error results (e.g., `NyBeskjedResultat`)
+- All mutations require authentication and authorization (Altinn service codes or resource IDs)
+- Use `MerkelappInput` with `lenke`, `tekst`, and `eksternId` for notification content
+- `grupperingsid` ties notifications to a parent `Sak` (case)
+
+### Norwegian Domain Terms
+
+| Norwegian | English | Usage |
+|---|---|---|
+| Arbeidsgiver | Employer | Primary user group |
+| Notifikasjon | Notification | Core domain concept |
+| Beskjed | Message | Informational notification type |
+| Oppgave | Task | Actionable notification type |
+| Kalenderavtale | Calendar appointment | Time-bound notification type |
+| Sak | Case | Groups related notifications |
+| Hendelse | Event | Event sourcing event |
+| Mottaker | Recipient | Notification target |
+| Produsent | Producer | System that creates notifications |
+| Bruker | User | End user (employer) |
+| Varsling | Notification/Alert | External notification (SMS/email) |
+| Påminnelse | Reminder | Scheduled reminder |
+| Utgått | Expired | Deadline passed |
+| Harddelete | Hard delete | Permanent deletion |
+| Frist | Deadline | Task deadline |
+
+### Access Control
+
+- Producer API: Authenticated via Maskinporten tokens with organization number
+- User API: Authenticated via TokenX with person identity
+- Authorization: Checked against Altinn service codes or resource IDs per organization
+- Inbound access policy defined in NAIS manifests (allowlisted applications)
+
+## Code Review Checklist
+
+When proposing changes, verify:
+
+- [ ] New event types in `HendelseModel.kt` are handled in all `when` expressions
+- [ ] GraphQL schema changes are reflected in both schema files and Kotlin resolvers
+- [ ] Database migrations are backward-compatible (no destructive changes without coordination)
+- [ ] NAIS manifests are updated for both dev and prod if adding new env vars or resources
+- [ ] Tests pass: `mvn test` for Kotlin, `npm test` for widget
+- [ ] No secrets or credentials in committed code
+- [ ] Norwegian naming conventions are consistent with existing code

--- a/app/nais/dev-gcp-bruker-api-writer.yaml
+++ b/app/nais/dev-gcp-bruker-api-writer.yaml
@@ -37,6 +37,11 @@ spec:
           apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
           kind: Project
         role: roles/cloudsql.client
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system
   envFrom:
     - secret: google-sql-notifikasjon-bruker-api
   filesFrom:

--- a/app/nais/dev-gcp-bruker-api.yaml
+++ b/app/nais/dev-gcp-bruker-api.yaml
@@ -61,6 +61,8 @@ spec:
           namespace: toi
     outbound:
       rules:
+        - application: logging
+          namespace: nais-system
         - application: arbeidsgiver-altinn-tilganger
       external:
         - host: fakedings.intern.dev.nav.no # fakedings login

--- a/app/nais/dev-gcp-dataprodukt.yaml
+++ b/app/nais/dev-gcp-dataprodukt.yaml
@@ -43,3 +43,8 @@ spec:
         databases:
           - name: dataprodukt-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/dev-gcp-ekstern-varsling.yaml
+++ b/app/nais/dev-gcp-ekstern-varsling.yaml
@@ -44,6 +44,8 @@ spec:
   accessPolicy:
     outbound:
       rules:
+        - application: logging
+          namespace: nais-system
         - application: altinn-varsel-firewall
       external:
         - host: platform.tt02.altinn.no

--- a/app/nais/dev-gcp-hendelse-transformer.yaml
+++ b/app/nais/dev-gcp-hendelse-transformer.yaml
@@ -31,3 +31,8 @@ spec:
     max: 1
   kafka:
     pool: nav-dev
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/dev-gcp-kafka-backup.yaml
+++ b/app/nais/dev-gcp-kafka-backup.yaml
@@ -41,3 +41,8 @@ spec:
         databases:
           - name: kafka-backup-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/dev-gcp-kafka-bq.yaml
+++ b/app/nais/dev-gcp-kafka-bq.yaml
@@ -35,8 +35,13 @@ spec:
     bigQueryDatasets:
       - name: debughendelse
         permission: READWRITE
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system
   env:
     - name: BIGQUERY_DATASET_ID
-      value: debughendelse 
+      value: debughendelse
     - name: BIGQUERY_TABLE_NAME
       value: notifikasjon

--- a/app/nais/dev-gcp-kafka-reaper.yaml
+++ b/app/nais/dev-gcp-kafka-reaper.yaml
@@ -41,3 +41,8 @@ spec:
         databases:
           - name: kafka-reaper-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/dev-gcp-manuelt-vedlikehold.yaml
+++ b/app/nais/dev-gcp-manuelt-vedlikehold.yaml
@@ -31,3 +31,8 @@ spec:
     max: 1
   kafka:
     pool: nav-dev
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/dev-gcp-produsent-api.yaml
+++ b/app/nais/dev-gcp-produsent-api.yaml
@@ -50,6 +50,9 @@ spec:
             envVarPrefix: DB
   accessPolicy:
     outbound:
+      rules:
+        - application: logging
+          namespace: nais-system
       external:
         - host: fakedings.intern.dev.nav.no
         - host: tt02.altinn.no

--- a/app/nais/dev-gcp-replay-validator.yaml
+++ b/app/nais/dev-gcp-replay-validator.yaml
@@ -31,3 +31,8 @@ spec:
     max: 1
   kafka:
     pool: nav-dev
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/dev-gcp-skedulert-harddelete.yaml
+++ b/app/nais/dev-gcp-skedulert-harddelete.yaml
@@ -41,3 +41,8 @@ spec:
         databases:
           - name: skedulert-harddelete-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/dev-gcp-skedulert-paaminnelse.yaml
+++ b/app/nais/dev-gcp-skedulert-paaminnelse.yaml
@@ -41,3 +41,8 @@ spec:
         databases:
           - name: skedulert-paaminnelse-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/dev-gcp-skedulert-utgaatt.yaml
+++ b/app/nais/dev-gcp-skedulert-utgaatt.yaml
@@ -40,3 +40,8 @@ spec:
         databases:
           - name: skedulert-utgatt-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/prod-gcp-bruker-api-writer.yaml
+++ b/app/nais/prod-gcp-bruker-api-writer.yaml
@@ -37,6 +37,11 @@ spec:
           apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
           kind: Project
         role: roles/cloudsql.client
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system
   envFrom:
     - secret: google-sql-notifikasjon-bruker-api
   filesFrom:

--- a/app/nais/prod-gcp-bruker-api.yaml
+++ b/app/nais/prod-gcp-bruker-api.yaml
@@ -63,6 +63,8 @@ spec:
           namespace: toi
     outbound:
       rules:
+        - application: logging
+          namespace: nais-system
         - application: arbeidsgiver-altinn-tilganger
       external:
         - host: ereg-services.prod-fss-pub.nais.io # ereg brukes i bruker-api

--- a/app/nais/prod-gcp-dataprodukt.yaml
+++ b/app/nais/prod-gcp-dataprodukt.yaml
@@ -45,3 +45,8 @@ spec:
         databases:
           - name: dataprodukt-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/prod-gcp-ekstern-varsling.yaml
+++ b/app/nais/prod-gcp-ekstern-varsling.yaml
@@ -44,6 +44,8 @@ spec:
   accessPolicy:
     outbound:
       rules:
+        - application: logging
+          namespace: nais-system
         - application: altinn-varsel-firewall
       external:
         - host: platform.altinn.no

--- a/app/nais/prod-gcp-kafka-backup.yaml
+++ b/app/nais/prod-gcp-kafka-backup.yaml
@@ -42,3 +42,8 @@ spec:
         databases:
           - name: kafka-backup-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/prod-gcp-kafka-bq.yaml
+++ b/app/nais/prod-gcp-kafka-bq.yaml
@@ -38,6 +38,11 @@ spec:
     bigQueryDatasets:
       - name: debughendelse
         permission: READWRITE
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system
   env:
     - name: BIGQUERY_DATASET_ID
       value: debughendelse 

--- a/app/nais/prod-gcp-kafka-reaper.yaml
+++ b/app/nais/prod-gcp-kafka-reaper.yaml
@@ -42,3 +42,8 @@ spec:
         databases:
           - name: kafka-reaper-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/prod-gcp-manuelt-vedlikehold.yaml
+++ b/app/nais/prod-gcp-manuelt-vedlikehold.yaml
@@ -28,3 +28,8 @@ spec:
         - id: loki
   kafka:
     pool: nav-prod
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/prod-gcp-produsent-api.yaml
+++ b/app/nais/prod-gcp-produsent-api.yaml
@@ -37,6 +37,10 @@ spec:
     min: 2
     max: 8
   accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system
     inbound:
       rules:
         - application: tiltaksgjennomforing-api

--- a/app/nais/prod-gcp-replay-validator.yaml
+++ b/app/nais/prod-gcp-replay-validator.yaml
@@ -34,3 +34,8 @@ spec:
     max: 1
   kafka:
     pool: nav-prod
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/prod-gcp-skedulert-harddelete.yaml
+++ b/app/nais/prod-gcp-skedulert-harddelete.yaml
@@ -43,3 +43,8 @@ spec:
         databases:
           - name: skedulert-harddelete-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/prod-gcp-skedulert-paaminnelse.yaml
+++ b/app/nais/prod-gcp-skedulert-paaminnelse.yaml
@@ -45,3 +45,8 @@ spec:
         databases:
           - name: skedulert-paaminnelse-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/nais/prod-gcp-skedulert-utgaatt.yaml
+++ b/app/nais/prod-gcp-skedulert-utgaatt.yaml
@@ -43,3 +43,8 @@ spec:
         databases:
           - name: skedulert-utgatt-model
             envVarPrefix: DB
+  accessPolicy:
+    outbound:
+      rules:
+        - application: logging
+          namespace: nais-system

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>ktor-serialization-jackson-jvm</artifactId>
             <version>${ktor.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.ktor</groupId>
+            <artifactId>ktor-client-logging-jvm</artifactId>
+            <version>${ktor.version}</version>
+        </dependency>
 
         <!-- altinn-ws -->
         <dependency>

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/Main.kt
@@ -7,7 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.dataprodukt.Dataprodukt
 import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.EksternVarsling
 import no.nav.arbeidsgiver.notifikasjon.hendelse_transformer.HendelseTransformer
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.kafka_backup.KafkaBackup
 import no.nav.arbeidsgiver.notifikasjon.kafka_bq.KafkaBQ
 import no.nav.arbeidsgiver.notifikasjon.kafka_reaper.KafkaReaper

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerAPI.kt
@@ -15,7 +15,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.NaisEnvironment
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnTilgangerService
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.tid.atOsloAsOffsetDateTime
 import java.time.LocalDate
 import java.time.OffsetDateTime

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/bruker/BrukerRepository.kt
@@ -29,6 +29,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Tilleggsinformasj
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnTilganger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.nærmeste_leder.NarmesteLederLeesah
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import java.time.*

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktModel.kt
@@ -31,7 +31,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SoftDelete
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.TilleggsinformasjonSak
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.ParameterSetters
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.skedulert_harddelete.ScheduledTime
 import java.time.Instant
 import java.util.*

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn2VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn2VarselKlient.kt
@@ -15,6 +15,7 @@ import no.altinn.services.serviceengine.notification._2010._10.INotificationAgen
 import no.altinn.services.serviceengine.notification._2010._10.INotificationAgencyExternalBasicSendStandaloneNotificationBasicV3AltinnFaultFaultFaultMessage
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.texas.AuthClient
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.texas.AuthClientImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.texas.IdentityProvider

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -415,47 +415,126 @@ interface Altinn3VarselKlient {
     /**
      * Alle mulige statusverdier i det nye API-et.
      * Brukes for både order-level og recipient-level statuser.
+     *
+     * @see <a href="https://docs.altinn.studio/nb/notifications/reference/notification-status/">Altinn Notification Status Reference</a>
      */
     @Suppress("unused")
     object ShipmentStatus {
-        // Order-level statuser
+        // ── Order-level statuser ──────────────────────────────────────────
+
+        /** Midlertidig. Bestillingen er registrert i systemet og venter på å bli plukket opp for behandling. */
         const val Order_Registered = "Order_Registered"
+
+        /** Midlertidig. Bestillingen er plukket opp og varsler er under generering. */
         const val Order_Processing = "Order_Processing"
+
+        /**
+         * Endelig. Alle varsler i bestillingen er ferdig behandlet.
+         * Alle mottakere har fått et endelig resultat (levert eller feilet).
+         */
         const val Order_Completed = "Order_Completed"
+
+        /**
+         * Endelig. Sendebetingelsen ble ikke oppfylt, så ingen varsler ble sendt.
+         * Gjelder f.eks. send-condition med KRR-sjekk der mottaker har reservert seg.
+         */
         const val Order_SendConditionNotMet = "Order_SendConditionNotMet"
+
+        /** Endelig. Bestillingen ble kansellert før varsler ble sendt. */
         const val Order_Cancelled = "Order_Cancelled"
+
+        /**
+         * Midlertidig. Bestillingen er ferdig prosessert – alle varsler er generert.
+         * Varsler kan fortsatt være under utsending til mottakere.
+         */
         const val Order_Processed = "Order_Processed"
 
-        // SMS statuser
+        // ── SMS-statuser ──────────────────────────────────────────────────
+
+        /** Midlertidig. SMS-varselet er opprettet, men ikke ennå sendt til SMS-gateway. */
         const val SMS_New = "SMS_New"
+
+        /** Midlertidig. SMS-varselet er sendt til SMS-gateway og venter på bekreftelse. */
         const val SMS_Sending = "SMS_Sending"
+
+        /** Midlertidig. SMS-gateway har akseptert meldingen, men levering til mottaker er ikke bekreftet ennå. */
         const val SMS_Accepted = "SMS_Accepted"
+
+        /** Endelig. SMS-meldingen er levert til mottakers telefon. */
         const val SMS_Delivered = "SMS_Delivered"
+
+        /** Endelig. Generell feil – SMS-en kunne ikke leveres. */
         const val SMS_Failed = "SMS_Failed"
+
+        /** Endelig. Mottakers telefonnummer er ugyldig. */
         const val SMS_Failed_InvalidRecipient = "SMS_Failed_InvalidRecipient"
+
+        /** Endelig. Mottaker har reservert seg mot elektronisk kommunikasjon i KRR. */
         const val SMS_Failed_RecipientReserved = "SMS_Failed_RecipientReserved"
+
+        /** Endelig. Mottakers nummer er sperret (barred) hos operatør. */
         const val SMS_Failed_BarredReceiver = "SMS_Failed_BarredReceiver"
+
+        /** Endelig. SMS-en ble slettet av operatør eller gateway. */
         const val SMS_Failed_Deleted = "SMS_Failed_Deleted"
+
+        /** Endelig. SMS-en utløp hos operatør/gateway før den kunne leveres. */
         const val SMS_Failed_Expired = "SMS_Failed_Expired"
+
+        /** Endelig. SMS-en kunne ikke leveres til mottaker av ukjent årsak. */
         const val SMS_Failed_Undelivered = "SMS_Failed_Undelivered"
+
+        /** Endelig. Mottaker kunne ikke identifiseres (f.eks. oppslag i kontaktregister feilet). */
         const val SMS_Failed_RecipientNotIdentified = "SMS_Failed_RecipientNotIdentified"
+
+        /** Endelig. SMS-en ble avvist av gateway eller operatør. */
         const val SMS_Failed_Rejected = "SMS_Failed_Rejected"
+
+        /** Endelig. SMS-en overskred time-to-live og ble ikke levert innen tidsfristen. */
         const val SMS_Failed_TTL = "SMS_Failed_TTL"
 
-        // Email statuser
+        // ── E-post-statuser ───────────────────────────────────────────────
+
+        /** Midlertidig. E-postvarselet er opprettet, men ikke ennå sendt til e-posttjenesten. */
         const val Email_New = "Email_New"
+
+        /** Midlertidig. E-posten er sendt til e-posttjenesten og venter på bekreftelse. */
         const val Email_Sending = "Email_Sending"
+
+        /** Midlertidig. E-posttjenesten har akseptert meldingen for levering. Venter på endelig leveringsbekreftelse. */
         const val Email_Succeeded = "Email_Succeeded"
+
+        /** Endelig. E-posten er levert til mottakers innboks. */
         const val Email_Delivered = "Email_Delivered"
+
+        /** Endelig. Generell feil – e-posten kunne ikke leveres. */
         const val Email_Failed = "Email_Failed"
+
+        /** Endelig. Mottaker har reservert seg mot elektronisk kommunikasjon i KRR. */
         const val Email_Failed_RecipientReserved = "Email_Failed_RecipientReserved"
+
+        /** Endelig. Mottaker kunne ikke identifiseres (f.eks. oppslag i kontaktregister feilet). */
         const val Email_Failed_RecipientNotIdentified = "Email_Failed_RecipientNotIdentified"
+
+        /** Endelig. E-postadressen har ugyldig format. */
         const val Email_Failed_InvalidFormat = "Email_Failed_InvalidFormat"
+
+        /** Endelig. Mottaker er undertrykt (suppressed) – e-posttjenesten nekter levering pga. tidligere feil/klager. */
         const val Email_Failed_SuppressedRecipient = "Email_Failed_SuppressedRecipient"
+
+        /** Endelig. Midlertidig feil under sending – e-posttjenesten kunne ikke levere etter gjentatte forsøk. */
         const val Email_Failed_TransientError = "Email_Failed_TransientError"
+
+        /** Endelig. E-posten returnerte (bounced) fra mottakers e-postserver. */
         const val Email_Failed_Bounced = "Email_Failed_Bounced"
+
+        /** Endelig. E-posten ble filtrert som spam av mottakers e-postserver. */
         const val Email_Failed_FilteredSpam = "Email_Failed_FilteredSpam"
+
+        /** Endelig. E-posten ble satt i karantene av mottakers e-postsystem. */
         const val Email_Failed_Quarantined = "Email_Failed_Quarantined"
+
+        /** Endelig. E-posten overskred time-to-live og ble ikke levert innen tidsfristen. */
         const val Email_Failed_TTL = "Email_Failed_TTL"
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -42,12 +42,12 @@ open class Altinn3VarselKlientImpl(
 
     private val log = logger()
 
-    override suspend fun order(eksternVarsel: EksternVarsel) = try {
+    override suspend fun order(eksternVarsel: EksternVarsel, idempotencyId: String) = try {
         httpClient.post {
             url("$altinnBaseUrl/notifications/api/v1/future/orders")
             plattformTokenBearerAuth()
             contentType(ContentType.Application.Json)
-            setBody(OrderRequest.from(eksternVarsel))
+            setBody(OrderRequest.from(eksternVarsel, idempotencyId))
         }.body<JsonNode>().let {
             OrderResponse.Success.fromJson(it)
         }
@@ -106,7 +106,7 @@ private const val EPOST_AVSENDER = "ikke-svar@nav.no"
 
 @Suppress("ConstPropertyName")
 interface Altinn3VarselKlient {
-    suspend fun order(eksternVarsel: EksternVarsel): OrderResponse
+    suspend fun order(eksternVarsel: EksternVarsel, idempotencyId: String): OrderResponse
     suspend fun shipment(shipmentId: String): ShipmentResponse
 
 
@@ -142,8 +142,8 @@ interface Altinn3VarselKlient {
             }
 
             companion object {
-                fun from(eksternVarsel: EksternVarsel.Epost) = Email(
-                    idempotencyId = eksternVarsel.ordreId ?: UUID.randomUUID().toString(),
+                fun from(eksternVarsel: EksternVarsel.Epost, idempotencyId: String) = Email(
+                    idempotencyId = idempotencyId,
                     recipient = Recipient(
                         recipientEmail = RecipientEmail(
                             emailAddress = eksternVarsel.epostadresse,
@@ -178,8 +178,8 @@ interface Altinn3VarselKlient {
             )
 
             companion object {
-                fun from(eksternVarsel: EksternVarsel.Sms) = Sms(
-                    idempotencyId = eksternVarsel.ordreId ?: UUID.randomUUID().toString(),
+                fun from(eksternVarsel: EksternVarsel.Sms, idempotencyId: String) = Sms(
+                    idempotencyId = idempotencyId,
                     recipient = Recipient(
                         recipientSms = RecipientSms(
                             phoneNumber = fiksGyldigMobilnummer(eksternVarsel.mobilnummer),
@@ -226,8 +226,8 @@ interface Altinn3VarselKlient {
             )
 
             companion object {
-                fun from(eksternVarsel: EksternVarsel.Altinnressurs) = Organization(
-                    idempotencyId = eksternVarsel.ordreId ?: UUID.randomUUID().toString(),
+                fun from(eksternVarsel: EksternVarsel.Altinnressurs, idempotencyId: String) = Organization(
+                    idempotencyId = idempotencyId,
                     recipient = Recipient(
                         recipientOrganization = RecipientOrganization(
                             orgNumber = eksternVarsel.fnrEllerOrgnr,
@@ -247,10 +247,10 @@ interface Altinn3VarselKlient {
         }
 
         companion object {
-            fun from(eksternVarsel: EksternVarsel): OrderRequest = when (eksternVarsel) {
-                is EksternVarsel.Altinnressurs -> Organization.from(eksternVarsel)
-                is EksternVarsel.Epost -> Email.from(eksternVarsel)
-                is EksternVarsel.Sms -> Sms.from(eksternVarsel)
+            fun from(eksternVarsel: EksternVarsel, idempotencyId: String): OrderRequest = when (eksternVarsel) {
+                is EksternVarsel.Altinnressurs -> Organization.from(eksternVarsel, idempotencyId)
+                is EksternVarsel.Epost -> Email.from(eksternVarsel, idempotencyId)
+                is EksternVarsel.Sms -> Sms.from(eksternVarsel, idempotencyId)
                 is EksternVarsel.Altinntjeneste -> throw UnsupportedOperationException("Altinntjeneste er ikke støttet")
             }
 
@@ -466,7 +466,7 @@ class Altinn3VarselKlientMedFilter(
     private val loggingKlient: Altinn3VarselKlientLogging
 ) : Altinn3VarselKlientImpl() {
 
-    override suspend fun order(eksternVarsel: EksternVarsel): OrderResponse {
+    override suspend fun order(eksternVarsel: EksternVarsel, idempotencyId: String): OrderResponse {
         val mottaker = when (eksternVarsel) {
             is EksternVarsel.Sms -> eksternVarsel.mobilnummer
             is EksternVarsel.Epost -> eksternVarsel.epostadresse
@@ -474,9 +474,9 @@ class Altinn3VarselKlientMedFilter(
             is EksternVarsel.Altinntjeneste -> throw UnsupportedOperationException("Altinntjeneste er ikke støttet")
         }
         return if (repository.mottakerErPåAllowList(mottaker)) {
-            super.order(eksternVarsel)
+            super.order(eksternVarsel, idempotencyId)
         } else {
-            loggingKlient.order(eksternVarsel)
+            loggingKlient.order(eksternVarsel, idempotencyId)
         }
     }
 
@@ -492,7 +492,7 @@ class Altinn3VarselKlientMedFilter(
 class Altinn3VarselKlientLogging : Altinn3VarselKlient {
     private val log = logger()
 
-    override suspend fun order(eksternVarsel: EksternVarsel): OrderResponse {
+    override suspend fun order(eksternVarsel: EksternVarsel, idempotencyId: String): OrderResponse {
         log.info("order($eksternVarsel)")
         val fakeOrderId = "fake-${UUID.randomUUID()}"
         val fakeShipmentId = "fake-${UUID.randomUUID()}"

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -332,6 +332,19 @@ interface Altinn3VarselKlient {
             val shipmentId: String,
             val sendersReference: String?,
             val type: String?,
+            /**
+             * Order-level status for hele bestillingen.
+             *
+             * Mulige verdier:
+             * - [ShipmentStatus.Order_Registered] — Midlertidig. Bestillingen er registrert og venter på behandling.
+             * - [ShipmentStatus.Order_Processing] — Midlertidig. Bestillingen er plukket opp og varsler er under generering.
+             * - [ShipmentStatus.Order_Processed] — Midlertidig. Alle varsler er generert, men kan fortsatt være under utsending.
+             * - [ShipmentStatus.Order_Completed] — Endelig. Alle mottakere har fått et endelig resultat (levert eller feilet).
+             * - [ShipmentStatus.Order_SendConditionNotMet] — Endelig. Sendebetingelsen ble ikke oppfylt, ingen varsler ble sendt.
+             * - [ShipmentStatus.Order_Cancelled] — Endelig. Bestillingen ble kansellert før varsler ble sendt.
+             *
+             * @see <a href="https://docs.altinn.studio/nb/notifications/reference/notification-status/">Altinn Notification Status Reference</a>
+             */
             val status: String,
             val lastUpdate: OffsetDateTime?,
             val recipients: List<RecipientDelivery>,
@@ -383,6 +396,43 @@ interface Altinn3VarselKlient {
 
             @JsonIgnoreProperties(ignoreUnknown = true)
             data class RecipientDelivery(
+                /**
+                 * Leveringsstatus per mottaker (SMS eller e-post).
+                 *
+                 * SMS-statuser:
+                 * - [ShipmentStatus.SMS_New] — Midlertidig. Opprettet, ikke sendt til gateway ennå.
+                 * - [ShipmentStatus.SMS_Sending] — Midlertidig. Sendt til gateway, venter på bekreftelse.
+                 * - [ShipmentStatus.SMS_Accepted] — Midlertidig. Akseptert av gateway, levering ikke bekreftet.
+                 * - [ShipmentStatus.SMS_Delivered] — Endelig. Levert til mottakers telefon.
+                 * - [ShipmentStatus.SMS_Failed] — Endelig. Generell feil.
+                 * - [ShipmentStatus.SMS_Failed_InvalidRecipient] — Endelig. Ugyldig telefonnummer.
+                 * - [ShipmentStatus.SMS_Failed_RecipientReserved] — Endelig. Reservert mot elektronisk kommunikasjon (KRR).
+                 * - [ShipmentStatus.SMS_Failed_BarredReceiver] — Endelig. Nummer sperret hos operatør.
+                 * - [ShipmentStatus.SMS_Failed_Deleted] — Endelig. Slettet av operatør/gateway.
+                 * - [ShipmentStatus.SMS_Failed_Expired] — Endelig. Utløpt hos operatør/gateway.
+                 * - [ShipmentStatus.SMS_Failed_Undelivered] — Endelig. Kunne ikke leveres, ukjent årsak.
+                 * - [ShipmentStatus.SMS_Failed_RecipientNotIdentified] — Endelig. Mottaker ikke identifisert.
+                 * - [ShipmentStatus.SMS_Failed_Rejected] — Endelig. Avvist av gateway/operatør.
+                 * - [ShipmentStatus.SMS_Failed_TTL] — Endelig. Overskred time-to-live.
+                 *
+                 * E-post-statuser:
+                 * - [ShipmentStatus.Email_New] — Midlertidig. Opprettet, ikke sendt til e-posttjenesten ennå.
+                 * - [ShipmentStatus.Email_Sending] — Midlertidig. Sendt til e-posttjenesten, venter på bekreftelse.
+                 * - [ShipmentStatus.Email_Succeeded] — Midlertidig. Akseptert for levering, venter på endelig bekreftelse.
+                 * - [ShipmentStatus.Email_Delivered] — Endelig. Levert til mottakers innboks.
+                 * - [ShipmentStatus.Email_Failed] — Endelig. Generell feil.
+                 * - [ShipmentStatus.Email_Failed_RecipientReserved] — Endelig. Reservert mot elektronisk kommunikasjon (KRR).
+                 * - [ShipmentStatus.Email_Failed_RecipientNotIdentified] — Endelig. Mottaker ikke identifisert.
+                 * - [ShipmentStatus.Email_Failed_InvalidFormat] — Endelig. Ugyldig e-postadresse.
+                 * - [ShipmentStatus.Email_Failed_SuppressedRecipient] — Endelig. Mottaker undertrykt pga. tidligere feil/klager.
+                 * - [ShipmentStatus.Email_Failed_TransientError] — Endelig. Kunne ikke levere etter gjentatte forsøk.
+                 * - [ShipmentStatus.Email_Failed_Bounced] — Endelig. Returnert (bounced) fra mottakers e-postserver.
+                 * - [ShipmentStatus.Email_Failed_FilteredSpam] — Endelig. Filtrert som spam.
+                 * - [ShipmentStatus.Email_Failed_Quarantined] — Endelig. Satt i karantene.
+                 * - [ShipmentStatus.Email_Failed_TTL] — Endelig. Overskred time-to-live.
+                 *
+                 * @see <a href="https://docs.altinn.studio/nb/notifications/reference/notification-status/">Altinn Notification Status Reference</a>
+                 */
                 val status: String,
                 val lastUpdate: String?,
                 val destination: String?,
@@ -420,121 +470,44 @@ interface Altinn3VarselKlient {
      */
     @Suppress("unused")
     object ShipmentStatus {
-        // ── Order-level statuser ──────────────────────────────────────────
-
-        /** Midlertidig. Bestillingen er registrert i systemet og venter på å bli plukket opp for behandling. */
+        // Order-level statuser
         const val Order_Registered = "Order_Registered"
-
-        /** Midlertidig. Bestillingen er plukket opp og varsler er under generering. */
         const val Order_Processing = "Order_Processing"
-
-        /**
-         * Endelig. Alle varsler i bestillingen er ferdig behandlet.
-         * Alle mottakere har fått et endelig resultat (levert eller feilet).
-         */
         const val Order_Completed = "Order_Completed"
-
-        /**
-         * Endelig. Sendebetingelsen ble ikke oppfylt, så ingen varsler ble sendt.
-         * Gjelder f.eks. send-condition med KRR-sjekk der mottaker har reservert seg.
-         */
         const val Order_SendConditionNotMet = "Order_SendConditionNotMet"
-
-        /** Endelig. Bestillingen ble kansellert før varsler ble sendt. */
         const val Order_Cancelled = "Order_Cancelled"
-
-        /**
-         * Midlertidig. Bestillingen er ferdig prosessert – alle varsler er generert.
-         * Varsler kan fortsatt være under utsending til mottakere.
-         */
         const val Order_Processed = "Order_Processed"
 
-        // ── SMS-statuser ──────────────────────────────────────────────────
-
-        /** Midlertidig. SMS-varselet er opprettet, men ikke ennå sendt til SMS-gateway. */
+        // SMS-statuser
         const val SMS_New = "SMS_New"
-
-        /** Midlertidig. SMS-varselet er sendt til SMS-gateway og venter på bekreftelse. */
         const val SMS_Sending = "SMS_Sending"
-
-        /** Midlertidig. SMS-gateway har akseptert meldingen, men levering til mottaker er ikke bekreftet ennå. */
         const val SMS_Accepted = "SMS_Accepted"
-
-        /** Endelig. SMS-meldingen er levert til mottakers telefon. */
         const val SMS_Delivered = "SMS_Delivered"
-
-        /** Endelig. Generell feil – SMS-en kunne ikke leveres. */
         const val SMS_Failed = "SMS_Failed"
-
-        /** Endelig. Mottakers telefonnummer er ugyldig. */
         const val SMS_Failed_InvalidRecipient = "SMS_Failed_InvalidRecipient"
-
-        /** Endelig. Mottaker har reservert seg mot elektronisk kommunikasjon i KRR. */
         const val SMS_Failed_RecipientReserved = "SMS_Failed_RecipientReserved"
-
-        /** Endelig. Mottakers nummer er sperret (barred) hos operatør. */
         const val SMS_Failed_BarredReceiver = "SMS_Failed_BarredReceiver"
-
-        /** Endelig. SMS-en ble slettet av operatør eller gateway. */
         const val SMS_Failed_Deleted = "SMS_Failed_Deleted"
-
-        /** Endelig. SMS-en utløp hos operatør/gateway før den kunne leveres. */
         const val SMS_Failed_Expired = "SMS_Failed_Expired"
-
-        /** Endelig. SMS-en kunne ikke leveres til mottaker av ukjent årsak. */
         const val SMS_Failed_Undelivered = "SMS_Failed_Undelivered"
-
-        /** Endelig. Mottaker kunne ikke identifiseres (f.eks. oppslag i kontaktregister feilet). */
         const val SMS_Failed_RecipientNotIdentified = "SMS_Failed_RecipientNotIdentified"
-
-        /** Endelig. SMS-en ble avvist av gateway eller operatør. */
         const val SMS_Failed_Rejected = "SMS_Failed_Rejected"
-
-        /** Endelig. SMS-en overskred time-to-live og ble ikke levert innen tidsfristen. */
         const val SMS_Failed_TTL = "SMS_Failed_TTL"
 
-        // ── E-post-statuser ───────────────────────────────────────────────
-
-        /** Midlertidig. E-postvarselet er opprettet, men ikke ennå sendt til e-posttjenesten. */
+        // E-post-statuser
         const val Email_New = "Email_New"
-
-        /** Midlertidig. E-posten er sendt til e-posttjenesten og venter på bekreftelse. */
         const val Email_Sending = "Email_Sending"
-
-        /** Midlertidig. E-posttjenesten har akseptert meldingen for levering. Venter på endelig leveringsbekreftelse. */
         const val Email_Succeeded = "Email_Succeeded"
-
-        /** Endelig. E-posten er levert til mottakers innboks. */
         const val Email_Delivered = "Email_Delivered"
-
-        /** Endelig. Generell feil – e-posten kunne ikke leveres. */
         const val Email_Failed = "Email_Failed"
-
-        /** Endelig. Mottaker har reservert seg mot elektronisk kommunikasjon i KRR. */
         const val Email_Failed_RecipientReserved = "Email_Failed_RecipientReserved"
-
-        /** Endelig. Mottaker kunne ikke identifiseres (f.eks. oppslag i kontaktregister feilet). */
         const val Email_Failed_RecipientNotIdentified = "Email_Failed_RecipientNotIdentified"
-
-        /** Endelig. E-postadressen har ugyldig format. */
         const val Email_Failed_InvalidFormat = "Email_Failed_InvalidFormat"
-
-        /** Endelig. Mottaker er undertrykt (suppressed) – e-posttjenesten nekter levering pga. tidligere feil/klager. */
         const val Email_Failed_SuppressedRecipient = "Email_Failed_SuppressedRecipient"
-
-        /** Endelig. Midlertidig feil under sending – e-posttjenesten kunne ikke levere etter gjentatte forsøk. */
         const val Email_Failed_TransientError = "Email_Failed_TransientError"
-
-        /** Endelig. E-posten returnerte (bounced) fra mottakers e-postserver. */
         const val Email_Failed_Bounced = "Email_Failed_Bounced"
-
-        /** Endelig. E-posten ble filtrert som spam av mottakers e-postserver. */
         const val Email_Failed_FilteredSpam = "Email_Failed_FilteredSpam"
-
-        /** Endelig. E-posten ble satt i karantene av mottakers e-postsystem. */
         const val Email_Failed_Quarantined = "Email_Failed_Quarantined"
-
-        /** Endelig. E-posten overskred time-to-live og ble ikke levert innen tidsfristen. */
         const val Email_Failed_TTL = "Email_Failed_TTL"
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -1,8 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.ekstern_varsling
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.NullNode
@@ -26,12 +24,10 @@ import java.time.OffsetDateTime
 import java.util.*
 
 /**
- * Klient for å sende varsler til Altinn 3
- * https://docs.altinn.studio/notifications/reference/api/openapi/#/Orders/post_orders
+ * Klient for å sende varsler til Altinn 3 via det nye /future/orders API-et.
+ * https://docs.altinn.studio/nb/notifications/reference/openapi/#/Order/post_future_orders
  *
- * Her skal det komme et bedre API etterhvert. Apiet skal støtte idempotens og enklere kunne hente ut alle varsler.
- * ref: https://altinn.slack.com/archives/C069J71UQCQ/p1740582966140809?thread_ts=1740580333.657779&cid=C069J71UQCQ
- * https://github.com/Altinn/altinn-notifications/tree/feature/api-v2/src/Altinn.Notifications.NewApiDemo
+ * Nytt API støtter idempotens via idempotencyId og enklere statushenting via /future/shipment/{id}.
  */
 open class Altinn3VarselKlientImpl(
     val altinnBaseUrl: String = System.getenv("ALTINN_3_API_BASE_URL"),
@@ -48,7 +44,7 @@ open class Altinn3VarselKlientImpl(
 
     override suspend fun order(eksternVarsel: EksternVarsel) = try {
         httpClient.post {
-            url("$altinnBaseUrl/notifications/api/v1/orders")
+            url("$altinnBaseUrl/notifications/api/v1/future/orders")
             plattformTokenBearerAuth()
             contentType(ContentType.Application.Json)
             setBody(OrderRequest.from(eksternVarsel))
@@ -72,13 +68,16 @@ open class Altinn3VarselKlientImpl(
         )
     }
 
-    override suspend fun notifications(orderId: String): NotificationsResponse = try {
-        val sms = smsNotifications(orderId)
-        val email = emailNotifications(orderId)
-        sms + email
+    override suspend fun shipment(shipmentId: String): ShipmentResponse = try {
+        httpClient.get {
+            url("$altinnBaseUrl/notifications/api/v1/future/shipment/$shipmentId")
+            plattformTokenBearerAuth()
+        }.body<JsonNode>().let {
+            ShipmentResponse.Success.fromJson(it)
+        }
     } catch (e: ResponseException) {
         ErrorResponse(
-            message = e.response.status.description,
+            message = """${e.response.status.description}: ${e.response.bodyAsText()}""",
             code = e.response.status.value.toString(),
             rå = e.response.body()
         )
@@ -93,43 +92,6 @@ open class Altinn3VarselKlientImpl(
         )
     }
 
-    override suspend fun orderStatus(orderId: String): OrderStatusResponse = try {
-        httpClient.get {
-            url("$altinnBaseUrl/notifications/api/v1/orders/$orderId/status")
-            plattformTokenBearerAuth()
-        }.body<JsonNode>().let {
-            OrderStatusResponse.Success.fromJson(it)
-        }
-    } catch (e: ResponseException) {
-        ErrorResponse(
-            message = e.response.status.description,
-            code = e.response.status.value.toString(),
-            rå = e.response.body()
-        )
-    } catch (e: Exception) {
-        e.rethrowIfCancellation()
-
-        ErrorResponse(
-            message = e.message ?: "",
-            code = e::class.java.simpleName ?: "",
-            rå = TextNode.valueOf(e.toString())
-        )
-    }
-
-    private suspend fun emailNotifications(orderId: String): NotificationsResponse.Success = httpClient.get {
-        url("$altinnBaseUrl/notifications/api/v1/orders/$orderId/notifications/email")
-        plattformTokenBearerAuth()
-    }.body<JsonNode>().let {
-        NotificationsResponse.Success.fromJson(it)
-    }
-
-    private suspend fun smsNotifications(orderId: String): NotificationsResponse.Success = httpClient.get {
-        url("$altinnBaseUrl/notifications/api/v1/orders/$orderId/notifications/sms")
-        plattformTokenBearerAuth()
-    }.body<JsonNode>().let {
-        NotificationsResponse.Success.fromJson(it)
-    }
-
     private suspend fun HttpMessageBuilder.plattformTokenBearerAuth() {
         altinnPlattformTokenClient.token("altinn:serviceowner/notifications.create").let {
             headers {
@@ -140,100 +102,155 @@ open class Altinn3VarselKlientImpl(
 }
 
 
+private const val EPOST_AVSENDER = "ikke-svar@nav.no"
+
+@Suppress("ConstPropertyName")
 interface Altinn3VarselKlient {
     suspend fun order(eksternVarsel: EksternVarsel): OrderResponse
-    suspend fun notifications(orderId: String): NotificationsResponse
-    suspend fun orderStatus(orderId: String): OrderStatusResponse
+    suspend fun shipment(shipmentId: String): ShipmentResponse
 
 
     /**
-     * DTOs
+     * DTOs for the new /future/orders API
      */
 
     @Suppress("unused")
     sealed class OrderRequest {
+
+        /**
+         * Epost til spesifikk epostadresse
+         */
         data class Email(
-            @JsonIgnore val reciever: String,
-            @JsonIgnore val subject: String,
-            @JsonIgnore val body: String,
+            val idempotencyId: String,
+            val recipient: Recipient,
         ) : OrderRequest() {
-            val notificationChannel
-                get() = "Email"
-            val recipients
-                get() = listOf(
-                    mapOf("emailAddress" to reciever)
+            data class Recipient(
+                val recipientEmail: RecipientEmail,
+            )
+
+            data class RecipientEmail(
+                val emailAddress: String,
+                val emailSettings: EmailSettings,
+            )
+
+            data class EmailSettings(
+                val subject: String,
+                val body: String,
+                val contentType: String = "Html",
+            ) {
+                val fromAddress = EPOST_AVSENDER
+            }
+
+            companion object {
+                fun from(eksternVarsel: EksternVarsel.Epost) = Email(
+                    idempotencyId = eksternVarsel.ordreId ?: UUID.randomUUID().toString(),
+                    recipient = Recipient(
+                        recipientEmail = RecipientEmail(
+                            emailAddress = eksternVarsel.epostadresse,
+                            emailSettings = EmailSettings(
+                                subject = eksternVarsel.tittel,
+                                body = eksternVarsel.body,
+                            )
+                        )
+                    )
                 )
-            val emailTemplate
-                get() = mapOf(
-                    "subject" to subject,
-                    "body" to body,
-                    "contentType" to "Html",
-                )
+            }
         }
 
+        /**
+         * SMS til spesifikt mobilnummer
+         */
         data class Sms(
-            @JsonIgnore val reciever: String,
-            @JsonIgnore val body: String,
+            val idempotencyId: String,
+            val recipient: Recipient,
         ) : OrderRequest() {
-            val notificationChannel
-                get() = "Sms"
-            val recipients
-                get() = listOf(
-                    mapOf("mobileNumber" to reciever)
+            data class Recipient(
+                val recipientSms: RecipientSms,
+            )
+
+            data class RecipientSms(
+                val phoneNumber: String,
+                val smsSettings: SmsSettings,
+            )
+
+            data class SmsSettings(
+                val body: String,
+            )
+
+            companion object {
+                fun from(eksternVarsel: EksternVarsel.Sms) = Sms(
+                    idempotencyId = eksternVarsel.ordreId ?: UUID.randomUUID().toString(),
+                    recipient = Recipient(
+                        recipientSms = RecipientSms(
+                            phoneNumber = fiksGyldigMobilnummer(eksternVarsel.mobilnummer),
+                            smsSettings = SmsSettings(
+                                body = eksternVarsel.tekst,
+                            )
+                        )
+                    )
                 )
-            val smsTemplate
-                get() = mapOf(
-                    "body" to body
-                )
+            }
         }
 
-        data class Resource(
-            val resourceId: String,
-            @JsonIgnore val orgnr: String,
-            @JsonIgnore val epostTittel: String,
-            @JsonIgnore val epostInnhold: String,
-            @JsonIgnore val smsInnhold: String,
+        /**
+         * Varsel basert på Altinn-ressurs med oppslag mot organisasjon.
+         * Altinn finner selv kontaktinfo basert på orgnummer og ressurs.
+         */
+        data class Organization(
+            val idempotencyId: String,
+            val recipient: Recipient,
         ) : OrderRequest() {
-            val resourceAction = "access"
-            val notificationChannel
-                get() = "EmailPreferred"
-            val recipients
-                get() = listOf(
-                    mapOf("organizationNumber" to orgnr)
+            data class Recipient(
+                val recipientOrganization: RecipientOrganization,
+            )
+
+            data class RecipientOrganization(
+                val orgNumber: String,
+                val channelSchema: String,
+                val resourceId: String,
+                val resourceAction: String = "access",
+                val emailSettings: EmailSettings,
+                val smsSettings: SmsSettings,
+            )
+
+            data class EmailSettings(
+                val subject: String,
+                val body: String,
+                val contentType: String = "Html",
+            ) {
+                val fromAddress = EPOST_AVSENDER
+            }
+
+            data class SmsSettings(
+                val body: String,
+            )
+
+            companion object {
+                fun from(eksternVarsel: EksternVarsel.Altinnressurs) = Organization(
+                    idempotencyId = eksternVarsel.ordreId ?: UUID.randomUUID().toString(),
+                    recipient = Recipient(
+                        recipientOrganization = RecipientOrganization(
+                            orgNumber = eksternVarsel.fnrEllerOrgnr,
+                            channelSchema = "EmailPreferred",
+                            resourceId = eksternVarsel.resourceId,
+                            emailSettings = EmailSettings(
+                                subject = eksternVarsel.epostTittel,
+                                body = eksternVarsel.epostInnhold,
+                            ),
+                            smsSettings = SmsSettings(
+                                body = eksternVarsel.smsInnhold,
+                            )
+                        )
+                    )
                 )
-            val emailTemplate
-                get() = mapOf(
-                    "subject" to epostTittel,
-                    "body" to epostInnhold,
-                    "contentType" to "Html",
-                )
-            val smsTemplate
-                get() = mapOf(
-                    "body" to smsInnhold
-                )
+            }
         }
 
         companion object {
-            fun from(eksternVarsel: EksternVarsel) = when (eksternVarsel) {
-                is EksternVarsel.Altinnressurs -> Resource(
-                    orgnr = eksternVarsel.fnrEllerOrgnr,
-                    resourceId = eksternVarsel.resourceId,
-                    epostTittel = eksternVarsel.epostTittel,
-                    epostInnhold = eksternVarsel.epostInnhold,
-                    smsInnhold = eksternVarsel.smsInnhold,
-                )
-
-                is EksternVarsel.Epost -> Email(
-                    reciever = eksternVarsel.epostadresse,
-                    subject = eksternVarsel.tittel,
-                    body = eksternVarsel.body,
-                )
-
-                is EksternVarsel.Sms -> Sms(
-                    reciever = fiksGyldigMobilnummer(eksternVarsel.mobilnummer),
-                    body = eksternVarsel.tekst,
-                )
-
+            fun from(eksternVarsel: EksternVarsel): OrderRequest = when (eksternVarsel) {
+                is EksternVarsel.Altinnressurs -> Organization.from(eksternVarsel)
+                is EksternVarsel.Epost -> Email.from(eksternVarsel)
+                is EksternVarsel.Sms -> Sms.from(eksternVarsel)
                 is EksternVarsel.Altinntjeneste -> throw UnsupportedOperationException("Altinntjeneste er ikke støttet")
             }
 
@@ -241,7 +258,7 @@ interface Altinn3VarselKlient {
              * På grunn av en endring i altinn 3 apiet i forhold til soap api, så støttes ikke lenger mobilnummer uten
              * landkode: https://docs.altinn.studio/nb/notifications/what-do-you-get/#supported-recipient-numbers
              *
-             * I produsent-api tillatter vi kun norske mobilnummer, men krever ikke landkode. Vi antar norge på samme måte
+             * I produsent-api tillater vi kun norske mobilnummer, men krever ikke landkode. Vi antar norge på samme måte
              * som det gamle altinn apiet.
              * Dersom vi åpner opp for andre land, må vi også endre valideringen i graphql apiet slik at landkode må angis.
              * Dersom dette gjøres kan denne mapping koden fjernes i sin helhet.
@@ -268,7 +285,7 @@ interface Altinn3VarselKlient {
         override val rå: JsonNode,
         val message: String,
         val code: String,
-    ) : OrderResponse, NotificationsResponse, OrderStatusResponse {
+    ) : OrderResponse, ShipmentResponse {
         fun isRetryable() =
             when (code) {
                 "400" -> false
@@ -287,221 +304,159 @@ interface Altinn3VarselKlient {
         data class Success(
             override val rå: JsonNode,
             val orderId: String,
+            val shipmentId: String,
         ) : OrderResponse {
 
             companion object {
                 fun fromJson(rawJson: JsonNode): Success {
                     return Success(
                         rawJson,
-                        orderId = rawJson["orderId"].asText()
+                        orderId = rawJson["notificationOrderId"].asText(),
+                        shipmentId = rawJson["notification"]["shipmentId"].asText(),
                     )
                 }
             }
         }
     }
 
-    @Suppress("unused")
-    sealed interface OrderStatusResponse {
+    /**
+     * Response fra GET /future/shipment/{id}
+     * Erstatter de gamle orderStatus og notifications endepunktene.
+     */
+    sealed interface ShipmentResponse {
         val rå: JsonNode
-
-        enum class ProcessingStatusValue {
-            Registered,
-            Processing,
-            Completed,
-            Cancelled
-        }
-
-        data class ProcessingStatus(
-            /**
-             * status should be enum but is string in api. prevent breakage by using string
-             * https://docs.altinn.studio/notifications/reference/api/endpoints/get-email-notifications/
-             *
-             * enum class ProcessingStatusValue {
-             *     Registered,
-             *     Processing,
-             *     Processed,
-             *     Completed,
-             *     Cancelled
-             * }
-             *
-             */
-            val status: String,
-            val description: String?,
-            val lastUpdate: OffsetDateTime?,
-        ) {
-            companion object {
-                const val Processing = "Processing"
-                const val Processed = "Processed"
-                const val Registered = "Registered"
-                const val Completed = "Completed"
-                const val Cancelled = "Cancelled"
-            }
-        }
-
-        @JsonIgnoreProperties(ignoreUnknown = true)
-        data class NotificationStatusSummary(
-            val generated: Int,
-            val succeeded: Int,
-        )
 
         @JsonIgnoreProperties(ignoreUnknown = true)
         data class Success(
             override val rå: JsonNode,
-            val orderId: String,
+            val shipmentId: String,
             val sendersReference: String?,
-            val processingStatus: ProcessingStatus,
-            val notificationsStatusSummary: NotificationStatusSummary?,
-        ) : OrderStatusResponse {
-            companion object {
-                fun fromJson(rawJson: JsonNode): Success {
-                    return Success(
-                        rå = rawJson,
-                        orderId = rawJson["id"].asText(),
-                        sendersReference = rawJson["sendersReference"]?.asText(null),
-                        processingStatus = laxObjectMapper.convertValue(rawJson["processingStatus"]),
-                        notificationsStatusSummary = laxObjectMapper.convertValue(
-                            rawJson["notificationsStatusSummary"] ?: NullNode.instance
-                        )
-                    )
-                }
-            }
-        }
-    }
+            val type: String?,
+            val status: String,
+            val lastUpdate: OffsetDateTime?,
+            val recipients: List<RecipientDelivery>,
+        ) : ShipmentResponse {
 
-
-    @Suppress("unused")
-    sealed interface NotificationsResponse {
-        val rå: JsonNode
-
-        @JsonIgnoreProperties(ignoreUnknown = true)
-        data class Success(
-            override val rå: JsonNode,
-            val orderId: String,
-            val sendersReference: String? = null,
-            val generated: Int,
-            val succeeded: Int,
-            val notifications: List<Notification>,
-        ) : NotificationsResponse {
-
-            val isProcessing
-                get() = notifications.any { it.sendStatus.isProcessing }
-
-            companion object {
-                fun fromJson(rawJson: JsonNode): Success {
-                    return Success(
-                        rå = rawJson,
-                        orderId = rawJson["orderId"].asText(),
-                        sendersReference = rawJson["sendersReference"]?.asText(null),
-                        generated = rawJson["generated"].asInt(),
-                        succeeded = rawJson["succeeded"].asInt(),
-                        notifications = laxObjectMapper.convertValue(rawJson["notifications"])
-                    )
-                }
-            }
-
-            operator fun plus(other: Success) = Success(
-                orderId = orderId,
-                sendersReference = sendersReference ?: other.sendersReference,
-                generated = generated + other.generated,
-                succeeded = succeeded + other.succeeded,
-                notifications = notifications + other.notifications,
-                rå = JsonNodeFactory.instance.arrayNode().apply {
-                    add(rå)
-                    add(other.rå)
-                }
-            )
-
-            data class Notification(
-                val id: String,
-                val succeeded: Boolean,
-                val recipient: Recipient,
-                val sendStatus: SendStatus,
-            ) {
-                @JsonInclude(JsonInclude.Include.NON_NULL)
-                data class Recipient(
-                    val emailAddress: String? = null,
-                    val mobileNumber: String? = null,
-                    val organizationNumber: String? = null,
-                    val nationalIdentityNumber: String? = null,
+            val isOrderProcessing
+                get() = status in listOf(
+                    ShipmentStatus.Order_Registered,
+                    ShipmentStatus.Order_Processing,
                 )
 
-                data class SendStatus(
-                    /**
-                     * status should be enum but is string in api. prevent breakage by using string
-                     * https://docs.altinn.studio/notifications/reference/api/endpoints/get-email-notifications/
-                     * https://docs.altinn.studio/notifications/reference/api/endpoints/get-sms-notifications/
-                     *
-                     * enum class Status {
-                     *     New,         // The email has been created but has not yet been picked up for processing.
-                     *     New,         // The SMS has been created but has not yet been picked up for processing.
-                     *
-                     *     Sending,     // The email is being processed and will be sent shortly.
-                     *     Sending,     // The SMS is being processed and will be sent shortly.
-                     *
-                     *     Accepted,    // The SMS has been accepted by the gateway service and will be sent soon.
-                     *
-                     *     Succeeded,   // The email has been accepted by the third-party service and will be sent soon.
-                     *
-                     *     Delivered,   // The email was successfully delivered to the recipient. No errors were reported, indicating successful delivery.
-                     *     Delivered,   // The SMS was successfully delivered to the recipient.
-                     *
-                     *     Failed,      // The email was not sent due to an unspecified failure.
-                     *     Failed,       // The SMS was not sent due to an unspecified failure.
-                     *
-                     *     Failed_RecipientNotIdentified,   // The email was not sent because the recipient’s email address could not be found.
-                     *     Failed_RecipientNotIdentified,   // The SMS was not sent because the recipient’s SMS address was not found.
+            val isOrderCompleted
+                get() = status == ShipmentStatus.Order_Completed
 
-                     *     Failed_InvalidEmailFormat,       // The email was not sent due to an invalid email address format.
-                     *     Failed_InvalidRecipient,         // The SMS was not sent because the recipient mobile number was invalid.
+            val isOrderProcessed
+                get() = status == ShipmentStatus.Order_Processed
 
-                     *     Failed_Bounced,                  // The email bounced due to issues like a non-existent email address or invalid domain.
-                     *     Failed_BarredReceiver,           // The SMS was not delivered because the recipient’s mobile number is barred, blocked or not in use.
+            val isOrderCancelled
+                get() = status == ShipmentStatus.Order_Cancelled
 
-                     *     Failed_FilteredSpam,             // The email was identified as spam and rejected or blocked (not quarantined).
-                     *     Failed_Rejected,                 // The SMS was not delivered because it was rejected.
+            val isOrderConditionNotMet
+                get() = status == ShipmentStatus.Order_SendConditionNotMet
 
-                     *     Failed_Quarantined,              // The email was quarantined due to being flagged as spam, bulk mail, or phishing.
-                     *
-                     *     Failed_Deleted,                  // The SMS was not delivered because the message has been deleted.
-                     *     Failed_Expired,                  // The SMS was not delivered because it has been expired.
-                     *     Failed_Undelivered,              // The SMS was not delivered due to invalid mobile number or no available route to destination.
-                     * }
-                     */
+            /**
+             * Sjekker om alle mottakere er ferdige (levert eller feilet)
+             */
+            val allRecipientsFinished
+                get() = recipients.all { it.isTerminal }
 
-                    val status: String,
-                    val description: String,
-                    val lastUpdate: String,
-                ) {
-                    val isProcessing
-                        get() = status in listOf(
-                            New,
-                            Sending,
-                            Accepted,
-                            Succeeded
-                        )
+            val allRecipientsDelivered
+                get() = recipients.all { it.isDelivered }
 
-                    companion object {
-                        val New = "New"
-                        val Sending = "Sending"
-                        val Accepted = "Accepted"
-                        val Succeeded = "Succeeded"
-                        val Delivered = "Delivered"
-                        val Failed = "Failed"
-                        val Failed_RecipientNotIdentified = "Failed_RecipientNotIdentified"
-                        val Failed_InvalidEmailFormat = "Failed_InvalidEmailFormat"
-                        val Failed_Bounced = "Failed_Bounced"
-                        val Failed_FilteredSpam = "Failed_FilteredSpam"
-                        val Failed_Quarantined = "Failed_Quarantined"
-                        val Failed_BarredReceiver = "Failed_BarredReceiver"
-                        val Failed_Deleted = "Failed_Deleted"
-                        val Failed_Expired = "Failed_Expired"
-                        val Failed_InvalidRecipient = "Failed_InvalidRecipient"
-                        val Failed_Undelivered = "Failed_Undelivered"
-                        val Failed_Rejected = "Failed_Rejected"
-                    }
+            val hasFailedRecipients
+                get() = recipients.any { it.isFailed }
+
+            companion object {
+                fun fromJson(rawJson: JsonNode): Success {
+                    return Success(
+                        rå = rawJson,
+                        shipmentId = rawJson["shipmentId"].asText(),
+                        sendersReference = rawJson["sendersReference"]?.asText(null),
+                        type = rawJson["type"]?.asText(null),
+                        status = rawJson["status"].asText(),
+                        lastUpdate = rawJson["lastUpdate"]?.asText(null)?.let { OffsetDateTime.parse(it) },
+                        recipients = rawJson["recipients"]?.let { laxObjectMapper.convertValue(it) } ?: emptyList(),
+                    )
                 }
             }
+
+            @JsonIgnoreProperties(ignoreUnknown = true)
+            data class RecipientDelivery(
+                val status: String,
+                val lastUpdate: String?,
+                val destination: String?,
+            ) {
+                val isDelivered
+                    get() = status in listOf(
+                        ShipmentStatus.SMS_Delivered,
+                        ShipmentStatus.Email_Delivered,
+                    )
+
+                val isFailed
+                    get() = status.contains("Failed")
+
+                val isProcessing
+                    get() = status in listOf(
+                        ShipmentStatus.SMS_New,
+                        ShipmentStatus.SMS_Sending,
+                        ShipmentStatus.SMS_Accepted,
+                        ShipmentStatus.Email_New,
+                        ShipmentStatus.Email_Sending,
+                        ShipmentStatus.Email_Succeeded,
+                    )
+
+                val isTerminal
+                    get() = isDelivered || isFailed
+            }
         }
+    }
+
+    /**
+     * Alle mulige statusverdier i det nye API-et.
+     * Brukes for både order-level og recipient-level statuser.
+     */
+    @Suppress("unused")
+    object ShipmentStatus {
+        // Order-level statuser
+        const val Order_Registered = "Order_Registered"
+        const val Order_Processing = "Order_Processing"
+        const val Order_Completed = "Order_Completed"
+        const val Order_SendConditionNotMet = "Order_SendConditionNotMet"
+        const val Order_Cancelled = "Order_Cancelled"
+        const val Order_Processed = "Order_Processed"
+
+        // SMS statuser
+        const val SMS_New = "SMS_New"
+        const val SMS_Sending = "SMS_Sending"
+        const val SMS_Accepted = "SMS_Accepted"
+        const val SMS_Delivered = "SMS_Delivered"
+        const val SMS_Failed = "SMS_Failed"
+        const val SMS_Failed_InvalidRecipient = "SMS_Failed_InvalidRecipient"
+        const val SMS_Failed_RecipientReserved = "SMS_Failed_RecipientReserved"
+        const val SMS_Failed_BarredReceiver = "SMS_Failed_BarredReceiver"
+        const val SMS_Failed_Deleted = "SMS_Failed_Deleted"
+        const val SMS_Failed_Expired = "SMS_Failed_Expired"
+        const val SMS_Failed_Undelivered = "SMS_Failed_Undelivered"
+        const val SMS_Failed_RecipientNotIdentified = "SMS_Failed_RecipientNotIdentified"
+        const val SMS_Failed_Rejected = "SMS_Failed_Rejected"
+        const val SMS_Failed_TTL = "SMS_Failed_TTL"
+
+        // Email statuser
+        const val Email_New = "Email_New"
+        const val Email_Sending = "Email_Sending"
+        const val Email_Succeeded = "Email_Succeeded"
+        const val Email_Delivered = "Email_Delivered"
+        const val Email_Failed = "Email_Failed"
+        const val Email_Failed_RecipientReserved = "Email_Failed_RecipientReserved"
+        const val Email_Failed_RecipientNotIdentified = "Email_Failed_RecipientNotIdentified"
+        const val Email_Failed_InvalidFormat = "Email_Failed_InvalidFormat"
+        const val Email_Failed_SuppressedRecipient = "Email_Failed_SuppressedRecipient"
+        const val Email_Failed_TransientError = "Email_Failed_TransientError"
+        const val Email_Failed_Bounced = "Email_Failed_Bounced"
+        const val Email_Failed_FilteredSpam = "Email_Failed_FilteredSpam"
+        const val Email_Failed_Quarantined = "Email_Failed_Quarantined"
+        const val Email_Failed_TTL = "Email_Failed_TTL"
     }
 }
 
@@ -525,19 +480,11 @@ class Altinn3VarselKlientMedFilter(
         }
     }
 
-    override suspend fun notifications(orderId: String): NotificationsResponse {
-        return if (repository.ordreHarMottakerPåAllowlist(orderId)){
-            super.notifications(orderId)
+    override suspend fun shipment(shipmentId: String): ShipmentResponse {
+        return if (repository.ordreHarMottakerPåAllowlist(shipmentId)){
+            super.shipment(shipmentId)
         } else {
-            loggingKlient.notifications(orderId)
-        }
-    }
-
-    override suspend fun orderStatus(orderId: String): OrderStatusResponse {
-        return if (repository.ordreHarMottakerPåAllowlist(orderId)){
-            super.orderStatus(orderId)
-        } else {
-            loggingKlient.orderStatus(orderId)
+            loggingKlient.shipment(shipmentId)
         }
     }
 }
@@ -547,37 +494,28 @@ class Altinn3VarselKlientLogging : Altinn3VarselKlient {
 
     override suspend fun order(eksternVarsel: EksternVarsel): OrderResponse {
         log.info("order($eksternVarsel)")
-        return OrderResponse.Success.fromJson(
-            JsonNodeFactory.instance.objectNode().apply {
-                put("orderId", "fake-${UUID.randomUUID()}")
-            }
+        val fakeOrderId = "fake-${UUID.randomUUID()}"
+        val fakeShipmentId = "fake-${UUID.randomUUID()}"
+        return OrderResponse.Success(
+            rå = JsonNodeFactory.instance.objectNode().apply {
+                put("notificationOrderId", fakeOrderId)
+                putObject("notification").put("shipmentId", fakeShipmentId)
+            },
+            orderId = fakeOrderId,
+            shipmentId = fakeShipmentId,
         )
     }
 
-    override suspend fun notifications(orderId: String): NotificationsResponse {
-        log.info("notifications($orderId)")
-        return NotificationsResponse.Success(
-            orderId = orderId,
-            sendersReference = null,
-            generated = 0,
-            succeeded = 0,
-            notifications = listOf(),
+    override suspend fun shipment(shipmentId: String): ShipmentResponse {
+        log.info("shipment($shipmentId)")
+        return ShipmentResponse.Success(
             rå = NullNode.instance,
-        )
-    }
-
-    override suspend fun orderStatus(orderId: String): OrderStatusResponse {
-        log.info("orderStatus($orderId)")
-        return OrderStatusResponse.Success(
-            orderId = orderId,
+            shipmentId = shipmentId,
             sendersReference = null,
-            rå = NullNode.instance,
-            processingStatus = OrderStatusResponse.ProcessingStatus(
-                status = OrderStatusResponse.ProcessingStatus.Completed,
-                description = null,
-                lastUpdate = null,
-            ),
-            notificationsStatusSummary = null,
+            type = null,
+            status = ShipmentStatus.Order_Completed,
+            lastUpdate = null,
+            recipients = emptyList(),
         )
     }
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -19,6 +19,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnPlattformToke
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.defaultHttpClient
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.teamLogger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.rethrowIfCancellation
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.ensurePrefix
 import java.time.OffsetDateTime
@@ -47,7 +48,7 @@ open class Altinn3VarselKlientImpl(
     ),
 ) : Altinn3VarselKlient {
     companion object {
-        private val teamLogger = logger()
+        private val teamLogger = teamLogger()
     }
 
     private val log = logger()

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.convertValue
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
+import io.ktor.client.plugins.logging.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -17,7 +18,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnPlattformToke
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnPlattformTokenClientImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.defaultHttpClient
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.rethrowIfCancellation
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.ensurePrefix
 import java.time.OffsetDateTime
@@ -33,12 +34,21 @@ open class Altinn3VarselKlientImpl(
     val altinnBaseUrl: String = System.getenv("ALTINN_3_API_BASE_URL"),
     val altinnPlattformTokenClient: AltinnPlattformTokenClient = AltinnPlattformTokenClientImpl(),
     val httpClient: HttpClient = defaultHttpClient(
+        customizeLogging = {
+        logger = object : Logger {
+            override fun log(message: String) = teamLogger.info(message)
+        }
+        level = LogLevel.ALL
+    },
         customizeMetrics = {
             clientName = "altinn3-varsel-client"
             canonicalizer = { path -> path.replace(Regex("[0-9a-fA-F-]{36}"), "{id}") }
         }
     ),
 ) : Altinn3VarselKlient {
+    companion object {
+        private val teamLogger = logger()
+    }
 
     private val log = logger()
 
@@ -208,10 +218,11 @@ interface Altinn3VarselKlient {
                 val orgNumber: String,
                 val channelSchema: String,
                 val resourceId: String,
-                val resourceAction: String = "access",
                 val emailSettings: EmailSettings,
                 val smsSettings: SmsSettings,
-            )
+            ) {
+                val resourceAction: String = "access"
+            }
 
             data class EmailSettings(
                 val subject: String,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.notifikasjon.ekstern_varsling
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.fasterxml.jackson.databind.node.NullNode
@@ -218,11 +220,17 @@ interface Altinn3VarselKlient {
             data class RecipientOrganization(
                 val orgNumber: String,
                 val channelSchema: String,
-                val resourceId: String,
+                @JsonIgnore val resourceId: String,
                 val emailSettings: EmailSettings,
                 val smsSettings: SmsSettings,
             ) {
                 val resourceAction: String = "access"
+
+                /**
+                 * Altinn 3 "future" api krever at resourceId sendes som en URN i formatet "urn:altinn:resource:{resourceId}".
+                 */
+                @JsonProperty("resourceId")
+                val resourceUrn: String = "urn:altinn:resource:${resourceId}"
             }
 
             data class EmailSettings(

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlient.kt
@@ -308,7 +308,8 @@ interface Altinn3VarselKlient {
     ) : OrderResponse, ShipmentResponse {
         fun isRetryable() =
             when (code) {
-                "400" -> false
+                "400",
+                "422" -> false
 
                 else -> true
             }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/AltinnVarselKlientResponse.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/AltinnVarselKlientResponse.kt
@@ -61,8 +61,10 @@ private val retryableErrorIds = listOf(
 /**
  *
  * https://altinn.github.io/docs/api/tjenesteeiere/soap/grensesnitt/varseltjeneste/#feilsituasjoner
+ * https://docs.altinn.studio/nb/notifications/reference/error-codes/#not-00001-manglende-kontaktinformasjon
  */
 private val supressableErrorIds = listOf(
+    422, // én eller flere mottakere ikke har nødvendig kontaktinformasjon tilgjengelig for Altinn.
     30304, // Avgiver av typen organisasjon har ikke registrert noen varslingsadresse som kan benyttes i varsel på angitt kanal.
     30307, // Feil opplevd under generering av EMailPreferred mottaker endepunkt, klarte ikke generere Email eller SMS endepunkt
     30308, // Feil opplevd under generering av SMSPreferred endepunkt, klarte ikke generere Email eller SMS endepunkt

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
@@ -876,7 +876,7 @@ class EksternVarslingRepository(
             ) {
                 nullableText(
                     when (response) {
-                        is Altinn3VarselKlient.OrderResponse.Success -> response.orderId
+                        is Altinn3VarselKlient.OrderResponse.Success -> response.shipmentId
                         is Altinn3VarselKlient.ErrorResponse -> null
                     }
                 )

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingRepository.kt
@@ -30,7 +30,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Tilleggsinformasj
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Transaction
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import java.sql.ResultSet
 import java.time.Duration
 import java.time.LocalDateTime

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
@@ -340,7 +340,7 @@ class EksternVarslingService(
                 if (shipment.allRecipientsDelivered)
                     return Pair(Altinn3VarselStatus.Kvittert, shipment.rå)
 
-                return Pair(Altinn3VarselStatus.KvittertMedFeil, shipment.rå)
+                Pair(Altinn3VarselStatus.KvittertMedFeil, shipment.rå)
             }
 
             else -> {

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
@@ -3,8 +3,6 @@ package no.nav.arbeidsgiver.notifikasjon.ekstern_varsling
 import com.fasterxml.jackson.databind.JsonNode
 import io.micrometer.core.instrument.Tags
 import kotlinx.coroutines.*
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.NotificationsResponse.Success.Notification.SendStatus
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.launchProcessingLoop
@@ -226,6 +224,7 @@ class EksternVarslingService(
                 val kalkulertSendeTidspunkt =
                     varsel.kalkuertSendetidspunkt(åpningstider, now = osloTid.localDateTimeNow())
                 if (kalkulertSendeTidspunkt <= osloTid.localDateTimeNow()) {
+                    // TODO, use varsel.data.varselId as idempotency key for altinn
                     when (val response = altinn3VarselKlient.order(varsel.data.eksternVarsel)) {
                         is Altinn3VarselKlient.OrderResponse.Success -> {
                             eksternVarslingRepository.markerSomSendtAndReleaseJob(varselId, response)
@@ -250,10 +249,12 @@ class EksternVarslingService(
                 try {
                     when (varsel.response) {
                         is AltinnResponse.Ok -> {
-                            val ordreId = varsel.response.rå["orderId"].asText()
-                            if (ordreId.isEmpty())
-                                throw RuntimeException("Ordre er markert som sendt, men mangler orderId")
-                            val (ordreStatus, altinnResponse) = hentVarselOrdreStatus(ordreId)
+                            val shipmentId = varsel.response.rå["notification"]?.get("shipmentId")?.asText()
+                                ?: varsel.response.rå["orderId"]?.asText()
+                                ?: ""
+                            if (shipmentId.isEmpty())
+                                throw RuntimeException("Ordre er markert som sendt, men mangler shipmentId")
+                            val (ordreStatus, altinnResponse) = hentShipmentStatus(shipmentId)
                             when (ordreStatus) {
                                 Altinn3VarselStatus.Prosessert,
                                 Altinn3VarselStatus.Prosesserer -> eksternVarslingRepository.returnToJobQueue(varsel.data.varselId)
@@ -309,47 +310,42 @@ class EksternVarslingService(
     }
 
 
-    private suspend fun hentVarselOrdreStatus(ordreId: String): Pair<Altinn3VarselStatus, JsonNode> {
-        val ordreStatus = altinn3VarselKlient.orderStatus(ordreId)
-        if (ordreStatus !is Altinn3VarselKlient.OrderStatusResponse.Success) {
-            log.error("Feil ved henting av ordrestatus ${ordreStatus.rå}")
-            return Pair(Altinn3VarselStatus.Prosesserer, ordreStatus.rå)
+    private suspend fun hentShipmentStatus(shipmentId: String): Pair<Altinn3VarselStatus, JsonNode> {
+        val shipment = altinn3VarselKlient.shipment(shipmentId)
+        if (shipment !is Altinn3VarselKlient.ShipmentResponse.Success) {
+            log.error("Feil ved henting av shipment status ${shipment.rå}")
+            return Pair(Altinn3VarselStatus.Prosesserer, shipment.rå)
         }
 
-        return when (ordreStatus.processingStatus.status) {
-            ProcessingStatus.Registered,
-            ProcessingStatus.Processing -> Pair(Altinn3VarselStatus.Prosesserer, ordreStatus.rå)
-            ProcessingStatus.Processed -> Pair(Altinn3VarselStatus.Prosessert, ordreStatus.rå)
+        return when {
+            shipment.isOrderProcessing ->
+                Pair(Altinn3VarselStatus.Prosesserer, shipment.rå)
 
-            ProcessingStatus.Cancelled -> Pair(Altinn3VarselStatus.Kansellert, ordreStatus.rå)
+            shipment.isOrderProcessed ->
+                Pair(Altinn3VarselStatus.Prosessert, shipment.rå)
 
-            ProcessingStatus.Completed -> {
-                // Orderen er ferdig prosessert og alle notifikasjoner er blitt generert. Sjekker om notifikasjoner alle notifikasjoner er blitt sendt ut
-                altinn3VarselKlient.notifications(ordreId).let {
-                    if (it !is Altinn3VarselKlient.NotificationsResponse.Success) {
-                        log.error("Feil ved henting av notifikasjoner: ${it.rå}")
-                        return Pair(Altinn3VarselStatus.Prosesserer, it.rå)
-                    }
+            shipment.isOrderCancelled || shipment.isOrderConditionNotMet ->
+                Pair(Altinn3VarselStatus.Kansellert, shipment.rå)
 
-                    if (it.isProcessing) {
-                        return Pair(Altinn3VarselStatus.Prosesserer, it.rå)
-                    }
-
-                    val failed = it.notifications.filter { notification ->
-                        notification.sendStatus.status.startsWith(SendStatus.Failed)
-                    }
-                    if (failed.isNotEmpty()) {
-                        log.warn("Eksternt varsel med altinn ordre id $ordreId er fullført, men har ikke klart å sende ut alle notifikasjoner. antall feilet: ${failed.count()}. succedded: ${it.succeeded}, generated: ${it.generated}")
-                    }
-                    if (it.generated == it.succeeded)
-                        return Pair(Altinn3VarselStatus.Kvittert, it.rå)
-
-                    return Pair(Altinn3VarselStatus.KvittertMedFeil, it.rå)
+            shipment.isOrderCompleted -> {
+                // Orderen er ferdig prosessert. Sjekker status på mottakere.
+                if (shipment.recipients.any { it.isProcessing }) {
+                    return Pair(Altinn3VarselStatus.Prosesserer, shipment.rå)
                 }
+
+                if (shipment.hasFailedRecipients) {
+                    val failedCount = shipment.recipients.count { it.isFailed }
+                    log.warn("Eksternt varsel med shipment id $shipmentId er fullført, men har ikke klart å sende ut alle notifikasjoner. antall feilet: $failedCount, totalt: ${shipment.recipients.size}")
+                }
+
+                if (shipment.allRecipientsDelivered)
+                    return Pair(Altinn3VarselStatus.Kvittert, shipment.rå)
+
+                return Pair(Altinn3VarselStatus.KvittertMedFeil, shipment.rå)
             }
 
             else -> {
-                throw RuntimeException("Fikk ${ordreStatus.processingStatus.status} fra Altinn, denne blir ikke håndtert")
+                throw RuntimeException("Fikk ${shipment.status} fra Altinn, denne blir ikke håndtert")
             }
         }
     }
@@ -424,18 +420,31 @@ class EksternVarslingService(
 
 /**
  * Extracts status and description from the given JsonNode.
- * Either from the /processingStatus node or from the /notifications array.
+ * Supports both the new /future/shipment format and legacy formats.
  */
 private fun JsonNode.extractStatusAndDescription(): Pair<String, String> {
 
-    // Case 1: ordrestatus. Object with processingStatus
+    // Case 1: New /future/shipment format. Object with status and recipients array.
+    val shipmentStatus = at("/status")
+    val recipients = at("/recipients")
+    if (!shipmentStatus.isMissingNode && recipients.isArray) {
+        val failedRecipients = recipients.filter { it.at("/status").asText().contains("Failed") }
+        return if (failedRecipients.isNotEmpty()) {
+            failedRecipients.map { it.at("/status").asText() }.joinToString(",") to
+                failedRecipients.map { it.at("/destination")?.asText("ukjent") ?: "ukjent" }.joinToString(",")
+        } else {
+            shipmentStatus.asText() to ""
+        }
+    }
+
+    // Case 2: Legacy ordrestatus. Object with processingStatus
     val statusNode = at("/processingStatus/status")
     val descNode = at("/processingStatus/description")
     if (!statusNode.isMissingNode && !descNode.isMissingNode) {
         return statusNode.asText() to descNode.asText()
     }
 
-    // Case 2: notifications: Array with notifications
+    // Case 3: Legacy notifications: Array with notifications
     if (isArray) {
         return flatMap { order ->
             val notifications = order.at("/notifications")

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
@@ -224,8 +224,7 @@ class EksternVarslingService(
                 val kalkulertSendeTidspunkt =
                     varsel.kalkuertSendetidspunkt(åpningstider, now = osloTid.localDateTimeNow())
                 if (kalkulertSendeTidspunkt <= osloTid.localDateTimeNow()) {
-                    // TODO, use varsel.data.varselId as idempotency key for altinn
-                    when (val response = altinn3VarselKlient.order(varsel.data.eksternVarsel)) {
+                    when (val response = altinn3VarselKlient.order(varsel.data.eksternVarsel, varsel.data.varselId.toString())) {
                         is Altinn3VarselKlient.OrderResponse.Success -> {
                             eksternVarslingRepository.markerSomSendtAndReleaseJob(varselId, response)
                         }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingService.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.*
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.launchProcessingLoop
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.rethrowIfCancellation
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTid
 import no.nav.arbeidsgiver.notifikasjon.tid.OsloTidImpl

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingStatusEksportService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingStatusEksportService.kt
@@ -41,6 +41,7 @@ class EksternVarslingStatusEksportService(
         val varslingStatus = when (event) {
             is HendelseModel.EksterntVarselFeilet -> {
                 val status = when (event.altinnFeilkode) {
+                    "422",
                     "30304",
                     "30307",
                     "30308" -> Status.MANGLER_KOFUVI

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelsesstrøm.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/hendelse/Hendelsesstrøm.kt
@@ -2,7 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.hendelse
 
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HendelseMetadata
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Database.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.writeValueAsStringSupportingTypeInfoInCollections
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.unblocking.NonBlockingDataSource
 import org.apache.http.client.utils.URIBuilder
 import org.apache.http.message.BasicNameValuePair

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Enhetsregisteret.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Enhetsregisteret.kt
@@ -7,6 +7,7 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.defaultHttpClient
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 
 interface Enhetsregisteret {
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Util.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/Util.kt
@@ -1,8 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur
 
 import kotlinx.coroutines.delay
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.util.*
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.pow
@@ -19,11 +17,6 @@ fun <T> basedOnEnv(
         "dev-gcp" -> dev()
         else -> other()
     }
-
-
-/** Get logger for enclosing class. */
-inline fun <reified T : Any> T.logger(): Logger =
-    LoggerFactory.getLogger(this::class.java)
 
 fun Int.toThePowerOf(exponent: Int): Long = toDouble().pow(exponent).toLong()
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/altinn/AltinnTilgangerClient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/altinn/AltinnTilgangerClient.kt
@@ -12,6 +12,7 @@ import io.ktor.http.*
 import io.ktor.network.sockets.*
 import io.ktor.serialization.jackson.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.texas.AuthClient
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.texas.AuthClientImpl
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.texas.IdentityProvider

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/azuread/AzurePreAuthorizedApps.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/azuread/AzurePreAuthorizedApps.kt
@@ -2,7 +2,7 @@ package no.nav.arbeidsgiver.notifikasjon.infrastruktur.azuread
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 
 typealias AppName = String
 typealias ClientId = String

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/graphql/GraphQL.kt
@@ -19,9 +19,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.future
 import kotlinx.coroutines.slf4j.MDCContext
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics.meterRegistry
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.coRecord
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.findCause
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.getTimer
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.isCausedBy
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.ProdusentAPI
 import org.intellij.lang.annotations.Language
 import kotlin.coroutines.cancellation.CancellationException

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpAuthProviders.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpAuthProviders.kt
@@ -3,7 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon.infrastruktur.http
 import io.ktor.server.auth.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.azuread.AzurePreAuthorizedApps
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.azuread.AzurePreAuthorizedAppsImpl
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.texas.*
 import org.slf4j.MDC
 

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpClient.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/http/HttpClient.kt
@@ -4,6 +4,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.logging.*
 import io.ktor.network.sockets.*
 import io.ktor.serialization.jackson.*
 import io.micrometer.core.instrument.Tags
@@ -31,6 +32,7 @@ val defaultCanonicalizer: (String) -> String = { path ->
 
 
 fun defaultHttpClient(
+    customizeLogging: LoggingConfig.() -> Unit = { },
     customizeMetrics: HttpClientMetricsFeature.Config.() -> Unit = {
         canonicalizer = defaultCanonicalizer
     },
@@ -68,6 +70,15 @@ fun defaultHttpClient(
         }
 
         delayMillis { 250L }
+    }
+
+
+
+    install(Logging) {
+        customizeLogging()
+        sanitizeHeader {
+            true
+        }
     }
 
     configure()

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -10,7 +10,11 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.toThePowerOf
 import org.apache.kafka.clients.consumer.*
 import org.apache.kafka.clients.consumer.ConsumerConfig.*
 import org.apache.kafka.common.TopicPartition

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/JsonNodeHendelsesstrømKafkaImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/JsonNodeHendelsesstrømKafkaImpl.kt
@@ -1,7 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka
 
 import com.fasterxml.jackson.databind.JsonNode
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import org.apache.kafka.common.serialization.StringDeserializer
 
 class JsonNodeValueDeserializer : JsonDeserializer<JsonNode>(JsonNode::class.java)

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PartitionAwareHendelsesstrøm.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PartitionAwareHendelsesstrøm.kt
@@ -7,7 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PeriodicReplayer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/PeriodicReplayer.kt
@@ -1,6 +1,6 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka
 
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import org.apache.kafka.clients.consumer.Consumer
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/LogConfig.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/LogConfig.kt
@@ -3,12 +3,10 @@ package no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.LoggerContext
-import ch.qos.logback.classic.PatternLayout
 import ch.qos.logback.classic.spi.Configurator
 import ch.qos.logback.classic.spi.Configurator.ExecutionStatus
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.ConsoleAppender
-import ch.qos.logback.core.encoder.LayoutWrappingEncoder
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.ContextAware
 import ch.qos.logback.core.spi.ContextAwareBase
@@ -41,14 +39,14 @@ class LogConfig : ContextAwareBase(), Configurator {
                         else -> FilterReply.NEUTRAL
                     }
                 })
-                if (naisCluster != null) {
-                    encoder = LogstashEncoder().setup(lc)
-                } else {
-                    encoder = LayoutWrappingEncoder<ILoggingEvent>().setup(lc).apply {
-                        layout = PatternLayout().also {
-                            it.pattern = "%d %-5level [%thread] %logger: %msg %mdc%n"
-                        }.setup(lc)
+                addFilter(object : Filter<ILoggingEvent>() {
+                    override fun decide(event: ILoggingEvent) = when {
+                        (event.markerList ?: emptyList()).contains(TEAM_LOG_MARKER) -> FilterReply.DENY
+                        else -> FilterReply.NEUTRAL
                     }
+                })
+                encoder = LogstashEncoder().setup(lc) {
+                    isIncludeMdc = true
                 }
             }
         }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/LogConfig.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/logging/LogConfig.kt
@@ -14,8 +14,18 @@ import ch.qos.logback.core.spi.ContextAware
 import ch.qos.logback.core.spi.ContextAwareBase
 import ch.qos.logback.core.spi.FilterReply
 import ch.qos.logback.core.spi.LifeCycle
+import net.logstash.logback.appender.LogstashTcpSocketAppender
+import net.logstash.logback.composite.loggingevent.LoggingEventPatternJsonProvider
 import net.logstash.logback.encoder.LogstashEncoder
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.NaisEnvironment.clusterName
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
+import org.slf4j.LoggerFactory
+import org.slf4j.Marker
+import org.slf4j.MarkerFactory
+import org.slf4j.spi.LoggingEventBuilder
+
+const val TEAM_LOGS = "TEAM_LOGS"
+val TEAM_LOG_MARKER: Marker = MarkerFactory.getMarker(TEAM_LOGS)
 
 /* used by resources/META-INF/services/ch.qos.logback.classic.spi */
 class LogConfig : ContextAwareBase(), Configurator {
@@ -50,6 +60,32 @@ class LogConfig : ContextAwareBase(), Configurator {
                 other = { Level.INFO }
             )
             addAppender(rootAppender)
+
+            if (clusterName.isNotEmpty()) {
+                addAppender(LogstashTcpSocketAppender().setup(lc) {
+                    this.name = "TEAMLOGS"
+                    addDestination("team-logs.nais-system:5170")
+                    this.encoder = LogstashEncoder().setup(lc) {
+                        this.customFields = """{
+                        |"google_cloud_project":"${System.getenv("GOOGLE_CLOUD_PROJECT")}",
+                        |"nais_namespace_name":"${System.getenv("NAIS_NAMESPACE")}",
+                        |"nais_pod_name":"${System.getenv("NAIS_POD_NAME")}",
+                        |"nais_container_name":"${System.getenv("NAIS_APP_NAME")}"
+                        |}""".trimMargin()
+                        this.isIncludeContext = false
+                        addProvider(LoggingEventPatternJsonProvider().apply {
+                            this.pattern =
+                                """{"message":"%replace(%message){'^(.{200000}).+$', '$1...truncated'}"}"""
+                        })
+                    }
+                    addFilter(object : Filter<ILoggingEvent>() {
+                        override fun decide(event: ILoggingEvent) = when {
+                            (event.markerList ?: emptyList()).contains(TEAM_LOG_MARKER) -> FilterReply.ACCEPT
+                            else -> FilterReply.DENY
+                        }
+                    })
+                })
+            }
         }
 
         lc.getLogger("org.apache.kafka").level = Level.INFO
@@ -70,4 +106,111 @@ private fun <T> T.setup(context: LoggerContext, body: T.() -> Unit = {}): T
     this.body()
     this.start()
     return this
+}
+
+inline fun <reified T> T.logger(): org.slf4j.Logger = LoggerFactory.getLogger(T::class.qualifiedName)
+inline fun <reified T> T.teamLogger(): org.slf4j.Logger = MarkerLogger(logger(), TEAM_LOG_MARKER)
+
+/**
+ * Logger wrapper that enforces usage of a specific Marker for all logging methods.
+ * Prevents direct use of Marker arguments in logging methods.
+ *
+ * Useful to ensure TeamLog marker is guaranteed when using teamLogger().
+ */
+class MarkerLogger(
+    val logger: org.slf4j.Logger,
+    val marker: Marker
+) : org.slf4j.Logger {
+
+
+    /**
+     * proxy logging methods with marker
+     */
+
+    override fun trace(msg: String?) = logger.trace(marker, msg)
+    override fun trace(format: String?, arg: Any?) = logger.trace(marker, format, arg)
+    override fun trace(format: String?, arg1: Any?, arg2: Any?) = logger.trace(marker, format, arg1, arg2)
+    override fun trace(format: String?, vararg arguments: Any?) = logger.trace(marker, format, *arguments)
+    override fun trace(msg: String?, t: Throwable?) = logger.trace(marker, msg, t)
+    override fun debug(msg: String?) = logger.debug(marker, msg)
+    override fun debug(format: String?, arg: Any?) = logger.debug(marker, format, arg)
+    override fun debug(format: String?, arg1: Any?, arg2: Any?) = logger.debug(marker, format, arg1, arg2)
+    override fun debug(format: String?, vararg arguments: Any?) = logger.debug(marker, format, *arguments)
+    override fun debug(msg: String?, t: Throwable?) = logger.debug(marker, msg, t)
+    override fun info(msg: String?) = logger.info(marker, msg)
+    override fun info(format: String?, arg: Any?) = logger.info(marker, format, arg)
+    override fun info(format: String?, arg1: Any?, arg2: Any?) = logger.info(marker, format, arg1, arg2)
+    override fun info(format: String?, vararg arguments: Any?) = logger.info(marker, format, *arguments)
+    override fun info(msg: String?, t: Throwable?) = logger.info(marker, msg, t)
+    override fun warn(msg: String?) = logger.warn(marker, msg)
+    override fun warn(format: String?, arg: Any?) = logger.warn(marker, format, arg)
+    override fun warn(format: String?, vararg arguments: Any?) = logger.warn(marker, format, *arguments)
+    override fun warn(format: String?, arg1: Any?, arg2: Any?) = logger.warn(marker, format, arg1, arg2)
+    override fun warn(msg: String?, t: Throwable?) = logger.warn(marker, msg, t)
+    override fun error(msg: String?) = logger.error(marker, msg)
+    override fun error(format: String?, arg: Any?) = logger.error(marker, format, arg)
+    override fun error(format: String?, arg1: Any?, arg2: Any?) = logger.error(marker, format, arg1, arg2)
+    override fun error(format: String?, vararg arguments: Any?) = logger.error(marker, format, *arguments)
+    override fun error(msg: String?, t: Throwable?) = logger.error(marker, msg, t)
+
+
+    /**
+     * prevent direct marker usage
+     */
+
+    override fun isTraceEnabled(marker: Marker?): Boolean = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, format: String?, vararg argArray: Any?) = directMarkerUsageNotAllowed()
+    override fun trace(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    override fun isDebugEnabled(marker: Marker?): Boolean = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, format: String?, vararg arguments: Any?) = directMarkerUsageNotAllowed()
+    override fun debug(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    override fun isInfoEnabled(marker: Marker?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, format: String?, vararg arguments: Any?) = directMarkerUsageNotAllowed()
+    override fun info(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    override fun isWarnEnabled(marker: Marker?): Boolean = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, format: String?, vararg arguments: Any?) = directMarkerUsageNotAllowed()
+    override fun warn(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    override fun isErrorEnabled(marker: Marker?): Boolean = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, msg: String?) = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, format: String?, arg: Any?) = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, format: String?, arg1: Any?, arg2: Any?) = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, format: String?, vararg arguments: Any?) = directMarkerUsageNotAllowed()
+    override fun error(marker: Marker?, msg: String?, t: Throwable?) = directMarkerUsageNotAllowed()
+    private fun directMarkerUsageNotAllowed(): Nothing =
+        throw UnsupportedOperationException("Direct use of Marker arg in MarkerLogger is not allowed")
+
+
+    /**
+     * override default methods, not overriden by delegation "by logger"
+     */
+
+    override fun makeLoggingEventBuilder(level: org.slf4j.event.Level?): LoggingEventBuilder? =
+        logger.makeLoggingEventBuilder(level)
+
+    override fun atLevel(level: org.slf4j.event.Level?): LoggingEventBuilder? = logger.atLevel(level)
+    override fun atTrace(): LoggingEventBuilder? = logger.atTrace()
+    override fun isEnabledForLevel(level: org.slf4j.event.Level?): Boolean = logger.isEnabledForLevel(level)
+    override fun atDebug(): LoggingEventBuilder? = logger.atDebug()
+    override fun atInfo(): LoggingEventBuilder? = logger.atInfo()
+    override fun atWarn(): LoggingEventBuilder? = logger.atWarn()
+    override fun atError(): LoggingEventBuilder? = logger.atError()
+
+    override fun isTraceEnabled(): Boolean = logger.isTraceEnabled
+    override fun isDebugEnabled(): Boolean = logger.isDebugEnabled
+    override fun isInfoEnabled(): Boolean = logger.isInfoEnabled
+    override fun isWarnEnabled(): Boolean = logger.isWarnEnabled
+    override fun isErrorEnabled(): Boolean = logger.isErrorEnabled
+    override fun getName(): String? = logger.name
 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegister.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/produsenter/ProdusentRegister.kt
@@ -6,7 +6,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Mottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NærmesteLederMottaker
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.azuread.AppName
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import java.util.*
 
 typealias Merkelapp = String

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/texas/Texas.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/texas/Texas.kt
@@ -16,7 +16,7 @@ import io.micrometer.core.instrument.Tags
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.coRecord
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.defaultHttpClient
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.http.withTimer
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.rethrowIfCancellation
 
 /**

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/manuelt_vedlikehold/ManueltVedlikeholdService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/manuelt_vedlikehold/ManueltVedlikeholdService.kt
@@ -6,7 +6,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionHendelseMetadata
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka.PartitionProcessor
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.*

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -30,7 +30,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.ParameterSetters
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Transaction
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository.AggregateType
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationKalenderavtale.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationKalenderavtale.kt
@@ -7,7 +7,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.KalenderavtaleOppdatert
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.KalenderavtaleOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel.Sak
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyBeskjed.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import graphql.schema.idl.RuntimeWiring
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.BeskjedOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel.Sak
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.produsent.tilProdusentModel

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNyOppgave.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import graphql.schema.idl.RuntimeWiring
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.OppgaveOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel.Sak
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/MutationNySak.kt
@@ -10,7 +10,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NyStatusSak
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NærmesteLederMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.SakOpprettet
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.*
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository.AggregateType

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Util.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Util.kt
@@ -1,7 +1,7 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Mottaker
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.Merkelapp
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.Produsent
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteRepositoryImpl.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteRepositoryImpl.kt
@@ -5,7 +5,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.NyTidStrategi.FORLENG
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Database
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.ISO8601Period
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.skedulert_harddelete.SkedulertHardDeleteRepository.AggregateType
 import no.nav.arbeidsgiver.notifikasjon.skedulert_harddelete.SkedulertHardDeleteRepository.AggregateType.*
 import no.nav.arbeidsgiver.notifikasjon.skedulert_harddelete.SkedulertHardDeleteRepository.SkedulertHardDelete

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteService.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_harddelete/SkedulertHardDeleteService.kt
@@ -5,7 +5,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseProdusent
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.NaisEnvironment
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.*

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/skedulert_utgått/SkedulertUtgåttRepository.kt
@@ -4,6 +4,7 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HardDeletedRepository
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.KalenderavtaleTilstand
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.tid.asOsloLocalDate
 import java.time.Instant
 import java.time.LocalDate

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlientImplTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlientImplTest.kt
@@ -31,12 +31,12 @@ class Altinn3VarselKlientImplTest {
             tekst = "Hei, dette er en test",
             ordreId = "test-idempotency-123"
         ).let { dto ->
-            val json = Altinn3VarselKlient.OrderRequest.from(dto)
+            val json = Altinn3VarselKlient.OrderRequest.from(dto, "test-idempotency")
             JSONAssert.assertEquals(
                 //language=json
                 """
                         {
-                          "idempotencyId": "test-idempotency-123",
+                          "idempotencyId": "test-idempotency",
                           "recipient": {
                             "recipientSms": {
                               "phoneNumber": "+4799999999",
@@ -77,12 +77,12 @@ class Altinn3VarselKlientImplTest {
                 tekst = "Hei, dette er en test",
                 ordreId = "ordre123"
             )
-            val json = Altinn3VarselKlient.OrderRequest.from(dto)
+            val json = Altinn3VarselKlient.OrderRequest.from(dto, "test-idempotency")
             JSONAssert.assertEquals(
                 //language=json
                 """
                         {
-                          "idempotencyId": "ordre123",
+                          "idempotencyId": "test-idempotency",
                           "recipient": {
                             "recipientSms": {
                               "phoneNumber": "$output",
@@ -110,12 +110,12 @@ class Altinn3VarselKlientImplTest {
             body = "Hei, dette er en test",
             ordreId = "test-idempotency-456"
         ).let { dto ->
-            val json = Altinn3VarselKlient.OrderRequest.from(dto)
+            val json = Altinn3VarselKlient.OrderRequest.from(dto, "test-idempotency")
             JSONAssert.assertEquals(
                 //language=json
                 """
                         {
-                          "idempotencyId": "test-idempotency-456",
+                          "idempotencyId": "test-idempotency",
                           "recipient": {
                             "recipientEmail": {
                               "emailAddress": "foo@bar.baz",
@@ -147,12 +147,12 @@ class Altinn3VarselKlientImplTest {
             smsInnhold = "Hei, sms",
             ordreId = "test-idempotency-789"
         ).let { dto ->
-            val json = Altinn3VarselKlient.OrderRequest.from(dto)
+            val json = Altinn3VarselKlient.OrderRequest.from(dto, "test-idempotency")
             JSONAssert.assertEquals(
                 //language=json
                 """
                         {
-                          "idempotencyId": "test-idempotency-789",
+                          "idempotencyId": "test-idempotency",
                           "recipient": {
                             "recipientOrganization": {
                               "orgNumber": "42",
@@ -191,7 +191,7 @@ class Altinn3VarselKlientImplTest {
         )
 
         assertThrows<UnsupportedOperationException> {
-            Altinn3VarselKlient.OrderRequest.from(eksternVarsel)
+            Altinn3VarselKlient.OrderRequest.from(eksternVarsel, "test-idempotency")
 
         }
     }
@@ -217,7 +217,7 @@ class Altinn3VarselKlientImplTest {
                 override suspend fun token(scope: String) = "fake-token"
             },
         )
-        client.order(eksternVarselSms).let {
+        client.order(eksternVarselSms, "123").let {
             it as Altinn3VarselKlient.OrderResponse.Success
             assertEquals("42", it.orderId)
             assertEquals("shipment-42", it.shipmentId)
@@ -269,7 +269,7 @@ class Altinn3VarselKlientImplTest {
                 override suspend fun token(scope: String) = "fake-token"
             },
         )
-        client.order(eksternVarselEpost).let {
+        client.order(eksternVarselEpost, "123").let {
             it as Altinn3VarselKlient.OrderResponse.Success
             assertEquals("42", it.orderId)
             assertEquals("shipment-42", it.shipmentId)
@@ -325,7 +325,7 @@ class Altinn3VarselKlientImplTest {
             },
         )
 
-        client.order(eksternVarselSms).let {
+        client.order(eksternVarselSms, "123").let {
             it as Altinn3VarselKlient.ErrorResponse
             assertEquals("RuntimeException", it.code)
             assertEquals("Failed to get token", it.message)
@@ -375,7 +375,7 @@ class Altinn3VarselKlientImplTest {
                 override suspend fun token(scope: String) = "fake-token"
             },
         )
-        client.order(eksternVarselSms).let {
+        client.order(eksternVarselSms, "123").let {
             it as Altinn3VarselKlient.ErrorResponse
             assertEquals("400", it.code)
             assertTrue(it.message.contains("Bad Request"))

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlientImplTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlientImplTest.kt
@@ -9,8 +9,6 @@ import io.ktor.http.content.*
 import io.ktor.serialization.jackson.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.test.runTest
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.NotificationsResponse.Success
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.NotificationsResponse.Success.Notification
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.altinn.AltinnPlattformTokenClient
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
@@ -24,26 +22,28 @@ import kotlin.test.assertTrue
 class Altinn3VarselKlientImplTest {
 
     @Test
-    fun `DTO mapping EksternVarsel Sms - NotificationDTO Sms`() {
+    fun `DTO mapping EksternVarsel Sms - new future orders format`() {
         EksternVarsel.Sms(
             fnrEllerOrgnr = "99999999901",
             sendeVindu = HendelseModel.EksterntVarselSendingsvindu.LØPENDE,
             sendeTidspunkt = null,
             mobilnummer = "99999999",
             tekst = "Hei, dette er en test",
-            ordreId = "123"
+            ordreId = "test-idempotency-123"
         ).let { dto ->
             val json = Altinn3VarselKlient.OrderRequest.from(dto)
             JSONAssert.assertEquals(
                 //language=json
                 """
                         {
-                          "notificationChannel" : "Sms",
-                          "recipients" : [ {
-                            "mobileNumber" : "+4799999999"
-                          } ],
-                          "smsTemplate" : {
-                            "body" : "Hei, dette er en test"
+                          "idempotencyId": "test-idempotency-123",
+                          "recipient": {
+                            "recipientSms": {
+                              "phoneNumber": "+4799999999",
+                              "smsSettings": {
+                                "body": "Hei, dette er en test"
+                              }
+                            }
                           }
                         }
                       """,
@@ -75,21 +75,23 @@ class Altinn3VarselKlientImplTest {
                 sendeTidspunkt = null,
                 mobilnummer = input,
                 tekst = "Hei, dette er en test",
-                ordreId = "123"
+                ordreId = "ordre123"
             )
             val json = Altinn3VarselKlient.OrderRequest.from(dto)
             JSONAssert.assertEquals(
                 //language=json
                 """
-                            {
-                              "notificationChannel" : "Sms",
-                              "recipients" : [ {
-                                "mobileNumber" : "$output"
-                              } ],
-                              "smsTemplate" : {
-                                "body" : "Hei, dette er en test"
+                        {
+                          "idempotencyId": "ordre123",
+                          "recipient": {
+                            "recipientSms": {
+                              "phoneNumber": "$output",
+                              "smsSettings": {
+                                "body": "Hei, dette er en test"
                               }
                             }
+                          }
+                        }
                           """,
                 laxObjectMapper.writeValueAsString(json),
                 true
@@ -98,7 +100,7 @@ class Altinn3VarselKlientImplTest {
     }
 
     @Test
-    fun `DTO mapping EksternVarsel Epost - NotificationDTO Email`() {
+    fun `DTO mapping EksternVarsel Epost - new future orders format`() {
         EksternVarsel.Epost(
             fnrEllerOrgnr = "99999999901",
             sendeVindu = HendelseModel.EksterntVarselSendingsvindu.LØPENDE,
@@ -106,21 +108,24 @@ class Altinn3VarselKlientImplTest {
             epostadresse = "foo@bar.baz",
             tittel = "Test",
             body = "Hei, dette er en test",
-            ordreId = "123"
+            ordreId = "test-idempotency-456"
         ).let { dto ->
             val json = Altinn3VarselKlient.OrderRequest.from(dto)
             JSONAssert.assertEquals(
                 //language=json
                 """
                         {
-                          "notificationChannel" : "Email",
-                          "recipients" : [ {
-                            "emailAddress" : "foo@bar.baz"
-                          } ],
-                          "emailTemplate" : {
-                            "subject" : "Test",
-                            "body" : "Hei, dette er en test",
-                            "contentType" : "Html"
+                          "idempotencyId": "test-idempotency-456",
+                          "recipient": {
+                            "recipientEmail": {
+                              "emailAddress": "foo@bar.baz",
+                              "emailSettings": {
+                                "fromAddress": "ikke-svar@nav.no",
+                                "subject": "Test",
+                                "body": "Hei, dette er en test",
+                                "contentType": "Html"
+                              }
+                            }
                           }
                         }
                         """,
@@ -131,7 +136,7 @@ class Altinn3VarselKlientImplTest {
     }
 
     @Test
-    fun `DTO mapping EksternVarsel Altinnressurs - NotificationDTO Resource`() {
+    fun `DTO mapping EksternVarsel Altinnressurs - new future orders format`() {
         EksternVarsel.Altinnressurs(
             fnrEllerOrgnr = "42",
             sendeVindu = HendelseModel.EksterntVarselSendingsvindu.LØPENDE,
@@ -140,26 +145,30 @@ class Altinn3VarselKlientImplTest {
             epostTittel = "Test",
             epostInnhold = "Hei, epost",
             smsInnhold = "Hei, sms",
-            ordreId = "123"
+            ordreId = "test-idempotency-789"
         ).let { dto ->
             val json = Altinn3VarselKlient.OrderRequest.from(dto)
             JSONAssert.assertEquals(
                 //language=json
                 """
                         {
-                          "notificationChannel" : "EmailPreferred",
-                          "recipients" : [ {
-                            "organizationNumber" : "42"
-                          } ],
-                          "resourceId" : "nav_foo-bar",
-                          "resourceAction" : "access",
-                          "emailTemplate" : {
-                            "subject" : "Test",
-                            "body" : "Hei, epost",
-                            "contentType" : "Html"
-                          },
-                          "smsTemplate" : {
-                            "body" : "Hei, sms"
+                          "idempotencyId": "test-idempotency-789",
+                          "recipient": {
+                            "recipientOrganization": {
+                              "orgNumber": "42",
+                              "channelSchema": "EmailPreferred",
+                              "resourceId": "nav_foo-bar",
+                              "resourceAction": "access",
+                              "emailSettings": {
+                                "fromAddress": "ikke-svar@nav.no",
+                                "subject": "Test",
+                                "body": "Hei, epost",
+                                "contentType": "Html"
+                              },
+                              "smsSettings": {
+                                "body": "Hei, sms"
+                              }
+                            }
                           }
                         }
                         """,
@@ -188,11 +197,11 @@ class Altinn3VarselKlientImplTest {
     }
 
     @Test
-    fun `Altinn3VarselKlientImpl#order success for sms returnerer order id`() = runTest {
+    fun `Altinn3VarselKlientImpl#order success for sms returnerer order id og shipment id`() = runTest {
         val mockEngine = MockEngine {
             respond(
-                content = mockResponse,
-                status = HttpStatusCode.OK,
+                content = mockOrderResponse,
+                status = HttpStatusCode.Created,
                 headers = headersOf(HttpHeaders.ContentType, "application/json")
             )
         }
@@ -211,22 +220,25 @@ class Altinn3VarselKlientImplTest {
         client.order(eksternVarselSms).let {
             it as Altinn3VarselKlient.OrderResponse.Success
             assertEquals("42", it.orderId)
+            assertEquals("shipment-42", it.shipmentId)
         }
         assertEquals(1, mockEngine.requestHistory.size)
         mockEngine.requestHistory.first().let { req ->
-            assertEquals("http://altinn/notifications/api/v1/orders", req.url.toString())
+            assertEquals("http://altinn/notifications/api/v1/future/orders", req.url.toString())
             assertEquals(HttpMethod.Post, req.method)
             assertEquals("Bearer fake-token", req.headers[HttpHeaders.Authorization])
             JSONAssert.assertEquals(
                 //language=json
                 """
                     {
-                      "notificationChannel" : "Sms",
-                      "recipients" : [ {
-                        "mobileNumber" : "+4799999999"
-                      } ],
-                      "smsTemplate" : {
-                        "body" : "Hei, dette er en test"
+                      "idempotencyId": "123",
+                      "recipient": {
+                        "recipientSms": {
+                          "phoneNumber": "+4799999999",
+                          "smsSettings": {
+                            "body": "Hei, dette er en test"
+                          }
+                        }
                       }
                     }
                     """,
@@ -237,11 +249,11 @@ class Altinn3VarselKlientImplTest {
     }
 
     @Test
-    fun `Altinn3VarselKlientImpl#order success for email returnerer order id`() = runTest {
+    fun `Altinn3VarselKlientImpl#order success for email returnerer order id og shipment id`() = runTest {
         val mockEngine = MockEngine {
             respond(
-                content = mockResponse,
-                status = HttpStatusCode.OK,
+                content = mockOrderResponse,
+                status = HttpStatusCode.Created,
                 headers = headersOf(HttpHeaders.ContentType, "application/json")
             )
         }
@@ -260,27 +272,29 @@ class Altinn3VarselKlientImplTest {
         client.order(eksternVarselEpost).let {
             it as Altinn3VarselKlient.OrderResponse.Success
             assertEquals("42", it.orderId)
+            assertEquals("shipment-42", it.shipmentId)
         }
         assertEquals(1, mockEngine.requestHistory.size)
         mockEngine.requestHistory.last().let { req ->
-            assertEquals("http://altinn/notifications/api/v1/orders", req.url.toString())
+            assertEquals("http://altinn/notifications/api/v1/future/orders", req.url.toString())
             assertEquals(HttpMethod.Post, req.method)
             assertEquals("Bearer fake-token", req.headers[HttpHeaders.Authorization])
             JSONAssert.assertEquals(
                 //language=json
                 """
                     {
-                      "notificationChannel": "Email",
-                      "emailTemplate": {
-                        "subject": "Hei, dette er en tittel",
-                        "body": "Hei, dette er en test",
-                        "contentType": "Html"
-                      },
-                      "recipients": [
-                        {
-                          "emailAddress": "adresse@epost.com"
+                      "idempotencyId": "123",
+                      "recipient": {
+                        "recipientEmail": {
+                          "emailAddress": "adresse@epost.com",
+                          "emailSettings": {
+                            "fromAddress": "ikke-svar@nav.no",
+                            "subject": "Hei, dette er en tittel",
+                            "body": "Hei, dette er en test",
+                            "contentType": "Html"
+                          }
                         }
-                      ]
+                      }
                     }
                     """,
                 req.bodyAsString(),
@@ -293,8 +307,8 @@ class Altinn3VarselKlientImplTest {
     fun `Altinn3VarselKlientImpl#order returns error when platform token fails`() = runTest {
         val mockEngine = MockEngine {
             respond(
-                content = mockResponse,
-                status = HttpStatusCode.OK,
+                content = mockOrderResponse,
+                status = HttpStatusCode.Created,
                 headers = headersOf(HttpHeaders.ContentType, "application/json")
             )
         }
@@ -369,200 +383,135 @@ class Altinn3VarselKlientImplTest {
     }
 
     @Test
-    fun `Altinn3VarselKlientImpl#notifications`() = runTest {
-        val orderId = "42"
+    fun `Altinn3VarselKlientImpl#shipment returns delivery manifest`() = runTest {
+        val shipmentId = "shipment-42"
         //language=json
-        val mockSmsResponse = """
+        val mockShipmentResponse = """
             {
-                "orderId": "42",
+                "shipmentId": "$shipmentId",
                 "sendersReference": null,
-                "generated": 1,
-                "succeeded": 1,
-                "notifications": [
+                "type": "Notification",
+                "status": "Order_Completed",
+                "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                "recipients": [
                     {
-                        "id": "4321",
-                        "succeeded": false,
-                        "recipient": {
-                            "mobileNumber": "+4799999999"
-                        },
-                        "sendStatus": {
-                            "status": "New",
-                            "description": "The sms has been created, but has not been picked up for processing yet.",
-                            "lastUpdate": "2023-11-14T16:06:02.877361Z"
-                        }
+                        "status": "Email_Delivered",
+                        "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                        "destination": "recipient@domain.com"
+                    },
+                    {
+                        "status": "SMS_Delivered",
+                        "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                        "destination": "+4799999999"
                     }
                 ]
             }"""
 
-        //language=json
-        val mockEmailResponse = """
-            {
-                "orderId": "42",
-                "generated": 1,
-                "succeeded": 1,
-                "notifications": [
-                    {
-                        "id": "1234",
-                        "succeeded": false,
-                        "recipient": {
-                            "emailAddress": "recipient@domain.com"
-                        },
-                        "sendStatus": {
-                            "status": "New",
-                            "description": "The email has been created, but has not been picked up for processing yet.",
-                            "lastUpdate": "2023-11-14T16:06:02.877361Z"
-                        }
-                    }
-                ]
-            }"""
+        val client = newClient(shipmentId, mockShipmentResponse)
+        val result = client.shipment(shipmentId)
+        result as Altinn3VarselKlient.ShipmentResponse.Success
+        assertEquals(shipmentId, result.shipmentId)
+        assertEquals("Order_Completed", result.status)
+        assertEquals(2, result.recipients.size)
+        assertTrue(result.allRecipientsDelivered)
+        assertTrue(result.allRecipientsFinished)
+        assertTrue(result.isOrderCompleted)
 
-        // gets sms and email notifications for a given order id
-        val client = newClient(orderId, mockSmsResponse, mockEmailResponse)
-        val result = client.notifications(orderId)
-        result as Success
-        assertEquals(orderId, result.orderId)
-        assertEquals(null, result.sendersReference)
-        assertEquals(2, result.generated)
-        assertEquals(2, result.succeeded)
-        assertEquals(2, result.notifications.size)
-        assertEquals(
-            listOf(
-                Notification(
-                    id = "4321",
-                    succeeded = false,
-                    recipient = Notification.Recipient(
-                        mobileNumber = "+4799999999"
-                    ),
-                    sendStatus = Notification.SendStatus(
-                        status = "New",
-                        description = "The sms has been created, but has not been picked up for processing yet.",
-                        lastUpdate = "2023-11-14T16:06:02.877361Z"
-                    )
-                ),
-                Notification(
-                    id = "1234",
-                    succeeded = false,
-                    recipient = Notification.Recipient(
-                        emailAddress = "recipient@domain.com"
-                    ),
-                    sendStatus = Notification.SendStatus(
-                        status = "New",
-                        description = "The email has been created, but has not been picked up for processing yet.",
-                        lastUpdate = "2023-11-14T16:06:02.877361Z"
-                    )
-                ),
-            ),
-            result.notifications
-        )
-        assertEquals(2, (client.httpClient.engine as MockEngine).requestHistory.size)
+        assertEquals(1, (client.httpClient.engine as MockEngine).requestHistory.size)
         (client.httpClient.engine as MockEngine).requestHistory.first().let { req ->
-            assertEquals("http://altinn/notifications/api/v1/orders/$orderId/notifications/sms", req.url.toString())
-            assertEquals(HttpMethod.Get, req.method)
-            assertEquals("Bearer fake-token", req.headers[HttpHeaders.Authorization])
-        }
-        (client.httpClient.engine as MockEngine).requestHistory.last().let { req ->
-            assertEquals("http://altinn/notifications/api/v1/orders/$orderId/notifications/email", req.url.toString())
+            assertEquals("http://altinn/notifications/api/v1/future/shipment/$shipmentId", req.url.toString())
             assertEquals(HttpMethod.Get, req.method)
             assertEquals("Bearer fake-token", req.headers[HttpHeaders.Authorization])
         }
     }
 
     @Test
-    fun `Altinn3VarselKlientImpl#notifications no sms only email`() = runTest {
-        // gets sms and email notifications for a given order id
-        val client = newClient(
-            "43",
-            smsResponse = """
-                {
-                  "generated": 0,
-                  "notifications": [],
-                  "orderId": "70bc6dff-0c14-4842-b36a-3ab64a2dae08",
-                  "succeeded": 0
-                }""",
-            emailResponse = """
-                {
-                  "generated": 4,
-                  "notifications": [
+    fun `Altinn3VarselKlientImpl#shipment with processing recipients`() = runTest {
+        val shipmentId = "shipment-43"
+        //language=json
+        val mockShipmentResponse = """
+            {
+                "shipmentId": "$shipmentId",
+                "sendersReference": null,
+                "type": "Notification",
+                "status": "Order_Completed",
+                "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                "recipients": [
                     {
-                      "id": "042f1a8a-fe29-47c9-a992-433399563c12",
-                      "recipient": {
-                        "emailAddress": "abc@a.no",
-                        "organizationNumber": "211511052"
-                      },
-                      "sendStatus": {
-                        "description": "The email has been created, but has not been picked up for processing yet.",
+                        "status": "Email_New",
                         "lastUpdate": "2025-03-31T16:21:04.12234Z",
-                        "status": "New"
-                      },
-                      "succeeded": false
+                        "destination": "abc@a.no"
                     },
                     {
-                      "id": "6b3bfbc4-a092-4df7-8f38-e43171df49a9",
-                      "recipient": {
-                        "emailAddress": "sss.sss@ssss.no",
-                        "organizationNumber": "211511052"
-                      },
-                      "sendStatus": {
-                        "description": "The email is being processed and will be sent shortly.",
+                        "status": "Email_Sending",
                         "lastUpdate": "2025-03-31T16:21:04.126885Z",
-                        "status": "Sending"
-                      },
-                      "succeeded": false
+                        "destination": "sss.sss@ssss.no"
                     },
                     {
-                      "id": "6b3bfbc4-a092-4df7-8f38-e43171df49a9",
-                      "recipient": {
-                        "mobileNumber": "+4799999999",
-                        "organizationNumber": "211511052"
-                      },
-                      "sendStatus": {
-                        "description": "The SMS has been accepted by the gateway service and will be sent soon.",
+                        "status": "SMS_Accepted",
                         "lastUpdate": "2025-03-31T16:21:04.126885Z",
-                        "status": "Accepted"
-                      },
-                      "succeeded": false
+                        "destination": "+4799999999"
                     },
                     {
-                      "id": "6b3bfbc4-a092-4df7-8f38-e43171df49a9",
-                      "recipient": {
-                        "emailAddress": "sss.sss@ssss.no",
-                        "organizationNumber": "211511052"
-                      },
-                      "sendStatus": {
-                        "description": "The email has been accepted by the third-party service and will be sent soon.",
+                        "status": "Email_Succeeded",
                         "lastUpdate": "2025-03-31T16:21:04.126885Z",
-                        "status": "Succeeded"
-                      },
-                      "succeeded": false
+                        "destination": "sss.sss@ssss.no"
                     }
-                  ],
-                  "orderId": "70bc6dff-0c14-4842-b36a-3ab64a2dae08",
-                  "succeeded": 0
-                }"""
-        )
-        client.notifications("43").let {
-            it as Success
-            assertEquals(4, it.generated)
-            assertEquals(0, it.succeeded)
-            assertEquals(4, it.notifications.size)
-            assertTrue(it.notifications.all { notification -> notification.sendStatus.isProcessing })
+                ]
+            }"""
+
+        val client = newClient(shipmentId, mockShipmentResponse)
+        client.shipment(shipmentId).let {
+            it as Altinn3VarselKlient.ShipmentResponse.Success
+            assertEquals(4, it.recipients.size)
+            assertTrue(it.recipients.all { recipient -> recipient.isProcessing })
+        }
+    }
+
+    @Test
+    fun `Altinn3VarselKlientImpl#shipment with failed recipients`() = runTest {
+        val shipmentId = "shipment-44"
+        //language=json
+        val mockShipmentResponse = """
+            {
+                "shipmentId": "$shipmentId",
+                "sendersReference": null,
+                "type": "Notification",
+                "status": "Order_Completed",
+                "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                "recipients": [
+                    {
+                        "status": "Email_Delivered",
+                        "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                        "destination": "ok@test.no"
+                    },
+                    {
+                        "status": "Email_Failed_Bounced",
+                        "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                        "destination": "bad@test.no"
+                    }
+                ]
+            }"""
+
+        val client = newClient(shipmentId, mockShipmentResponse)
+        client.shipment(shipmentId).let {
+            it as Altinn3VarselKlient.ShipmentResponse.Success
+            assertEquals(2, it.recipients.size)
+            assertTrue(it.hasFailedRecipients)
+            assertTrue(it.allRecipientsFinished)
+            assertTrue(!it.allRecipientsDelivered)
         }
     }
 }
 
 
 //language=json
-private const val mockResponse = """
+private const val mockOrderResponse = """
         {
-          "orderId": "42",
-          "recipientLookup": {
-            "status": "Success",
-            "isReserved": [
-              "string"
-            ],
-            "missingContact": [
-              "string"
-            ]
+          "notificationOrderId": "42",
+          "notification": {
+            "shipmentId": "shipment-42",
+            "sendersReference": null
           }
         }"""
 
@@ -596,41 +545,21 @@ private suspend fun HttpRequestData.bodyAsString(): String {
 }
 
 private fun newClient(
-    orderId: String,
-    @Language("JSON") smsResponse: String,
-    @Language("JSON") emailResponse: String
+    shipmentId: String,
+    @Language("JSON") shipmentResponse: String
 ) = Altinn3VarselKlientImpl(
     altinnBaseUrl = "http://altinn",
     httpClient = HttpClient(MockEngine { req ->
         when (req.url.encodedPath) {
-            "/notifications/api/v1/orders/$orderId/notifications/sms" -> respond(
-                content = smsResponse,
+            "/notifications/api/v1/future/shipment/$shipmentId" -> respond(
+                content = shipmentResponse,
                 status = HttpStatusCode.OK,
                 headers = headersOf(HttpHeaders.ContentType, "application/json")
             )
 
-            "/notifications/api/v1/orders/$orderId/notifications/email" -> respond(
-                content = emailResponse,
-                status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, "application/json")
-            )
-
-            "/notifications/api/v1/orders" -> respond(
-                //language=json
-                content = """
-                            {
-                              "orderId": "42",
-                              "recipientLookup": {
-                                "status": "Success",
-                                "isReserved": [
-                                  "string"
-                                ],
-                                "missingContact": [
-                                  "string"
-                                ]
-                              }
-                            }""",
-                status = HttpStatusCode.OK,
+            "/notifications/api/v1/future/orders" -> respond(
+                content = mockOrderResponse,
+                status = HttpStatusCode.Created,
                 headers = headersOf(HttpHeaders.ContentType, "application/json")
             )
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlientImplTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlientImplTest.kt
@@ -383,6 +383,44 @@ class Altinn3VarselKlientImplTest {
     }
 
     @Test
+    fun `Altinn3VarselKlientImpl#order returns error due to missing contact info KOFUVI`() = runTest {
+        // returns error when http call fails
+        val client = Altinn3VarselKlientImpl(
+            altinnBaseUrl = "http://altinn",
+            httpClient = HttpClient(MockEngine {
+                respondError(
+                    status = HttpStatusCode.UnprocessableEntity,
+                    content = """
+                        {
+                          "type": "urn:altinn:error:NOT-00001",
+                          "title": "Missing contact information for recipient(s)",
+                          "status": 422,
+                          "code": "NOT-00001",
+                          "traceId": "00-b291127285024130cd8420758f373c2f-4959c5217011cd13-00",
+                          "statusDescription": "Unprocessable Entity"
+                        }
+                        """.trimIndent(),
+                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                )
+            }) {
+                expectSuccess = true
+                install(ContentNegotiation) {
+                    jackson()
+                }
+            },
+            altinnPlattformTokenClient = object : AltinnPlattformTokenClient {
+                override suspend fun token(scope: String) = "fake-token"
+            },
+        )
+        client.order(eksternVarselSms, "123").let {
+            it as Altinn3VarselKlient.ErrorResponse
+            assertEquals("422", it.code)
+            assertTrue(it.message.contains("Unprocessable Entity"))
+            assertTrue(it.message.contains("NOT-00001"))
+        }
+    }
+
+    @Test
     fun `Altinn3VarselKlientImpl#shipment returns delivery manifest`() = runTest {
         val shipmentId = "shipment-42"
         //language=json

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlientImplTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/Altinn3VarselKlientImplTest.kt
@@ -157,7 +157,7 @@ class Altinn3VarselKlientImplTest {
                             "recipientOrganization": {
                               "orgNumber": "42",
                               "channelSchema": "EmailPreferred",
-                              "resourceId": "nav_foo-bar",
+                              "resourceId": "urn:altinn:resource:nav_foo-bar",
                               "resourceAction": "access",
                               "emailSettings": {
                                 "fromAddress": "ikke-svar@nav.no",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/DevGcpAltinn3VarselKlientRunner.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/DevGcpAltinn3VarselKlientRunner.kt
@@ -71,23 +71,16 @@ fun main() = runBlocking {
             body = "Dette er en test",
             ordreId = null,
         )
-        val orderId = devGcpClient.order(varsel).let {
+        val orderResponse = devGcpClient.order(varsel).let {
             println("orderrespons:")
             println(it)
             println("")
-            (it as Altinn3VarselKlient.OrderResponse.Success).orderId
+            it as Altinn3VarselKlient.OrderResponse.Success
         }
 
-        devGcpClient.orderStatus(orderId).also {
+        devGcpClient.shipment(orderResponse.shipmentId).also {
             println("")
-            println("ordreStatus orderId $orderId:")
-            println(it)
-            println("")
-        }
-
-        devGcpClient.notifications(orderId).also {
-            println("")
-            println("notifications orderId $orderId:")
+            println("shipment status shipmentId ${orderResponse.shipmentId}:")
             println(it)
             println("")
         }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/DevGcpAltinn3VarselKlientRunner.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/DevGcpAltinn3VarselKlientRunner.kt
@@ -9,6 +9,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.texas.TexasAuthConfig
 import no.nav.arbeidsgiver.notifikasjon.util.App.`ekstern-varsling`
 import no.nav.arbeidsgiver.notifikasjon.util.DevGcpEnv
 import java.net.URI
+import java.util.*
 
 fun main() = runBlocking {
     val gcpEnv = DevGcpEnv(`ekstern-varsling`)
@@ -71,7 +72,7 @@ fun main() = runBlocking {
             body = "Dette er en test",
             ordreId = null,
         )
-        val orderResponse = devGcpClient.order(varsel).let {
+        val orderResponse = devGcpClient.order(varsel, UUID.randomUUID().toString()).let {
             println("orderrespons:")
             println(it)
             println("")

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTest.kt
@@ -81,7 +81,7 @@ class EksternVarslingServiceTest {
                 }
             },
             altinn3VarselKlient = altinn3VarselKlient ?: object : Altinn3VarselKlient {
-                override suspend fun order(eksternVarsel: EksternVarsel): Altinn3VarselKlient.OrderResponse {
+                override suspend fun order(eksternVarsel: EksternVarsel, idempotencyId: String): Altinn3VarselKlient.OrderResponse {
                     meldingSendt.set(MeldingsType.Altinn3)
                     val fakeOrderId = "fake-${UUID.randomUUID()}"
                     val fakeShipmentId = "fake-${UUID.randomUUID()}"
@@ -782,7 +782,7 @@ class EksternVarslingServiceTest {
                 },
             )
 
-            override suspend fun order(eksternVarsel: EksternVarsel): Altinn3VarselKlient.OrderResponse {
+            override suspend fun order(eksternVarsel: EksternVarsel, idempotencyId: String): Altinn3VarselKlient.OrderResponse {
                 val ordreId = UUID.randomUUID()
                 val shipmentId = UUID.randomUUID()
                 return Altinn3VarselKlient.OrderResponse.Success(
@@ -852,7 +852,7 @@ class EksternVarslingServiceTest {
             }
         """.trimIndent()
         val altinn3VarselKlient: Altinn3VarselKlient = object : Altinn3VarselKlient {
-            override suspend fun order(eksternVarsel: EksternVarsel) =
+            override suspend fun order(eksternVarsel: EksternVarsel, idempotencyId: String) =
                 Altinn3VarselKlient.OrderResponse.Success(
                     orderId = "314",
                     shipmentId = "shipment-314",
@@ -905,7 +905,7 @@ class EksternVarslingServiceTest {
     @Test
     fun `Altinn3 varsel oppførsel status simulering (synkron feil)`() = runBlocking {
         val altinn3VarselKlient: Altinn3VarselKlient = object : Altinn3VarselKlient {
-            override suspend fun order(eksternVarsel: EksternVarsel): Altinn3VarselKlient.OrderResponse {
+            override suspend fun order(eksternVarsel: EksternVarsel, idempotencyId: String): Altinn3VarselKlient.OrderResponse {
                 return Altinn3VarselKlient.ErrorResponse(
                     message = """
                             Bad Request: {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingServiceTest.kt
@@ -6,10 +6,7 @@ import com.fasterxml.jackson.databind.node.NullNode
 import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.NotificationsResponse
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.NotificationsResponse.Success.Notification
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.NotificationsResponse.Success.Notification.SendStatus
-import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.OrderStatusResponse.NotificationStatusSummary
+import no.nav.arbeidsgiver.notifikasjon.ekstern_varsling.Altinn3VarselKlient.ShipmentStatus
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnMottaker
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.AltinnressursVarselKontaktinfo
@@ -86,57 +83,41 @@ class EksternVarslingServiceTest {
             altinn3VarselKlient = altinn3VarselKlient ?: object : Altinn3VarselKlient {
                 override suspend fun order(eksternVarsel: EksternVarsel): Altinn3VarselKlient.OrderResponse {
                     meldingSendt.set(MeldingsType.Altinn3)
-                    return Altinn3VarselKlient.OrderResponse.Success.fromJson(
-                        JsonNodeFactory.instance.objectNode().apply {
-                            put("orderId", "fake-${UUID.randomUUID()}")
-                        }
-                    )
-                }
-
-                override suspend fun notifications(orderId: String): NotificationsResponse {
-                    return NotificationsResponse.Success(
-                        orderId = orderId,
-                        generated = 3,
-                        succeeded = 3,
-                        sendersReference = "fake-${UUID.randomUUID()}",
-                        rå = JsonNodeFactory.instance.nullNode(),
-                        notifications = listOf(
-                            Notification(
-                                id = "fake-${UUID.randomUUID()}",
-                                succeeded = true,
-                                sendStatus = SendStatus(
-                                    status = SendStatus.Delivered,
-                                    description = "",
-                                    lastUpdate = ""
-                                ),
-                                recipient = Notification.Recipient(
-                                    null,
-                                    null,
-                                    null,
-                                    null
-                                )
-                            )
-                        )
-
-                    )
-                }
-
-                override suspend fun orderStatus(orderId: String): Altinn3VarselKlient.OrderStatusResponse {
-                    return Altinn3VarselKlient.OrderStatusResponse.Success(
-                        orderId = orderId,
-                        processingStatus = Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus(
-                            status = Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus.Completed,
-                            description = null,
-                            lastUpdate = null,
-                        ),
+                    val fakeOrderId = "fake-${UUID.randomUUID()}"
+                    val fakeShipmentId = "fake-${UUID.randomUUID()}"
+                    return Altinn3VarselKlient.OrderResponse.Success(
                         rå = JsonNodeFactory.instance.objectNode().apply {
-                            put("orderId", orderId)
+                            put("notificationOrderId", fakeOrderId)
+                            putObject("notification").put("shipmentId", fakeShipmentId)
                         },
-                        sendersReference = "fake-${UUID.randomUUID()}",
-                        notificationsStatusSummary = NotificationStatusSummary(
-                            generated = 3, succeeded = 3,
-                        )
+                        orderId = fakeOrderId,
+                        shipmentId = fakeShipmentId,
+                    )
+                }
 
+                override suspend fun shipment(shipmentId: String): Altinn3VarselKlient.ShipmentResponse {
+                    return Altinn3VarselKlient.ShipmentResponse.Success(
+                        rå = JsonNodeFactory.instance.objectNode().apply {
+                            put("shipmentId", shipmentId)
+                            put("status", ShipmentStatus.Order_Completed)
+                            putArray("recipients").addObject().apply {
+                                put("status", ShipmentStatus.Email_Delivered)
+                                put("lastUpdate", "2025-03-31T16:21:04.126885Z")
+                                put("destination", "test@test.no")
+                            }
+                        },
+                        shipmentId = shipmentId,
+                        sendersReference = null,
+                        type = "Notification",
+                        status = ShipmentStatus.Order_Completed,
+                        lastUpdate = null,
+                        recipients = listOf(
+                            Altinn3VarselKlient.ShipmentResponse.Success.RecipientDelivery(
+                                status = ShipmentStatus.Email_Delivered,
+                                lastUpdate = "2025-03-31T16:21:04.126885Z",
+                                destination = "test@test.no",
+                            )
+                        ),
                     )
                 }
             },
@@ -730,135 +711,93 @@ class EksternVarslingServiceTest {
 
     @Test
     fun `Altinn3 varsel oppførsel status simulering`() = runBlocking {
-        val notificationsNewRå = laxObjectMapper.readValue<JsonNode>(
+        val shipmentProcessingRå = laxObjectMapper.readValue<JsonNode>(
             """
                 {
-                "generated": 2,
-                "notifications": [
-                  {
-                    "id": "042f1a8a-fe29-47c9-a992-433399563c12",
-                    "recipient": {
-                      "emailAddress": "abc@a.no",
-                      "organizationNumber": "12341234"
-                    },
-                    "sendStatus": {
-                      "description": "The email was successfully delivered to the recipient. No errors were reported, indicating successful delivery.",
-                      "lastUpdate": "2025-03-31T16:21:04.12234Z",
-                      "status": "Delivered"
-                    },
-                    "succeeded": true
-                  },
-                  {
-                    "id": "6b3bfbc4-a092-4df7-8f38-e43171df49a9",
-                    "recipient": {
-                      "emailAddress": "sss.sss@sss.no",
-                      "organizationNumber": "12341234"
-                    },
-                    "sendStatus": {
-                      "description": "The email has been created, but has not been picked up for processing yet.",
-                      "lastUpdate": "2025-03-31T16:21:04.126885Z",
-                      "status": "New"
-                    },
-                    "succeeded": false
-                  }
-                ],
-                "orderId": "70bc6dff-0c14-4842-b36a-3ab64a2dae08",
-                "succeeded": 1
+                "shipmentId": "70bc6dff-0c14-4842-b36a-3ab64a2dae08",
+                "sendersReference": null,
+                "type": "Notification",
+                "status": "Order_Processing",
+                "lastUpdate": "2025-03-31T16:21:04.12234Z",
+                "recipients": []
               }
             """.trimIndent()
         )
-        val notificationsDeliveredRå = laxObjectMapper.readValue<JsonNode>(
+        val shipmentWithNewRecipientsRå = laxObjectMapper.readValue<JsonNode>(
             """
                 {
-                "generated": 2,
-                "notifications": [
+                "shipmentId": "70bc6dff-0c14-4842-b36a-3ab64a2dae08",
+                "sendersReference": null,
+                "type": "Notification",
+                "status": "Order_Completed",
+                "lastUpdate": "2025-03-31T16:21:04.12234Z",
+                "recipients": [
                   {
-                    "id": "042f1a8a-fe29-47c9-a992-433399563c12",
-                    "recipient": {
-                      "emailAddress": "abc@a.no",
-                      "organizationNumber": "12341234"
-                    },
-                    "sendStatus": {
-                      "description": "The email was successfully delivered to the recipient. No errors were reported, indicating successful delivery.",
-                      "lastUpdate": "2025-03-31T16:21:04.12234Z",
-                      "status": "Delivered"
-                    },
-                    "succeeded": true
+                    "status": "Email_Delivered",
+                    "lastUpdate": "2025-03-31T16:21:04.12234Z",
+                    "destination": "abc@a.no"
                   },
                   {
-                    "id": "6b3bfbc4-a092-4df7-8f38-e43171df49a9",
-                    "recipient": {
-                      "emailAddress": "sss.sss@sss.no",
-                      "organizationNumber": "12341234"
-                    },
-                    "sendStatus": {
-                      "description": "The email was successfully delivered to the recipient. No errors were reported, indicating successful delivery.",
-                      "lastUpdate": "2025-03-31T16:21:04.126885Z",
-                      "status": "Delivered"
-                    },
-                    "succeeded": true
+                    "status": "Email_New",
+                    "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                    "destination": "sss.sss@sss.no"
                   }
-                ],
-                "orderId": "70bc6dff-0c14-4842-b36a-3ab64a2dae08",
-                "succeeded": 2
+                ]
+              }
+            """.trimIndent()
+        )
+        val shipmentAllDeliveredRå = laxObjectMapper.readValue<JsonNode>(
+            """
+                {
+                "shipmentId": "70bc6dff-0c14-4842-b36a-3ab64a2dae08",
+                "sendersReference": null,
+                "type": "Notification",
+                "status": "Order_Completed",
+                "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                "recipients": [
+                  {
+                    "status": "Email_Delivered",
+                    "lastUpdate": "2025-03-31T16:21:04.12234Z",
+                    "destination": "abc@a.no"
+                  },
+                  {
+                    "status": "Email_Delivered",
+                    "lastUpdate": "2025-03-31T16:21:04.126885Z",
+                    "destination": "sss.sss@sss.no"
+                  }
+                ]
               }
             """.trimIndent()
         )
         val altinn3VarselKlient: Altinn3VarselKlient = object : Altinn3VarselKlient {
-            val orderStatusResolvers = mutableListOf(
-                { orderId: String ->
-                    Altinn3VarselKlient.OrderStatusResponse.Success(
-                        rå = JsonNodeFactory.instance.objectNode(),
-                        orderId = orderId,
-                        sendersReference = null,
-                        Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus(
-                            Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus.Processing,
-                            null,
-                            null
-                        ),
-                        NotificationStatusSummary(0, 0)
-                    )
+            val shipmentResolvers = mutableListOf(
+                { _: String ->
+                    Altinn3VarselKlient.ShipmentResponse.Success.fromJson(shipmentProcessingRå)
                 },
-                { orderId: String ->
-                    Altinn3VarselKlient.OrderStatusResponse.Success(
-                        rå = JsonNodeFactory.instance.objectNode(),
-                        orderId = orderId,
-                        sendersReference = null,
-                        Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus(
-                            Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus.Completed,
-                            null,
-                            null
-                        ),
-                        NotificationStatusSummary(0, 0)
-                    )
+                { _: String ->
+                    Altinn3VarselKlient.ShipmentResponse.Success.fromJson(shipmentWithNewRecipientsRå)
+                },
+                { _: String ->
+                    Altinn3VarselKlient.ShipmentResponse.Success.fromJson(shipmentAllDeliveredRå)
                 },
             )
-            val notificationResolvers = mutableListOf(
-                {
-                    NotificationsResponse.Success.fromJson(notificationsNewRå)
-                },
-                {
-                    NotificationsResponse.Success.fromJson(notificationsDeliveredRå)
-                },
-            )
-
 
             override suspend fun order(eksternVarsel: EksternVarsel): Altinn3VarselKlient.OrderResponse {
                 val ordreId = UUID.randomUUID()
+                val shipmentId = UUID.randomUUID()
                 return Altinn3VarselKlient.OrderResponse.Success(
                     orderId = "$ordreId",
-                    rå = JsonNodeFactory.instance.objectNode().put("orderId", ordreId.toString())
+                    shipmentId = "$shipmentId",
+                    rå = JsonNodeFactory.instance.objectNode().apply {
+                        put("notificationOrderId", ordreId.toString())
+                        putObject("notification").put("shipmentId", shipmentId.toString())
+                    }
                 )
             }
 
-            override suspend fun notifications(orderId: String): NotificationsResponse {
-                return if (notificationResolvers.size > 1) notificationResolvers.removeAt(0)
-                    .invoke() else notificationResolvers.first().invoke()
-            }
-
-            override suspend fun orderStatus(orderId: String): Altinn3VarselKlient.OrderStatusResponse {
-                return if (orderStatusResolvers.size > 1) orderStatusResolvers.removeAt(0)
-                    .invoke(orderId) else orderStatusResolvers.first().invoke(orderId)
+            override suspend fun shipment(shipmentId: String): Altinn3VarselKlient.ShipmentResponse {
+                return if (shipmentResolvers.size > 1) shipmentResolvers.removeAt(0)
+                    .invoke(shipmentId) else shipmentResolvers.first().invoke(shipmentId)
             }
         }
 
@@ -879,7 +818,7 @@ class EksternVarslingServiceTest {
             eventually(5.seconds) {
                 val vellykket = hendelseProdusent.hendelserOfType<EksterntVarselVellykket>()
                 assertEquals(1, vellykket.size)
-                assertEquals(notificationsDeliveredRå, vellykket.first().råRespons)
+                assertEquals(shipmentAllDeliveredRå, vellykket.first().råRespons)
             }
             job.cancel()
         }
@@ -896,83 +835,36 @@ class EksternVarslingServiceTest {
     @Test
     fun `Altinn3 varsel oppførsel status simulering asynkron feil`() = runBlocking {
         //language=JSON
-        val orderStatusResponse = """
+        val shipmentResponse = """
             {
-              "id": "314",
-              "requestedSendTime": "2025-10-29T18:49:31.27885Z",
-              "creator": "nav",
-              "created": "2025-10-29T18:49:31.27928Z",
-              "notificationChannel": "Email",
-              "processingStatus": {
-                "status": "Completed",
-                "description": "Order processing is completed. All notifications have a final status.",
-                "lastUpdate": "2025-10-29T18:50:14.736615Z"
-              },
-              "notificationsStatusSummary": {
-                "email": {
-                  "links": {
-                    "self": "https://platform.altinn.no/notifications/api/v1/orders/1e0f2323-4b56-4489-aca4-9bc6c2cd86e6/notifications/email"
-                  },
-                  "generated": 1,
-                  "succeeded": 0
+              "shipmentId": "314",
+              "sendersReference": null,
+              "type": "Notification",
+              "status": "Order_Completed",
+              "lastUpdate": "2025-10-29T18:50:14.736615Z",
+              "recipients": [
+                {
+                  "status": "Email_Failed",
+                  "lastUpdate": "2025-03-31T16:21:04.12234Z",
+                  "destination": "abc@a.no"
                 }
-              }
+              ]
             }
         """.trimIndent()
-        //language=JSON
-        val notificationsRespons = """
-            {
-                "generated": 1,
-                "succeeded": 0,
-                "notifications": [
-                  {
-                    "id": "042f1a8a-fe29-47c9-a992-433399563c12",
-                    "recipient": {
-                      "emailAddress": "abc@a.no",
-                      "organizationNumber": "12341234"
-                    },
-                    "sendStatus": {
-                      "description": "The email was not sent due to an unspecified failure.",
-                      "lastUpdate": "2025-03-31T16:21:04.12234Z",
-                      "status": "Failed"
-                    },
-                    "succeeded": false
-                  }
-                ],
-                "orderId": "314"
-              }
-              """.trimIndent()
         val altinn3VarselKlient: Altinn3VarselKlient = object : Altinn3VarselKlient {
             override suspend fun order(eksternVarsel: EksternVarsel) =
                 Altinn3VarselKlient.OrderResponse.Success(
                     orderId = "314",
-                    rå = JsonNodeFactory.instance.objectNode().put("orderId", "314")
+                    shipmentId = "shipment-314",
+                    rå = JsonNodeFactory.instance.objectNode().apply {
+                        put("notificationOrderId", "314")
+                        putObject("notification").put("shipmentId", "shipment-314")
+                    }
                 )
 
-            /**
-             * notifications gjør 2 kall (sms og email) og konkatenerer resultatene, deerfor (+ "[]") her
-             */
-            override suspend fun notifications(orderId: String): NotificationsResponse.Success {
-                return NotificationsResponse.Success.fromJson(
-                    laxObjectMapper.readValue<JsonNode>(notificationsRespons)
-                ) + NotificationsResponse.Success.fromJson(
-                    laxObjectMapper.readValue<JsonNode>("""
-                        {"orderId":"314","generated":0,"succeeded":0,"notifications":[]}
-                    """)
-                )
-            }
-
-            override suspend fun orderStatus(orderId: String) =
-                Altinn3VarselKlient.OrderStatusResponse.Success(
-                    rå = laxObjectMapper.readValue<JsonNode>(orderStatusResponse),
-                    orderId = orderId,
-                    sendersReference = null,
-                    Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus(
-                        Altinn3VarselKlient.OrderStatusResponse.ProcessingStatus.Completed,
-                        null,
-                        null
-                    ),
-                    NotificationStatusSummary(1, 0)
+            override suspend fun shipment(shipmentId: String) =
+                Altinn3VarselKlient.ShipmentResponse.Success.fromJson(
+                    laxObjectMapper.readValue<JsonNode>(shipmentResponse)
                 )
         }
 
@@ -995,23 +887,15 @@ class EksternVarslingServiceTest {
                 assertEquals(1, feilet.size)
                 assertNotNull(feilet.first())
                 assertEquals(
-                    "Failed",
+                    "Email_Failed",
                     feilet.first().altinnFeilkode
-                )
-                assertEquals(
-                    "The email was not sent due to an unspecified failure.",
-                    feilet.first().feilmelding
                 )
                 repository.oppdaterModellEtterHendelse(feilet.first())
                 repository.findVarsel(feilet.first().varselId).let { varselTilstand ->
                     assertNotNull(varselTilstand)
                     varselTilstand as EksternVarselTilstand.Kvittert
                     varselTilstand.response as AltinnResponse.Feil
-                    assertEquals("Failed", varselTilstand.response.feilkode)
-                    assertEquals(
-                        "The email was not sent due to an unspecified failure.",
-                        varselTilstand.response.feilmelding
-                    )
+                    assertEquals("Email_Failed", varselTilstand.response.feilkode)
                 }
             }
             job.cancel()
@@ -1055,8 +939,7 @@ class EksternVarslingServiceTest {
                 )
             }
 
-            override suspend fun notifications(orderId: String) = TODO("Not yet implemented")
-            override suspend fun orderStatus(orderId: String) = TODO("Not yet implemented")
+            override suspend fun shipment(shipmentId: String) = TODO("Not yet implemented")
         }
         withTestDatabase(EksternVarsling.databaseConfig) { database ->
             val (repository, service, hendelseProdusent) = setupService(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingStatusEksportServiceTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/ekstern_varsling/EksternVarslingStatusEksportServiceTest.kt
@@ -27,6 +27,7 @@ class EksternVarslingStatusEksportServiceTest {
     @Test
     fun `når hendelse er EksterntVarselFeilet med feilkode`() = runTest {
         listOf(
+            "422",
             "30304",
             "30307",
             "30308",

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/GraphQLTestFns.kt
@@ -6,7 +6,7 @@ import com.jayway.jsonpath.JsonPath
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.api.ensurePrefix
 
 data class GraphQLError(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/ProdusentRepositoryStub.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/util/ProdusentRepositoryStub.kt
@@ -3,7 +3,7 @@ package no.nav.arbeidsgiver.notifikasjon.util
 
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Hendelse
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.HendelseMetadata
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logger
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentModel
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
 import java.util.*


### PR DESCRIPTION
…ers API

Bytter til det nye Altinn notifications API som støtter idempotens og enklere statushenting via en enkelt /future/shipment/{id} endpoint.

Endringer:
- POST /orders → POST /future/orders med ny request-struktur (idempotencyId, single recipient med nested settings)
- GET /orders/{id}/status og GET /orders/{id}/notifications/{sms,email} erstattes av GET /future/shipment/{id} med unified status enum
- Nye DTOs: ShipmentResponse, ShipmentStatus, RecipientDelivery
- OrderResponse returnerer nå både orderId og shipmentId
- Repository lagrer shipmentId i altinn_order_id for status-oppslag
- Bakoverkompatibel lesing av eksisterende ordre-responser i DB