### PR TITLE
🛠️fix(kafka): håndter commit-feil som membership-problem, ikke data-feil

### DIFF
--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/Config.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/Config.kt
@@ -10,6 +10,7 @@ import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.Serializer
 import org.apache.kafka.common.serialization.StringSerializer
 import java.lang.System.getenv
+import java.time.Duration
 import org.apache.kafka.clients.CommonClientConfigs as CommonProp
 import org.apache.kafka.clients.consumer.ConsumerConfig as ConsumerProp
 import org.apache.kafka.clients.producer.ProducerConfig as ProducerProp
@@ -74,6 +75,21 @@ val PRODUCER_PROPERTIES = COMMON_PROPERTIES + SSL_PROPERTIES + mapOf(
 )
 
 const val MAX_POLL_INTERVAL_MS = 300_000
+
+/**
+ * Eksplisitt timeout for commitSync, slik at en treg/hengende commit ikke sulter poll-loopen
+ * forbi max.poll.interval.ms (som ville selv-evicte medlemmet). Vi committer per record, opp til
+ * max.poll.records (10) per batch, så 10 × COMMIT_TIMEOUT må ligge godt under MAX_POLL_INTERVAL_MS.
+ */
+val COMMIT_TIMEOUT: Duration = Duration.ofSeconds(10)
+
+/**
+ * Antall påfølgende commit-feil før vi flagger KAFKA-subsystemet som unhealthy og lar pod-en restarte.
+ * Damper benigne rebalances (deploy/scale) som revokerer en partisjon akkurat idet vi committer den:
+ * en engangsfeil re-poller og rejoiner, mens vedvarende feil gir en ren restart.
+ */
+const val COMMIT_FAILURE_THRESHOLD = 3
+
 val CONSUMER_PROPERTIES = COMMON_PROPERTIES + SSL_PROPERTIES + mapOf(
     ConsumerProp.AUTO_OFFSET_RESET_CONFIG to "earliest",
     ConsumerProp.MAX_POLL_RECORDS_CONFIG to 10,

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -42,6 +42,7 @@ private constructor(
     private val onPartitionAssigned: ((partition: TopicPartition, maxOffset: Long) -> Unit)?,
     private val onPartitionRevoked: ((partition: TopicPartition) -> Unit)?,
     private val configOverrides: Map<String, Any> = emptyMap(),
+    consumerOverride: Consumer<K, V>? = null,
 ) {
     private val pollBodyTimer = Timer.builder("kafka.poll.body")
         .register(Metrics.meterRegistry)
@@ -52,6 +53,11 @@ private constructor(
     private val iterationExitCounter = Counter.builder("kafka.poll.body.iteration")
         .tag("point", "exit")
         .register(Metrics.meterRegistry)
+
+    private val commitFailureCounter = Counter.builder("kafka.commit.failures")
+        .register(Metrics.meterRegistry)
+
+    private val commitFailures = AtomicInteger(0)
 
     private val kafkaContext = Executors.newFixedThreadPool(1).asCoroutineDispatcher()
 
@@ -77,9 +83,27 @@ private constructor(
             onPartitionRevoked,
             configOverrides
         )
+
+        /**
+         * Test-seam: bygg en konsument rundt en injisert [Consumer] (typisk en MockConsumer),
+         * slik at commit-/rebalance-stiene kan testes uten en ekte Kafka-broker.
+         */
+        internal fun <K, V> forTest(
+            consumer: Consumer<K, V>,
+            topic: String = "test.topic",
+            groupId: String = "test-group",
+        ): CoroutineKafkaConsumer<K, V> = CoroutineKafkaConsumer(
+            topic = topic,
+            groupId = groupId,
+            keyDeserializer = org.apache.kafka.common.serialization.StringDeserializer::class.java,
+            valueDeserializer = org.apache.kafka.common.serialization.StringDeserializer::class.java,
+            onPartitionAssigned = null,
+            onPartitionRevoked = null,
+            consumerOverride = consumer,
+        )
     }
 
-    private val consumer: Consumer<K, V> = KafkaConsumer(
+    private val consumer: Consumer<K, V> = consumerOverride ?: KafkaConsumer(
         CONSUMER_PROPERTIES + mapOf<String, String>(
             KEY_DESERIALIZER_CLASS_CONFIG to keyDeserializer.canonicalName,
             VALUE_DESERIALIZER_CLASS_CONFIG to valueDeserializer.canonicalName,
@@ -88,7 +112,9 @@ private constructor(
     )
 
     init {
-        KafkaClientMetrics(consumer).bindTo(Metrics.meterRegistry)
+        if (consumerOverride == null) {
+            KafkaClientMetrics(consumer).bindTo(Metrics.meterRegistry)
+        }
         consumer.subscribe(listOf(topic))
         if (seekToBeginning) {
             seekToBeginningOnAssignment()
@@ -120,7 +146,7 @@ private constructor(
             try {
                 while (isActive && !stop.get() && !Health.terminating) {
                     replayer.replayWhenLeap()
-                    consumer.resume(resumeQueue.pollAll())
+                    consumer.resume(resumeQueue.pollAll().filter { it in consumer.assignment() })
 
                     val records = try {
                         consumer.poll(Duration.ofMillis(1000))
@@ -168,12 +194,8 @@ private constructor(
                     withContext(Dispatchers.IO) {
                         body(record)
                     }
-                    consumer.commitSync(mapOf(partition to OffsetAndMetadata(record.offset() + 1)))
-                    iterationExitCounter.increment()
-                    if (!seekToBeginning) log.info("successfully processed {}", record.loggableToString())
-                    retries.set(0)
-                    return@currentRecord
                 } catch (e: Exception) {
+                    // data plane: poison-pill -> seek + pause + capped backoff + retry forever
                     val attempt = retries.incrementAndGet()
                     val backoffMillis = capWithinMaxPollInterval(1000L * 2.toThePowerOf(attempt))
                     // log error if attempt is > 3 else just warn
@@ -190,10 +212,35 @@ private constructor(
                         e
                     )
                     val currentPartition = TopicPartition(record.topic(), record.partition())
-                    consumer.seek(currentPartition, record.offset())
-                    consumer.pause(listOf(currentPartition))
-                    retryTimer.schedule(backoffMillis) {
-                        resumeQueue.offer(currentPartition)
+                    if (currentPartition in consumer.assignment()) {
+                        consumer.seek(currentPartition, record.offset())
+                        consumer.pause(listOf(currentPartition))
+                        retryTimer.schedule(backoffMillis) {
+                            resumeQueue.offer(currentPartition)
+                        }
+                    }
+                    return@currentPartition
+                }
+
+                try {
+                    consumer.commitSync(
+                        mapOf(partition to OffsetAndMetadata(record.offset() + 1)),
+                        COMMIT_TIMEOUT
+                    )
+                    commitFailures.set(0)
+                    iterationExitCounter.increment()
+                    if (!seekToBeginning) log.info("successfully processed {}", record.loggableToString())
+                    retries.set(0)
+                    return@currentRecord
+                } catch (e: Exception) {
+                    // control plane: commit/membership problem, not a data error.
+                    val failures = commitFailures.incrementAndGet()
+                    commitFailureCounter.increment()
+                    log.error("commit failed (attempt {})", failures, e)
+                    if (failures >= COMMIT_FAILURE_THRESHOLD) {
+                        // -> while(!Health.terminating) exits -> consumer closes -> pod restarts (clean rejoin).
+                        // in-flight record is reprocessed after restart (at-least-once, handlers are idempotent).
+                        Health.subsystemAlive[Subsystem.KAFKA] = false
                     }
                     return@currentPartition
                 }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -10,11 +10,8 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
 import no.nav.arbeidsgiver.notifikasjon.hendelse.HendelseModel
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Metrics
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.*
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.logging.logger
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.toThePowerOf
 import org.apache.kafka.clients.consumer.*
 import org.apache.kafka.clients.consumer.ConsumerConfig.*
 import org.apache.kafka.common.TopicPartition
@@ -72,6 +69,7 @@ private constructor(
             onPartitionAssigned: ((partition: TopicPartition, endOffset: Long) -> Unit)? = null,
             onPartitionRevoked: ((partition: TopicPartition) -> Unit)? = null,
             configOverrides: Map<String, Any> = emptyMap(),
+            consumerOverride: Consumer<K, V>? = null,
         ): CoroutineKafkaConsumer<K, V> = CoroutineKafkaConsumer(
             topic,
             groupId,
@@ -81,25 +79,8 @@ private constructor(
             replayPeriodically,
             onPartitionAssigned,
             onPartitionRevoked,
-            configOverrides
-        )
-
-        /**
-         * Test-seam: bygg en konsument rundt en injisert [Consumer] (typisk en MockConsumer),
-         * slik at commit-/rebalance-stiene kan testes uten en ekte Kafka-broker.
-         */
-        internal fun <K, V> forTest(
-            consumer: Consumer<K, V>,
-            topic: String = "test.topic",
-            groupId: String = "test-group",
-        ): CoroutineKafkaConsumer<K, V> = CoroutineKafkaConsumer(
-            topic = topic,
-            groupId = groupId,
-            keyDeserializer = org.apache.kafka.common.serialization.StringDeserializer::class.java,
-            valueDeserializer = org.apache.kafka.common.serialization.StringDeserializer::class.java,
-            onPartitionAssigned = null,
-            onPartitionRevoked = null,
-            consumerOverride = consumer,
+            configOverrides,
+            consumerOverride
         )
     }
 
@@ -112,6 +93,9 @@ private constructor(
     )
 
     init {
+        if (consumerOverride != null && NaisEnvironment.clusterName != "") {
+            throw IllegalArgumentException("Consumer override only available on local machine")
+        }
         if (consumerOverride == null) {
             KafkaClientMetrics(consumer).bindTo(Metrics.meterRegistry)
         }

--- a/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
+++ b/app/src/main/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumer.kt
@@ -39,6 +39,7 @@ private constructor(
     private val onPartitionAssigned: ((partition: TopicPartition, maxOffset: Long) -> Unit)?,
     private val onPartitionRevoked: ((partition: TopicPartition) -> Unit)?,
     private val configOverrides: Map<String, Any> = emptyMap(),
+    val onKafkaUnhealthy: (() -> Unit),
     consumerOverride: Consumer<K, V>? = null,
 ) {
     private val pollBodyTimer = Timer.builder("kafka.poll.body")
@@ -69,6 +70,9 @@ private constructor(
             onPartitionAssigned: ((partition: TopicPartition, endOffset: Long) -> Unit)? = null,
             onPartitionRevoked: ((partition: TopicPartition) -> Unit)? = null,
             configOverrides: Map<String, Any> = emptyMap(),
+            onKafkaUnhealthy: (() -> Unit) = {
+                Health.subsystemAlive[Subsystem.KAFKA]  = false
+            },
             consumerOverride: Consumer<K, V>? = null,
         ): CoroutineKafkaConsumer<K, V> = CoroutineKafkaConsumer(
             topic,
@@ -80,7 +84,8 @@ private constructor(
             onPartitionAssigned,
             onPartitionRevoked,
             configOverrides,
-            consumerOverride
+            onKafkaUnhealthy,
+            consumerOverride,
         )
     }
 
@@ -136,7 +141,7 @@ private constructor(
                         consumer.poll(Duration.ofMillis(1000))
                     } catch (e: Exception) {
                         log.error("Unrecoverable error during poll {}", consumer.assignment(), e)
-                        Health.subsystemAlive[Subsystem.KAFKA] = false
+                        onKafkaUnhealthy()
                         throw e
                     }
 
@@ -195,12 +200,12 @@ private constructor(
                         Duration.ofMillis(backoffMillis),
                         e
                     )
-                    val currentPartition = TopicPartition(record.topic(), record.partition())
-                    if (currentPartition in consumer.assignment()) {
-                        consumer.seek(currentPartition, record.offset())
-                        consumer.pause(listOf(currentPartition))
+                    val currentTopicPartition = TopicPartition(record.topic(), record.partition())
+                    if (currentTopicPartition in consumer.assignment()) {
+                        consumer.seek(currentTopicPartition, record.offset())
+                        consumer.pause(listOf(currentTopicPartition))
                         retryTimer.schedule(backoffMillis) {
-                            resumeQueue.offer(currentPartition)
+                            resumeQueue.offer(currentTopicPartition)
                         }
                     }
                     return@currentPartition
@@ -224,7 +229,7 @@ private constructor(
                     if (failures >= COMMIT_FAILURE_THRESHOLD) {
                         // -> while(!Health.terminating) exits -> consumer closes -> pod restarts (clean rejoin).
                         // in-flight record is reprocessed after restart (at-least-once, handlers are idempotent).
-                        Health.subsystemAlive[Subsystem.KAFKA] = false
+                        onKafkaUnhealthy()
                     }
                     return@currentPartition
                 }

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumerCommitTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumerCommitTest.kt
@@ -1,26 +1,25 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka
 
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
 import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem
-import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.clients.consumer.MockConsumer
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
-import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.clients.consumer.*
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class CoroutineKafkaConsumerCommitTest {
 
     private val topic = "test.topic"
     private val tp = TopicPartition(topic, 0)
 
+    @BeforeEach
     @AfterEach
     fun resetHealth() {
         // Health er en global singleton; sett KAFKA tilbake til true så andre tester ikke påvirkes.
@@ -91,3 +90,23 @@ class CoroutineKafkaConsumerCommitTest {
         assertTrue(consumer.paused().contains(tp))
     }
 }
+
+
+
+/**
+ * Test-seam: bygg en konsument rundt en injisert [Consumer] (typisk en MockConsumer),
+ * slik at commit-/rebalance-stiene kan testes uten en ekte Kafka-broker.
+ */
+private fun CoroutineKafkaConsumer.Companion.forTest(
+    consumer: Consumer<String, String>,
+    topic: String = "test.topic",
+    groupId: String = "test-group",
+): CoroutineKafkaConsumer<String, String> = CoroutineKafkaConsumer.new(
+    topic = topic,
+    groupId = groupId,
+    keyDeserializer = org.apache.kafka.common.serialization.StringDeserializer::class.java,
+    valueDeserializer = org.apache.kafka.common.serialization.StringDeserializer::class.java,
+    onPartitionAssigned = null,
+    onPartitionRevoked = null,
+    consumerOverride = consumer,
+)

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumerCommitTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumerCommitTest.kt
@@ -1,0 +1,93 @@
+package no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
+import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.MockConsumer
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.TimeoutException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+
+class CoroutineKafkaConsumerCommitTest {
+
+    private val topic = "test.topic"
+    private val tp = TopicPartition(topic, 0)
+
+    @AfterEach
+    fun resetHealth() {
+        // Health er en global singleton; sett KAFKA tilbake til true så andre tester ikke påvirkes.
+        Health.subsystemAlive[Subsystem.KAFKA] = true
+    }
+
+    private fun mockConsumer(commitThrows: Boolean): MockConsumer<String, String> {
+        val consumer = object : MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
+            override fun commitSync(offsets: Map<TopicPartition, OffsetAndMetadata>, timeout: Duration) {
+                if (commitThrows) throw TimeoutException("Timeout of ${timeout.toMillis()}ms expired")
+                super.commitSync(offsets, timeout)
+            }
+        }
+        consumer.subscribe(listOf(topic))
+        consumer.rebalance(listOf(tp))
+        consumer.updateBeginningOffsets(mapOf(tp to 0L))
+        consumer.seek(tp, 0L)
+        return consumer
+    }
+
+    private fun MockConsumer<String, String>.scheduleRecords(count: Int, stop: AtomicBoolean) {
+        repeat(count) { i ->
+            schedulePollTask {
+                addRecord(ConsumerRecord(topic, 0, i.toLong(), "key", "value-$i"))
+            }
+        }
+        schedulePollTask { stop.set(true) }
+    }
+
+    @Test
+    fun `commit-feil under terskel restarter ikke - KAFKA forblir true`() = runBlocking {
+        Health.subsystemAlive[Subsystem.KAFKA] = true
+        val consumer = mockConsumer(commitThrows = true)
+        val stop = AtomicBoolean(false)
+        consumer.scheduleRecords(count = COMMIT_FAILURE_THRESHOLD - 1, stop = stop)
+
+        CoroutineKafkaConsumer.forTest(consumer).forEach(stop = stop) { /* body ok */ }
+
+        assertEquals(true, Health.subsystemAlive[Subsystem.KAFKA])
+    }
+
+    @Test
+    fun `vedvarende commit-feil over terskel flagger KAFKA unhealthy og avslutter loopen`() = runBlocking {
+        Health.subsystemAlive[Subsystem.KAFKA] = true
+        val consumer = mockConsumer(commitThrows = true)
+        val stop = AtomicBoolean(false)
+        // Flere records enn terskelen; loopen skal avslutte via Health.terminating før stop trigges.
+        consumer.scheduleRecords(count = COMMIT_FAILURE_THRESHOLD + 2, stop = stop)
+
+        CoroutineKafkaConsumer.forTest(consumer).forEach(stop = stop) { /* body ok */ }
+
+        assertEquals(false, Health.subsystemAlive[Subsystem.KAFKA])
+    }
+
+    @Test
+    fun `poison-pill i body pauser partisjonen og lar KAFKA forbli true`() = runBlocking {
+        Health.subsystemAlive[Subsystem.KAFKA] = true
+        val consumer = mockConsumer(commitThrows = false)
+        val stop = AtomicBoolean(false)
+        consumer.scheduleRecords(count = 1, stop = stop)
+
+        CoroutineKafkaConsumer.forTest(consumer).forEach(stop = stop) {
+            throw RuntimeException("poison pill")
+        }
+
+        assertEquals(true, Health.subsystemAlive[Subsystem.KAFKA])
+        // partisjonen ble pauset av backoff-stien (ikke flagget unhealthy)
+        assertTrue(consumer.paused().contains(tp))
+    }
+}

--- a/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumerCommitTest.kt
+++ b/app/src/test/kotlin/no/nav/arbeidsgiver/notifikasjon/infrastruktur/kafka/CoroutineKafkaConsumerCommitTest.kt
@@ -1,30 +1,22 @@
 package no.nav.arbeidsgiver.notifikasjon.infrastruktur.kafka
 
 import kotlinx.coroutines.runBlocking
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Health
-import no.nav.arbeidsgiver.notifikasjon.infrastruktur.Subsystem
 import org.apache.kafka.clients.consumer.*
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.TimeoutException
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.test.assertEquals
+import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@Execution(ExecutionMode.SAME_THREAD)
 class CoroutineKafkaConsumerCommitTest {
 
     private val topic = "test.topic"
     private val tp = TopicPartition(topic, 0)
-
-    @BeforeEach
-    @AfterEach
-    fun resetHealth() {
-        // Health er en global singleton; sett KAFKA tilbake til true så andre tester ikke påvirkes.
-        Health.subsystemAlive[Subsystem.KAFKA] = true
-    }
 
     private fun mockConsumer(commitThrows: Boolean): MockConsumer<String, String> {
         val consumer = object : MockConsumer<String, String>(OffsetResetStrategy.EARLIEST) {
@@ -51,41 +43,41 @@ class CoroutineKafkaConsumerCommitTest {
 
     @Test
     fun `commit-feil under terskel restarter ikke - KAFKA forblir true`() = runBlocking {
-        Health.subsystemAlive[Subsystem.KAFKA] = true
+        var kafkaHealty = true
         val consumer = mockConsumer(commitThrows = true)
         val stop = AtomicBoolean(false)
         consumer.scheduleRecords(count = COMMIT_FAILURE_THRESHOLD - 1, stop = stop)
 
-        CoroutineKafkaConsumer.forTest(consumer).forEach(stop = stop) { /* body ok */ }
+        CoroutineKafkaConsumer.forTest(consumer, onKafkaUnhealthy = { kafkaHealty = false }).forEach(stop = stop) { /* body ok */ }
 
-        assertEquals(true, Health.subsystemAlive[Subsystem.KAFKA])
+        assertTrue(kafkaHealty)
     }
 
     @Test
     fun `vedvarende commit-feil over terskel flagger KAFKA unhealthy og avslutter loopen`() = runBlocking {
-        Health.subsystemAlive[Subsystem.KAFKA] = true
+        var kafkaHealty = true
         val consumer = mockConsumer(commitThrows = true)
         val stop = AtomicBoolean(false)
         // Flere records enn terskelen; loopen skal avslutte via Health.terminating før stop trigges.
         consumer.scheduleRecords(count = COMMIT_FAILURE_THRESHOLD + 2, stop = stop)
 
-        CoroutineKafkaConsumer.forTest(consumer).forEach(stop = stop) { /* body ok */ }
+        CoroutineKafkaConsumer.forTest(consumer, onKafkaUnhealthy = { kafkaHealty = false }).forEach(stop = stop) { /* body ok */ }
 
-        assertEquals(false, Health.subsystemAlive[Subsystem.KAFKA])
+        assertFalse(kafkaHealty)
     }
 
     @Test
     fun `poison-pill i body pauser partisjonen og lar KAFKA forbli true`() = runBlocking {
-        Health.subsystemAlive[Subsystem.KAFKA] = true
+        var kafkaHealty = true
         val consumer = mockConsumer(commitThrows = false)
         val stop = AtomicBoolean(false)
-        consumer.scheduleRecords(count = 1, stop = stop)
+        consumer.scheduleRecords(count = COMMIT_FAILURE_THRESHOLD + 1, stop = stop)
 
-        CoroutineKafkaConsumer.forTest(consumer).forEach(stop = stop) {
+        CoroutineKafkaConsumer.forTest(consumer, onKafkaUnhealthy = { kafkaHealty = false }).forEach(stop = stop) {
             throw RuntimeException("poison pill")
         }
 
-        assertEquals(true, Health.subsystemAlive[Subsystem.KAFKA])
+        assertTrue(kafkaHealty)
         // partisjonen ble pauset av backoff-stien (ikke flagget unhealthy)
         assertTrue(consumer.paused().contains(tp))
     }
@@ -101,6 +93,7 @@ private fun CoroutineKafkaConsumer.Companion.forTest(
     consumer: Consumer<String, String>,
     topic: String = "test.topic",
     groupId: String = "test-group",
+    onKafkaUnhealthy: () -> Unit,
 ): CoroutineKafkaConsumer<String, String> = CoroutineKafkaConsumer.new(
     topic = topic,
     groupId = groupId,
@@ -108,5 +101,6 @@ private fun CoroutineKafkaConsumer.Companion.forTest(
     valueDeserializer = org.apache.kafka.common.serialization.StringDeserializer::class.java,
     onPartitionAssigned = null,
     onPartitionRevoked = null,
+    onKafkaUnhealthy = onKafkaUnhealthy,
     consumerOverride = consumer,
 )


### PR DESCRIPTION
 Etter Kafka-outage 2026-06-01 ble konsumenter stående fast og krasjet
 stille fordi en commit/membership-feil ble behandlet som en data-feil
 (seek/pause/retry). Tre avgrensede endringer i commit-stien:

 - Bind commitSync med eksplisitt COMMIT_TIMEOUT (10s) så en treg commit ikke sulter poll-loopen forbi max.poll.interval.ms og selv-evicter.
 - Skill body() fra commit: commit-feil teller opp og flagger Subsystem.KAFKA unhealthy ved COMMIT_FAILURE_THRESHOLD (3) -> loop avslutter -> pod restarter (ren rejoin). Poison-pill-stien uendret.
 - Guard resume/seek/pause mot consumer.assignment() så en revokert partisjon ikke kaster IllegalStateException ut av loopen.

 Legger til counter kafka.commit.failures og regresjonstester
 (CoroutineKafkaConsumerCommitTest) via en intern forTest-seam med
 MockConsumer.

 Refs: specifications/robust_consumer_rebalance.md
 Refs: postmortems/duplikater_etter_kafka_outage_2026-06-01.md

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>