### PR TITLE
Håndter alle råRespons-formater i EksterntVarselVellykket

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktModel.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktModel.kt
@@ -320,15 +320,7 @@ class DataproduktModel(
                            values (?, ?, ?, ?)
                            on conflict do nothing 
                         """,
-                    hendelse.råRespons.at("/notificationResult/0/endPoints/value/endPointResult").elements()
-                        .asSequence()
-                        .map {
-                            mapOf(
-                                "resultat_name" to it.at("/name/value").asText(),
-                                "resultat_receiver" to it.at("/receiverAddress/value").asText(),
-                                "resultat_type" to it.at("/transportType").asText(),
-                            )
-                        }.toList()
+                    hendelse.extractVarselResultater()
                 ) {
                     uuid(hendelse.varselId)
                     text(it["resultat_name"]!!)
@@ -697,6 +689,53 @@ class DataproduktModel(
                 }
             }
         }
+    }
+
+    private fun EksterntVarselVellykket.extractVarselResultater(): List<Map<String, String>> {
+        val råRespons = this.råRespons
+
+        // Altinn 2 SOAP response: { "notificationResult": [ { "endPoints": { "value": { "endPointResult": [...] } } } ] }
+        val altinn2Results = råRespons.at("/notificationResult/0/endPoints/value/endPointResult")
+        if (altinn2Results.isArray && altinn2Results.size() > 0) {
+            return altinn2Results.elements().asSequence().map {
+                mapOf(
+                    "resultat_name" to it.at("/name/value").asText(),
+                    "resultat_receiver" to it.at("/receiverAddress/value").asText(),
+                    "resultat_type" to it.at("/transportType").asText().uppercase(),
+                )
+            }.toList()
+        }
+
+        // Altinn 3 future response: { "recipients": [ { "destination": "...", "status": "...", "type": "..." } ] }
+        val altinn3Recipients = råRespons.at("/recipients")
+        if (altinn3Recipients.isArray && altinn3Recipients.size() > 0) {
+            return altinn3Recipients.elements().asSequence().map {
+                mapOf(
+                    "resultat_name" to it.at("/status").asText(),
+                    "resultat_receiver" to it.at("/destination").asText(),
+                    "resultat_type" to it.at("/type").asText().uppercase(),
+                )
+            }.toList()
+        }
+
+        // Altinn 3 legacy notifications response: [ { "notifications": [ { "recipient": {...}, "sendStatus": {...} } ] } ]
+        if (råRespons.isArray) {
+            return råRespons.elements().asSequence().flatMap { order ->
+                order.at("/notifications").elements().asSequence().map { notification ->
+                    val recipient = notification.at("/recipient")
+                    val receiverAddress = recipient.at("/emailAddress").asText("")
+                        .ifEmpty { recipient.at("/mobileNumber").asText("") }
+                    val transportType = if (recipient.has("emailAddress")) "EMAIL" else "SMS"
+                    mapOf(
+                        "resultat_name" to notification.at("/sendStatus/status").asText(),
+                        "resultat_receiver" to receiverAddress,
+                        "resultat_type" to transportType,
+                    )
+                }
+            }.toList()
+        }
+
+        return emptyList()
     }
 
     private fun ParameterSetters.setPåminnelseFelter(

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktEksterVarselVellykketTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/dataprodukt/DataproduktEksterVarselVellykketTest.kt
@@ -6,6 +6,7 @@ import no.nav.arbeidsgiver.notifikasjon.infrastruktur.json.laxObjectMapper
 import no.nav.arbeidsgiver.notifikasjon.util.EksempelHendelse
 import no.nav.arbeidsgiver.notifikasjon.util.uuid
 import no.nav.arbeidsgiver.notifikasjon.util.withTestDatabase
+import org.intellij.lang.annotations.Language
 import java.time.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -64,13 +65,126 @@ class DataproduktEksterVarselVellykketTest {
                     "resultat_type" to "EMAIL",
                 ),
                 mapOf(
-                    "resultat_name" to "JORDSMONN ULOGISK ",
+                    "resultat_name" to "JORDSMONN ULOGISK",
                     "resultat_receiver" to "12341234",
                     "resultat_type" to "SMS",
                 ),
                 mapOf(
-                    "resultat_name" to "TORN KONSEKVENT ",
+                    "resultat_name" to "TORN KONSEKVENT",
                     "resultat_receiver" to "KONSEKVENT.TORN2@foo.net",
+                    "resultat_type" to "EMAIL",
+                ),
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `Dataprodukt ekstern varsel vellykket med Altinn 3 legacy notifications respons`() = withTestDatabase(Dataprodukt.databaseConfig) { database ->
+        val subject = DataproduktModel(database)
+        subject.oppdaterModellEtterHendelse(
+            EksempelHendelse.BeskjedOpprettet.copy(
+                eksterneVarsler = listOf(
+                    altinntjenesteVarselKontaktinfo
+                )
+            ), meta
+        )
+        subject.oppdaterModellEtterHendelse(
+            EksempelHendelse.EksterntVarselVellykket.copy(
+                varselId = altinntjenesteVarselKontaktinfo.varselId,
+                råRespons = laxObjectMapper.readTree(altinn3LegacyRespons)
+            ), meta
+        )
+
+        val result = database.nonTransactionalExecuteQuery(
+            """
+                select * from ekstern_varsel_resultat where varsel_id = ?
+                """,
+            {
+                uuid(altinntjenesteVarselKontaktinfo.varselId)
+            }
+        ) {
+            mapOf(
+                "resultat_name" to this.getString("resultat_name"),
+                "resultat_receiver" to this.getString("resultat_receiver"),
+                "resultat_type" to this.getString("resultat_type"),
+            )
+        }
+
+        assertEquals(
+            listOf(
+                mapOf(
+                    "resultat_name" to "Delivered",
+                    "resultat_receiver" to "foo@foo.no",
+                    "resultat_type" to "EMAIL",
+                ),
+            ),
+            result
+        )
+    }
+
+    @Test
+    fun `Dataprodukt ekstern varsel vellykket med Altinn 3 recipients respons`() = withTestDatabase(Dataprodukt.databaseConfig) { database ->
+        val subject = DataproduktModel(database)
+        subject.oppdaterModellEtterHendelse(
+            EksempelHendelse.BeskjedOpprettet.copy(
+                eksterneVarsler = listOf(
+                    altinntjenesteVarselKontaktinfo
+                )
+            ), meta
+        )
+        subject.oppdaterModellEtterHendelse(
+            EksempelHendelse.EksterntVarselVellykket.copy(
+                varselId = altinntjenesteVarselKontaktinfo.varselId,
+                råRespons = laxObjectMapper.readTree(altinn3RecipientsRespons)
+            ), meta
+        )
+
+        val result = database.nonTransactionalExecuteQuery(
+            """
+                select * from ekstern_varsel_resultat where varsel_id = ?
+                """,
+            {
+                uuid(altinntjenesteVarselKontaktinfo.varselId)
+            }
+        ) {
+            mapOf(
+                "resultat_name" to this.getString("resultat_name"),
+                "resultat_receiver" to this.getString("resultat_receiver"),
+                "resultat_type" to this.getString("resultat_type"),
+            )
+        }
+
+        assertEquals(
+            listOf(
+                mapOf(
+                    "resultat_name" to "Email_Delivered",
+                    "resultat_receiver" to "bar@foo.no",
+                    "resultat_type" to "EMAIL",
+                ),
+                mapOf(
+                    "resultat_name" to "Email_Delivered",
+                    "resultat_receiver" to "foo@foo.kommune.no",
+                    "resultat_type" to "EMAIL",
+                ),
+                mapOf(
+                    "resultat_name" to "Email_Delivered",
+                    "resultat_receiver" to "foo@fpp.kommune.no",
+                    "resultat_type" to "EMAIL",
+                ),
+                mapOf(
+                    "resultat_name" to "Email_Delivered",
+                    "resultat_receiver" to "asdf@asdfasdf.kommune.no",
+                    "resultat_type" to "EMAIL",
+                ),
+                mapOf(
+                    "resultat_name" to "Email_Delivered",
+                    "resultat_receiver" to "asdfasdfasdf@asdf.kommune.no",
+                    "resultat_type" to "EMAIL",
+                ),
+                mapOf(
+                    "resultat_name" to "Email_Delivered",
+                    "resultat_receiver" to "postasdf@asdfasdf.kommune.no",
                     "resultat_type" to "EMAIL",
                 ),
             ),
@@ -79,7 +193,87 @@ class DataproduktEksterVarselVellykketTest {
     }
 }
 
+@Language("JSON")
+const val altinn3LegacyRespons = """
+[
+  {
+    "generated": 0,
+    "notifications": [],
+    "orderId": "998db3c9-0de8-437c-bf11-6b2dd9f21ef3",
+    "succeeded": 0
+  },
+  {
+    "generated": 1,
+    "notifications": [
+      {
+        "id": "1ffda27d-e760-4afc-a0ed-178119645300",
+        "recipient": {
+          "emailAddress": "foo@foo.no"
+        },
+        "sendStatus": {
+          "description": "The email was delivered to the recipient. No errors reported, making it likely it was received by the recipient.",
+          "lastUpdate": "2025-11-18T11:35:42.688347Z",
+          "status": "Delivered"
+        },
+        "succeeded": true
+      }
+    ],
+    "orderId": "998db3c9-0de8-437c-bf11-6b2dd9f21ef3",
+    "succeeded": 1
+  }
+]
+"""
+
+@Language("JSON")
+const val altinn3RecipientsRespons = """
+{
+  "lastUpdate": "2026-05-06T07:32:53.63865Z",
+  "recipients": [
+    {
+      "destination": "bar@foo.no",
+      "lastUpdate": "2026-05-06T07:32:25.615858Z",
+      "status": "Email_Delivered",
+      "type": "Email"
+    },
+    {
+      "destination": "foo@foo.kommune.no",
+      "lastUpdate": "2026-05-06T07:32:09.504019Z",
+      "status": "Email_Delivered",
+      "type": "Email"
+    },
+    {
+      "destination": "foo@fpp.kommune.no",
+      "lastUpdate": "2026-05-06T07:32:09.386348Z",
+      "status": "Email_Delivered",
+      "type": "Email"
+    },
+    {
+      "destination": "asdf@asdfasdf.kommune.no",
+      "lastUpdate": "2026-05-06T07:32:50.147282Z",
+      "status": "Email_Delivered",
+      "type": "Email"
+    },
+    {
+      "destination": "asdfasdfasdf@asdf.kommune.no",
+      "lastUpdate": "2026-05-06T07:32:53.216275Z",
+      "status": "Email_Delivered",
+      "type": "Email"
+    },
+    {
+      "destination": "postasdf@asdfasdf.kommune.no",
+      "lastUpdate": "2026-05-06T07:32:53.63865Z",
+      "status": "Email_Delivered",
+      "type": "Email"
+    }
+  ],
+  "shipmentId": "2abd417f-fe84-4c26-9958-7537dcdecc55",
+  "status": "Order_Completed",
+  "type": "Notification"
+}
+"""
+
 @Suppress("HttpUrlsUsage")
+@Language("JSON")
 const val vellykketRespons = """
 {
   "notificationResult": [
@@ -125,7 +319,7 @@ const val vellykketRespons = """
                 "nil": false,
                 "name": "{http://schemas.altinn.no/services/ServiceEngine/Notification/2015/06}Name",
                 "scope": "no.altinn.schemas.services.serviceengine.notification._2015._06.EndPointResult",
-                "value": "JORDSMONN ULOGISK ",
+                "value": "JORDSMONN ULOGISK",
                 "globalScope": false,
                 "declaredType": "java.lang.String",
                 "typeSubstituted": false
@@ -155,7 +349,7 @@ const val vellykketRespons = """
                 "nil": false,
                 "name": "{http://schemas.altinn.no/services/ServiceEngine/Notification/2015/06}Name",
                 "scope": "no.altinn.schemas.services.serviceengine.notification._2015._06.EndPointResult",
-                "value": "TORN KONSEKVENT ",
+                "value": "TORN KONSEKVENT",
                 "globalScope": false,
                 "declaredType": "java.lang.String",
                 "typeSubstituted": false
@@ -190,7 +384,7 @@ const val vellykketRespons = """
         "nil": false,
         "name": "{http://schemas.altinn.no/services/ServiceEngine/Notification/2015/06}ReporteeNumber",
         "scope": "no.altinn.schemas.services.serviceengine.notification._2015._06.NotificationResult",
-        "value": "810825472",
+        "value": "987654321",
         "globalScope": false,
         "declaredType": "java.lang.String",
         "typeSubstituted": false


### PR DESCRIPTION
Extracter extractVarselResultater() som håndterer tre ulike råRespons-formater:
- Altinn 2 SOAP (notificationResult/endPointResult)
- Altinn 3 legacy (notifications array)
- Altinn 3 ny (recipients array) resultat_type uppercases for konsistent aggregering.
Co-authored-by: GitHub Copilot <noreply@github.com>