### PR TITLE
legg til mottaker i ekstern_varsel_view

### DIFF
--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -628,8 +628,8 @@ SELECT
  frist, paaminnelse_bestilling_spesifikasjon_type,
  paaminnelse_bestilling_spesifikasjon_tid, paaminnelse_bestilling_utregnet_tid,
  epost_pseud, tlf_pseud, tjenestekode, tjenesteversjon, resultat_name_pseud,
- resultat_receiver_pseud, resultat_type, mottaker
- FROM `notifikasjon_platform_dataset.ekstern_varsel`
+ resultat_receiver_pseud, resultat_type, ev.mottaker
+ FROM `notifikasjon_platform_dataset.ekstern_varsel` ev
   join `notifikasjon_platform_dataset.notifikasjon` n using (notifikasjon_id)
   left join `notifikasjon_platform_dataset.ekstern_varsel_mottaker_epost` using (varsel_id)
   left join `notifikasjon_platform_dataset.ekstern_varsel_mottaker_tjeneste` using (varsel_id)

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -431,7 +431,7 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel" {
   data_source_id         = "scheduled_query"
   display_name           = "ekstern_varsel"
   location               = var.region
-  schedule               = "every 60 mins"
+  schedule               = "every 5 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.ekstern_varsel.table_id
@@ -628,8 +628,8 @@ SELECT
  frist, paaminnelse_bestilling_spesifikasjon_type,
  paaminnelse_bestilling_spesifikasjon_tid, paaminnelse_bestilling_utregnet_tid,
  epost_pseud, tlf_pseud, tjenestekode, tjenesteversjon, resultat_name_pseud,
- resultat_receiver_pseud, resultat_type, ev.mottaker
- FROM `notifikasjon_platform_dataset.ekstern_varsel` ev
+ resultat_receiver_pseud, resultat_type
+ FROM `notifikasjon_platform_dataset.ekstern_varsel`
   join `notifikasjon_platform_dataset.notifikasjon` n using (notifikasjon_id)
   left join `notifikasjon_platform_dataset.ekstern_varsel_mottaker_epost` using (varsel_id)
   left join `notifikasjon_platform_dataset.ekstern_varsel_mottaker_tjeneste` using (varsel_id)

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -444,7 +444,7 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel" {
         produsent_id,
         merkelapp,
         sendevindu,
-        case sendetidspunkt
+        case
             when sendetidspunkt = "-999999999-01-01T00:00" then DATETIME("1970-01-01 00:00:00")
             when LENGTH(sendetidspunkt) = 16 then PARSE_DATETIME("%FT%R", sendetidspunkt)
             else PARSE_DATETIME("%FT%R:%E*S", sendetidspunkt)

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -431,7 +431,7 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel" {
   data_source_id         = "scheduled_query"
   display_name           = "ekstern_varsel"
   location               = var.region
-  schedule               = "every 5 mins"
+  schedule               = "every 60 mins"
   destination_dataset_id = google_bigquery_dataset.this.dataset_id
   params = {
     destination_table_name_template = google_bigquery_table.ekstern_varsel.table_id
@@ -629,7 +629,7 @@ SELECT
  frist, paaminnelse_bestilling_spesifikasjon_type,
  paaminnelse_bestilling_spesifikasjon_tid, paaminnelse_bestilling_utregnet_tid,
  epost_pseud, tlf_pseud, tjenestekode, tjenesteversjon, resultat_name_pseud,
- resultat_receiver_pseud, resultat_type
+ resultat_receiver_pseud, resultat_type, mottaker
  FROM `notifikasjon_platform_dataset.ekstern_varsel`
   join `notifikasjon_platform_dataset.notifikasjon` n using (notifikasjon_id)
   left join `notifikasjon_platform_dataset.ekstern_varsel_mottaker_epost` using (varsel_id)

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -445,7 +445,8 @@ resource "google_bigquery_data_transfer_config" "ekstern_varsel" {
         merkelapp,
         sendevindu,
         case sendetidspunkt
-            when "-999999999-01-01T00:00" then DATETIME("1970-01-01 00:00:00")
+            when sendetidspunkt = "-999999999-01-01T00:00" then DATETIME("1970-01-01 00:00:00")
+            when LENGTH(sendetidspunkt) = 16 then PARSE_DATETIME("%FT%R", sendetidspunkt)
             else PARSE_DATETIME("%FT%R:%E*S", sendetidspunkt)
             end
             as sendetidspunkt,

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -628,7 +628,7 @@ SELECT
  frist, paaminnelse_bestilling_spesifikasjon_type,
  paaminnelse_bestilling_spesifikasjon_tid, paaminnelse_bestilling_utregnet_tid,
  epost_pseud, tlf_pseud, tjenestekode, tjenesteversjon, resultat_name_pseud,
- resultat_receiver_pseud, resultat_type
+ resultat_receiver_pseud, resultat_type, mottaker
  FROM `notifikasjon_platform_dataset.ekstern_varsel`
   join `notifikasjon_platform_dataset.notifikasjon` n using (notifikasjon_id)
   left join `notifikasjon_platform_dataset.ekstern_varsel_mottaker_epost` using (varsel_id)


### PR DESCRIPTION
en gammel feil i dev gjorde at mottaker feltet i bq tabellen ikke ble lagt til og dermed feilet det når vi la det til i viewet.

Måtte justere litt i eksporten og kjøre på nytt for å få den opp igjen 