### PR TITLE
Tillatt at notifikasjoner med ressurs lages på saker med tilsvarende servicecode

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Util.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Util.kt
@@ -1,6 +1,8 @@
 package no.nav.arbeidsgiver.notifikasjon.produsent.api
 
+import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel.Mottaker
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.basedOnEnv
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.Merkelapp
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.Produsent
@@ -127,7 +129,7 @@ internal inline fun tilgangsstyrProdusent(
     context: ProdusentAPI.Context,
     merkelapp: String,
     onError: (error: Error.TilgangsstyringError) -> Nothing
-): Produsent  {
+): Produsent {
     val produsent = hentProdusent(context) { error -> onError(error) }
     tilgangsstyrMerkelapp(produsent, merkelapp) { error -> onError(error) }
     return produsent
@@ -139,8 +141,8 @@ private inline fun validerMottakerMotSak(
     mottakerInput: MottakerInput,
     onError: (Error.UgyldigMottaker) -> Nothing
 ) {
-    var mottaker = mottakerInput.tilHendelseModel(virksomhetsnummer)
-    if (mottaker !in sak.mottakere) {
+    val mottaker = mottakerInput.tilHendelseModel(virksomhetsnummer)
+    if (mottaker !in sak.mottakere.berikMedFallback()) {
         onError(
             Error.UgyldigMottaker(
                 """
@@ -169,3 +171,52 @@ fun String.ensurePrefix(prefix: String) =
 
 fun String.ensureSuffix(suffix: String) =
     removeSuffix(suffix) + suffix
+
+
+
+private val serviceCodeEditionTilRessursMap = mapOf(
+    "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger" to ("5810" to "1"),
+    "nav_sosialtjenester_digisos-avtale" to ("5867" to "1"),
+    "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk" to ("3403" to basedOnEnv(
+        prod = { "2" },
+        other = { "1" })),
+    "nav_tiltak_arbeidstrening" to ("5332" to basedOnEnv(prod = { "2" }, other = { "1" })),
+    "nav_utbetaling_endre-kontonummer-refusjon-arbeidsgiver" to ("2896" to "87"),
+    "nav_tiltak_midlertidig-lonnstilskudd" to ("5516" to "1"),
+    "nav_tiltak_varig-lonnstilskudd" to ("5516" to "2"),
+    "nav_tiltak_sommerjobb" to ("5516" to "3"),
+    "nav_tiltak_mentor" to ("5516" to "4"),
+    "nav_tiltak_inkluderingstilskudd" to ("5516" to "5"),
+    "nav_tiltak_varig-tilrettelagt-arbeid-ordinaer" to ("5516" to "6"),
+    "nav_tiltak_adressesperre" to ("5516" to "7"),
+    "nav_tiltak_tilskuddsbrev" to ("5278" to "1"),
+    "nav_tiltak_ekspertbistand" to ("5384" to "1"),
+    "nav_foreldrepenger_inntektsmelding" to ("4936" to "1"),
+    "nav_sykepenger_inntektsmelding" to ("4936" to "1"),
+    "nav_sykepenger_fritak-arbeidsgiverperiode" to ("4936" to "1"),
+    "nav_sykdom-i-familien_inntektsmelding" to ("4936" to "1"),
+    "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver" to ("5441" to "1"),
+    "nav_arbeidsforhold_aa-registeret-brukerstotte" to ("5441" to "2"),
+    "nav_arbeidsforhold_aa-registeret-sok-tilgang" to ("5719" to "1"),
+    "nav_arbeidsforhold_aa-registeret-oppslag-samarbeidspartnere" to ("5723" to "1"),
+    "nav_rekruttering_kandidater" to ("5078" to "1"),
+    "nav_yrkesskade_skademelding" to ("5902" to "1"),
+).entries.groupBy({ it.value }, { it.key })
+
+/**
+ * midlertidig workaround at produsenter oppretter notifikasjoner på altinn ressurs mens sak er opprettet på altinn 2 tjeneste
+ * Nødvendig så lenge det finnes aktive saker på altinn 2 tjenester
+ */
+private fun List<Mottaker>.berikMedFallback() = flatMap {
+    when (it) {
+        is HendelseModel.AltinnMottaker ->
+            listOf(it) + (serviceCodeEditionTilRessursMap[it.serviceCode to it.serviceEdition]?.map { ressursId ->
+                HendelseModel.AltinnRessursMottaker(
+                    virksomhetsnummer = it.virksomhetsnummer,
+                    ressursId = ressursId,
+                )
+            } ?: listOf())
+
+        else -> listOf(it)
+    }
+}

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Common.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Common.kt
@@ -31,9 +31,13 @@ val stubProdusentRegister: ProdusentRegister = object : ProdusentRegister {
             tillatteMerkelapper = listOf("tag", "tag2"),
             tillatteMottakere = listOf(
                 ServicecodeDefinisjon(code = "5441", version = "1"),
+                ServicecodeDefinisjon(code = "4936", version = "1"),
                 ServicecodeDefinisjon(code = "1", version = "1"),
                 RessursIdDefinisjon(ressursId = "test-fager"),
                 RessursIdDefinisjon(ressursId = "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver"),
+                RessursIdDefinisjon(ressursId = "nav_foreldrepenger_inntektsmelding"),
+                RessursIdDefinisjon(ressursId = "nav_sykepenger_inntektsmelding"),
+                RessursIdDefinisjon(ressursId = "nav_sykdom-i-familien_inntektsmelding"),
                 NærmesteLederDefinisjon,
             )
         )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Common.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/Common.kt
@@ -5,8 +5,8 @@ import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.graphql.GraphQLRequest
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.produsenter.*
 import no.nav.arbeidsgiver.notifikasjon.produsent.ProdusentRepository
-import no.nav.arbeidsgiver.notifikasjon.util.fakeProdusentApiOboToken
 import no.nav.arbeidsgiver.notifikasjon.util.PRODUSENT_HOST
+import no.nav.arbeidsgiver.notifikasjon.util.fakeProdusentApiOboToken
 import no.nav.arbeidsgiver.notifikasjon.util.post
 import org.intellij.lang.annotations.Language
 import java.time.Instant
@@ -33,6 +33,7 @@ val stubProdusentRegister: ProdusentRegister = object : ProdusentRegister {
                 ServicecodeDefinisjon(code = "5441", version = "1"),
                 ServicecodeDefinisjon(code = "1", version = "1"),
                 RessursIdDefinisjon(ressursId = "test-fager"),
+                RessursIdDefinisjon(ressursId = "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver"),
                 NærmesteLederDefinisjon,
             )
         )

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedTest.kt
@@ -232,6 +232,78 @@ class NyBeskjedTest {
             nyBeskjed as MutationNyBeskjed.NyBeskjedVellykket
         }
     }
+
+    @Test
+    fun `Flere ressurs-mottakere mappet til samme servicecode er gyldige mot sak`() = withTestDatabase(Produsent.databaseConfig) { database ->
+        val produsentRepository = ProdusentRepositoryImpl(database)
+        ktorProdusentTestServer(
+            kafkaProducer = FakeHendelseProdusent(),
+            produsentRepository = produsentRepository,
+        ) {
+            // Sak opprettet med AltinnMottaker serviceCode 4936/1 (inntektsmelding)
+            HendelseModel.SakOpprettet(
+                virksomhetsnummer = "42",
+                merkelapp = "tag",
+                grupperingsid = "g42",
+                mottakere = listOf(
+                    HendelseModel.AltinnMottaker(
+                        serviceCode = "4936",
+                        serviceEdition = "1",
+                        virksomhetsnummer = "42"
+                    )
+                ),
+                hendelseId = uuid("11"),
+                sakId = uuid("11"),
+                tittel = "test",
+                lenke = "https://nav.no",
+                oppgittTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z"),
+                mottattTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z"),
+                kildeAppNavn = "",
+                produsentId = "",
+                nesteSteg = null,
+                hardDelete = null,
+                tilleggsinformasjon = null
+            ).also {
+                produsentRepository.oppdaterModellEtterHendelse(it)
+            }
+
+            // nav_foreldrepenger_inntektsmelding er mappet til 4936/1 — skal være gyldig
+            val beskjed1 = client.opprettBeskjedMedMottaker(
+                grupperingsId = "g42",
+                virksomhetsnummer = "42",
+                eksternId = "1",
+                mottaker =
+                    """altinnRessurs: {
+                        ressursId: "nav_foreldrepenger_inntektsmelding"
+                    }"""
+            )
+            beskjed1 as MutationNyBeskjed.NyBeskjedVellykket
+
+            // nav_sykepenger_inntektsmelding er også mappet til 4936/1 — skal være gyldig
+            val beskjed2 = client.opprettBeskjedMedMottaker(
+                grupperingsId = "g42",
+                virksomhetsnummer = "42",
+                eksternId = "2",
+                mottaker =
+                    """altinnRessurs: {
+                        ressursId: "nav_sykepenger_inntektsmelding"
+                    }"""
+            )
+            beskjed2 as MutationNyBeskjed.NyBeskjedVellykket
+
+            // nav_sykdom-i-familien_inntektsmelding er også mappet til 4936/1 — skal være gyldig
+            val beskjed3 = client.opprettBeskjedMedMottaker(
+                grupperingsId = "g42",
+                virksomhetsnummer = "42",
+                eksternId = "3",
+                mottaker =
+                    """altinnRessurs: {
+                        ressursId: "nav_sykdom-i-familien_inntektsmelding"
+                    }"""
+            )
+            beskjed3 as MutationNyBeskjed.NyBeskjedVellykket
+        }
+    }
 }
 
 

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/NyBeskjedTest.kt
@@ -184,6 +184,54 @@ class NyBeskjedTest {
             nyBeskjed3 as MutationNyBeskjed.NyBeskjedVellykket
         }
     }
+
+    @Test
+    fun `Validering av ressurs-mottaker mot sak med fallback-mappet servicecode`() = withTestDatabase(Produsent.databaseConfig) { database ->
+        val produsentRepository = ProdusentRepositoryImpl(database)
+        ktorProdusentTestServer(
+            kafkaProducer = FakeHendelseProdusent(),
+            produsentRepository = produsentRepository,
+        ) {
+            // Sak opprettet med AltinnMottaker (serviceCode/edition)
+            HendelseModel.SakOpprettet(
+                virksomhetsnummer = "42",
+                merkelapp = "tag",
+                grupperingsid = "g42",
+                mottakere = listOf(
+                    HendelseModel.AltinnMottaker(
+                        serviceCode = "5441",
+                        serviceEdition = "1",
+                        virksomhetsnummer = "42"
+                    )
+                ),
+                hendelseId = uuid("11"),
+                sakId = uuid("11"),
+                tittel = "test",
+                lenke = "https://nav.no",
+                oppgittTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z"),
+                mottattTidspunkt = OffsetDateTime.parse("2020-01-01T01:01Z"),
+                kildeAppNavn = "",
+                produsentId = "",
+                nesteSteg = null,
+                hardDelete = null,
+                tilleggsinformasjon = null
+            ).also {
+                produsentRepository.oppdaterModellEtterHendelse(it)
+            }
+
+            // Beskjed med ressurs-mottaker som er fallback-mappet til sakens serviceCode/edition — skal være gyldig
+            val nyBeskjed = client.opprettBeskjedMedMottaker(
+                grupperingsId = "g42",
+                virksomhetsnummer = "42",
+                eksternId = "1",
+                mottaker =
+                    """altinnRessurs: {
+                        ressursId: "nav_arbeidsforhold_aa-registeret-innsyn-arbeidsgiver"
+                    }"""
+            )
+            nyBeskjed as MutationNyBeskjed.NyBeskjedVellykket
+        }
+    }
 }
 
 


### PR DESCRIPTION
I overgangsfasen når produsenter tar i bruk AltinnRessursMottaker (Altinn 3 ressurs), vil det forekomme tilfeller hvor saken det gjelder er opprettet på AltinnMottaker (Altinn 2 tjeneste).
Siden vi validerer mottaker på notifikasjon mot mottaker på sak, må vi ta høyde for dette i valideringen.

Denne PRen legger til en mapping tilsvarende det vi gjør i `arbeidsgiver-altinn-tilganger` [ResourceRegistry::KnownResources](https://github.com/navikt/arbeidsgiver-altinn-tilganger/blob/main/src/main/kotlin/no/nav/fager/altinn/ResourceRegistry.kt#L23-L185)

Når vi sjekker mottaker på notifikasjon opp mot mottaker på sak så tar vi også høyde for at saken var opprettet på gammel mottaker type med den migrerte ressursen sin tjenestekode/versjon
