### PR TITLE
fix: hopp over duplikat notifikasjon ved koordinat-konflikt i produse…

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/ProdusentRepository.kt
@@ -600,7 +600,7 @@ class ProdusentRepositoryImpl(
 
     private suspend fun oppdaterModellEtterBeskjedOpprettet(beskjedOpprettet: BeskjedOpprettet) {
         database.transaction {
-            executeUpdate(
+            val inserted = executeUpdate(
                 """
                 insert into notifikasjon(
                     type,
@@ -626,6 +626,19 @@ class ProdusentRepositoryImpl(
                 text(beskjedOpprettet.eksternId)
                 timestamp_with_timezone(beskjedOpprettet.opprettetTidspunkt)
                 text(beskjedOpprettet.virksomhetsnummer)
+            }
+
+            // on conflict do nothing kan trigges av unikt_koordinat (merkelapp, ekstern_id) med en
+            // annen notifikasjonId — da er notifikasjonId ikke i tabellen og FK på mottaker-tabeller
+            // vil feile. Hopp over mottakere og varsler hvis ingen rad ble insertet.
+            if (inserted == 0) {
+                log.error(
+                    "BeskjedOpprettet: notifikasjon ikke insertet (duplikat koordinat eller id), hopper over mottakere og varsler. notifikasjonId={} merkelapp={} eksternId={}",
+                    beskjedOpprettet.notifikasjonId,
+                    beskjedOpprettet.merkelapp,
+                    beskjedOpprettet.eksternId,
+                )
+                return@transaction
             }
 
             for (mottaker in beskjedOpprettet.mottakere) {
@@ -655,7 +668,7 @@ class ProdusentRepositoryImpl(
 
     private suspend fun oppdaterModellEtterOppgaveOpprettet(oppgaveOpprettet: OppgaveOpprettet) {
         database.transaction {
-            executeUpdate(
+            val inserted = executeUpdate(
                 """
                 insert into notifikasjon(
                     type,
@@ -683,6 +696,19 @@ class ProdusentRepositoryImpl(
                 timestamp_with_timezone(oppgaveOpprettet.opprettetTidspunkt)
                 text(oppgaveOpprettet.virksomhetsnummer)
                 nullableDate(oppgaveOpprettet.frist)
+            }
+
+            // on conflict do nothing kan trigges av unikt_koordinat (merkelapp, ekstern_id) med en
+            // annen notifikasjonId — da er notifikasjonId ikke i tabellen og FK på mottaker-tabeller
+            // vil feile. Hopp over mottakere og varsler hvis ingen rad ble insertet.
+            if (inserted == 0) {
+                log.error(
+                    "OppgaveOpprettet: notifikasjon ikke insertet (duplikat koordinat eller id), hopper over mottakere og varsler. notifikasjonId={} merkelapp={} eksternId={}",
+                    oppgaveOpprettet.notifikasjonId,
+                    oppgaveOpprettet.merkelapp,
+                    oppgaveOpprettet.eksternId,
+                )
+                return@transaction
             }
 
             for (mottaker in oppgaveOpprettet.mottakere) {
@@ -884,7 +910,7 @@ class ProdusentRepositoryImpl(
 
     private suspend fun oppdaterModellEtterKalenderavtaleOpprettet(hendelse: KalenderavtaleOpprettet) {
         database.transaction {
-            executeUpdate(
+            val inserted = executeUpdate(
                 """
                 insert into notifikasjon(
                     type,
@@ -922,6 +948,19 @@ class ProdusentRepositoryImpl(
                     nullableJsonb(lokasjon)
                     boolean(erDigitalt)
                 }
+            }
+
+            // on conflict do nothing kan trigges av unikt_koordinat (merkelapp, ekstern_id) med en
+            // annen notifikasjonId — da er notifikasjonId ikke i tabellen og FK på mottaker-tabeller
+            // vil feile. Hopp over mottakere og varsler hvis ingen rad ble insertet.
+            if (inserted == 0) {
+                log.error(
+                    "KalenderavtaleOpprettet: notifikasjon ikke insertet (duplikat koordinat eller id), hopper over mottakere og varsler. notifikasjonId={} merkelapp={} eksternId={}",
+                    hendelse.notifikasjonId,
+                    hendelse.merkelapp,
+                    hendelse.eksternId,
+                )
+                return@transaction
             }
 
             for (mottaker in hendelse.mottakere) {

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/produsent/api/ProdusentModelIdempotensTest.kt
@@ -20,6 +20,37 @@ import kotlin.test.assertNull
 
 class ProdusentModelIdempotensTest {
 
+    /**
+     * Dette skjer når idempotens-sjekken ikke fungerer pga heng mot kafka —
+     * duplikat-hendelse med ny notifikasjonId men samme (merkelapp, eksternId).
+     */
+    @Test
+    fun `NyBeskjed to ganger ulik id`() = withTestDatabase(Produsent.databaseConfig) { database ->
+        val produsentModel = ProdusentRepositoryImpl(database)
+        val duplikatId = UUID.randomUUID()
+
+        produsentModel.oppdaterModellEtterHendelse(EksempelHendelse.BeskjedOpprettet)
+        produsentModel.oppdaterModellEtterHendelse(
+            EksempelHendelse.BeskjedOpprettet.copy(notifikasjonId = duplikatId, hendelseId = duplikatId)
+        )
+
+        // original mottaker skal finnes
+        assertEquals(
+            1,
+            database.nonTransactionalExecuteQuery(
+                "select * from mottaker_altinn_enkeltrettighet where notifikasjon_id = '${EksempelHendelse.BeskjedOpprettet.notifikasjonId}'"
+            ) {}.size
+        )
+
+        // duplikat-ID skal ikke ha fått noen mottaker
+        assertEquals(
+            0,
+            database.nonTransactionalExecuteQuery(
+                "select * from mottaker_altinn_enkeltrettighet where notifikasjon_id = '$duplikatId'"
+            ) {}.size
+        )
+    }
+
     @Test
     fun `alle hendelser to ganger`() = withTestDatabase(Produsent.databaseConfig) { database ->
         val produsentModel = ProdusentRepositoryImpl(database)


### PR DESCRIPTION
…nt-modellen

Kafka at-least-once delivery kan gi duplikate hendelser med ny notifikasjonId men samme (merkelapp, eksternId)-koordinat. INSERT INTO notifikasjon returnerte da 0 rader (ON CONFLICT DO NOTHING), og påfølgende INSERT på mottaker-tabeller feilet med FK-violation fordi den nye IDen ikke lå i notifikasjon-tabellen.

Fiksen fanger returverdien fra notifikasjon-inserten og returnerer tidlig fra transaksjonen dersom ingen rad ble insertet. Logger error med notifikasjonId, merkelapp og eksternId slik at duplikater kan oppdages og spores.

Gjøres identisk i oppdaterModellEtterBeskjedOpprettet, oppdaterModellEtterOppgaveOpprettet og
oppdaterModellEtterKalenderavtaleOpprettet.